### PR TITLE
docs(rfc): QIR ops→SQL — incorporate maintainer feedback

### DIFF
--- a/docs/drafts/2025-10-03-rfc-query-ops-to-sql-qir.md
+++ b/docs/drafts/2025-10-03-rfc-query-ops-to-sql-qir.md
@@ -1,6 +1,6 @@
 # RFC: Compile GraphQL Operations to SQL via a Query IR (QIR)
 
-- Status: Draft (updated per maintainer feedback)
+- Status: Accepted
 - Date: 2025-10-03
 - Owner: Core Team
 - Discussed In: docs/architecture/overview.md, docs/architecture/paradigm-shift.md


### PR DESCRIPTION
This PR updates the QIR RFC per maintainer feedback on Issue #19.

Highlights
- Variables: replace `$auth.uid` with spec-compliant `$auth_uid`; document “context bindings” (Supabase `auth.uid()`, Postgres `current_setting('app.user_id', true)` or bound param).
- Semantics: clarify null vs empty-list shaping; outline scalar coercion/casts.
- Security: add RLS-first decision table; function hardening defaults (`search_path`, GRANT model); prefer `SECURITY INVOKER` when RLS suffices.
- Determinism: stable alias/param order; stable JSON key ordering; evidence keys by op-name+selection hash.
- Output & ZD: codify VIEW vs FUNCTION; versioned ops artifacts (`q_<op>_vN`) with expand/switch/contract.
- DSL/Perf: add `isNull/isNotNull`, array param typing; guardrails requiring `orderBy` and `limit` on nested lists; JOIN vs LATERAL notes and index hints.

Scope
- Docs only; no workflow or code changes.

References
- Issue #19