### PR TITLE
chore(oss): add PR template, CODEOWNERS, CHANGELOG (supersedes #22)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Context
+- What problem does this PR solve? Link issues/tickets.
+
+## Changes
+- Summary of the minimal, surgical changes.
+
+## Rationale & Alternatives
+- Why this approach? What else was considered and why not?
+
+## Risks
+- User-facing or CI risks. How mitigated? Rollout notes.
+
+## Backout Plan
+- How to revert safely if needed.
+
+## Screenshots / Logs (if relevant)
+
+## Checklist
+- [ ] One-topic PR with tight diff
+- [ ] Tests pass locally (smallest relevant subset)
+- [ ] No widened permissions/secrets in workflows
+- [ ] Docs updated if behavior changed
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+- Documentation: add PR template and CODEOWNERS
+- CI: ensure Ubuntu-only CLI matrix to control Actions costs
+
+## [0.1.0] - 2025-09-01
+- Initial public repository layout
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners
+* @flyingrobots
+
+# Core domain (pure)
+/packages/wesley-core/ @flyingrobots
+
+# CLI + host adapters
+/packages/wesley-host-node/ @flyingrobots
+/packages/wesley-cli/ @flyingrobots
+
+# Generators & stacks
+/packages/wesley-generator-*/ @flyingrobots
+/packages/wesley-stack-*/ @flyingrobots
+


### PR DESCRIPTION
This consolidates the OSS hygiene from #22 on top of current main without risky rebase/merge conflicts.\n\n- Adds .github/pull_request_template.md (aligns with AGENTS.md guidance)\n- Adds CODEOWNERS (default to @flyingrobots)\n- Adds CHANGELOG.md (Keep a Changelog format)\n\nNotes\n- No workflow edits here; CI matrices already Ubuntu-only in main (macOS dropped to control spend).\n- Closes #22 as superseded once merged.