### PR TITLE
chore(go-public): polish docs, labels, and package metadata

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,7 +43,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-conduct@wesleyql.dev. All complaints will be reviewed and investigated promptly
+conduct@flyingrobots.dev. All complaints will be reviewed and investigated promptly
 and fairly.
 
 ## Attribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 
 ## How Can I Contribute?
 
+### Read the roadmap
+
+Before you open a large feature request, skim the current [roadmap](docs/roadmap.md)
+so work lines up with the active milestone.
+
 ### Reporting Bugs
 
 Before creating bug reports, please check existing issues. When creating a bug report, include:
@@ -37,6 +42,8 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 4. Ensure all tests pass: `pnpm test`
 5. Update documentation as needed
 6. Follow the commit message conventions
+7. Apply an appropriate label (see [docs/governance/labels.md](docs/governance/labels.md))
+   when you open the PR so reviewers know how to triage it.
 
 ## Architecture Guidelines
 
@@ -136,9 +143,10 @@ refactor: move generators to core
 ## Documentation
 
 Update relevant docs when making changes:
-- API changes: Update JSDoc comments
-- New features: Update README.md
-- Architecture changes: Update docs/architecture/
+- API changes: update JSDoc comments
+- New features: update README.md and Quick Start where needed
+- Architecture changes: update `docs/architecture/`
+- Roadmap or workflow changes: update `docs/roadmap.md` and `docs/governance/`
 
 ## License
 
@@ -156,7 +164,9 @@ pnpm publish
 
 ## Questions?
 
-Feel free to open an issue for any questions about contributing!
+Feel free to open an issue for any questions about contributing. For private
+questions (conduct or security), email `oss@flyingrobots.dev`
+(`security@flyingrobots.dev` for incident reports).
 
 ## Tooling & Hooks
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,38 @@ flowchart LR
     class DEP p3
 ```
 
+## Quick Start (local workspace)
+
+```bash
+# 1. Clone and install
+git clone https://github.com/flyingrobots/wesley.git
+cd wesley
+pnpm install
+
+# 2. Generate everything for the example schema
+node packages/wesley-host-node/bin/wesley.mjs generate \
+  --schema example/schema.graphql \
+  --ops example/ops \
+  --emit-bundle \
+  --out-dir example/out
+
+# 3. Dry-run the migration plan (no database required)
+node packages/wesley-host-node/bin/wesley.mjs plan --schema example/schema.graphql --explain
+node packages/wesley-host-node/bin/wesley.mjs rehearse --schema example/schema.graphql --dry-run --json
+```
+
+Where to go next:
+
+- 📚 Read the [delivery lifecycle](docs/architecture/lifecycle.md) to see how Transform → Plan → Rehearse → Ship fit together.
+- 🗺️ Check the [roadmap](docs/roadmap.md) for milestone status.
+- ⚔️ Run the [BLADE demo](docs/blade.md) for a scripted end-to-end walkthrough.
+
 ## Why GraphQL as schema?
 
 - One source of truth: Describe the domain once; Wesley generates SQL, migrations, types, validation, and RLS from it.
 - Naturally relational: Graphs express relationships and constraints cleanly; directives capture DB semantics where they’re used.
 - Portable by design: A schema → IR → generators pipeline targets Postgres/Supabase today, other backends tomorrow.
-- Schmea that evolves: Just like your database.
+- Schema that evolves: Just like your database.
 
 ## The problem (short version)
 
@@ -209,6 +235,7 @@ DSN quick reference
 - Node.js: 18.x, 20.x, 22.x (CI uses Node 20 LTS; recommended)
 - Package manager: pnpm 9 (workspace pinned via packageManager)
 - CI runners: Ubuntu (macOS runners intentionally removed to control GitHub Actions costs)
+- The CLI works on macOS/Windows for development, but official CI support targets Ubuntu images.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Wesley takes security seriously, especially when generating production database 
 
 ### Where to Report
 
-Please report security vulnerabilities to: security@wesleyql.dev
+Please report security vulnerabilities to: security@flyingrobots.dev
 
 ### What to Include
 

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -1,0 +1,41 @@
+# Wesley Delivery Lifecycle
+
+Wesley’s tooling still revolves around the heartbeat we built for the MVP:
+**Transform → Plan → Rehearse → Ship**. Each milestone in the roadmap adds
+capabilities to one or more steps in that ladder.
+
+| Phase | What happens | Delivered by |
+| ----- | ------------- | ------------ |
+| Transform | Parse GraphQL SDL to our canonical IR and emit artifacts (SQL, pgTAP, TypeScript/Zod, evidence bundle). | `wesley-core`, generators, `wesley-host-node` |
+| Plan | Diff schema changes, produce phased migrations (expand/backfill/validate/switch/contract) with lock annotations. | `wesley-core` planner and CLI `plan` command |
+| Rehearse | Execute the plan in a controlled environment, capture timings/locks/tests, record verdicts. | Shadow REALM tooling (`wesley shadow`, CI harness) |
+| Ship | Aggregate evidence, compute HOLMES scores, gate releases, and archive approvals in SHIPME. | HOLMES CLI, evidence schemas |
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Git as GraphQL schema
+    participant Transform
+    participant Plan
+    participant Rehearse
+    participant Ship
+
+    Git->>Transform: wesley generate
+    Transform->>Plan: IR + artifacts
+    Plan->>Rehearse: phased SQL + explain
+    Rehearse->>Ship: realm.json + metrics
+    Ship-->>Git: scores, certificates, follow-up tasks
+```
+
+## Why it matters
+
+- The roadmap is grouped by the phase each feature improves (QIR → Transform,
+  REALM → Rehearse, HOLMES → Ship, etc.).
+- Preflight checks ensure we never regress on the invariants that keep the
+  lifecycle boring: reproducible artifacts, additive-safe plans, and auditable
+  evidence.
+- Demo flows like BLADE are just scripted tours through the four phases.
+
+If you are working on a new feature, spell out which phase it improves when you
+open an issue or PR—this keeps the roadmap and docs aligned.

--- a/docs/governance/labels.md
+++ b/docs/governance/labels.md
@@ -1,0 +1,44 @@
+# Issue & PR Labels
+
+Wesley uses a small, well-documented label set so contributors can quickly find
+work and maintainers can triage effectively. All labels are applied directly on
+GitHub and can be reviewed with `gh label list`.
+
+| Label | Purpose |
+| ----- | ------- |
+| `bug` | Reproducible product bug that needs a fix. |
+| `feature` / `enhancement` | User-facing functionality requests. `feature` is used for roadmap work, `enhancement` for smaller improvements. |
+| `chore` | Internal maintenance (refactors, dependency bumps, repo hygiene). |
+| `docs` / `documentation` | Documentation work (README, guides, docs site). |
+| `tests` | Test coverage or flakiness fixes. |
+| `security` | Security or compliance related tasks. |
+| `ci` | Changes to automation or workflows. |
+| `rfc` | Exploratory proposals that require design discussion. |
+| `blocked` / `needs-discussion` | Work waiting on a decision or external dependency. |
+| `good first issue` | Curated onboarding tasks for newcomers. |
+| `help wanted` | We actively need contributions for this issue. |
+| `holmes`, `scoring` | Work specific to the HOLMES evidence stack. |
+| `status: non-blocking` | Nice-to-have items that are not release blockers. |
+| `pkg:*` | Ownership hints for the affected package(s). |
+
+## Label conventions
+
+- Every newly opened issue should get **one work-type label** (bug/feature/chore/docs/tests).
+- Use **module labels** (`pkg:*`) when the work sits in a single package; skip
+  them for cross-cutting features.
+- Add `good first issue` only if the description already includes clear steps
+  and the acceptance criteria can be completed without repo-wide context.
+- `status: non-blocking` is a reminder that an issue can be deferred without
+  risking the next milestone.
+
+## Adding new labels
+
+If you need to introduce a label, coordinate with maintainers first so we keep
+an intentional set. Once agreed, add it via the GitHub UI or with the CLI:
+
+```bash
+gh label create "name" --color 123abc --description "What this covers"
+```
+
+After adding a new label, update this document and reference it from
+[CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "docker:down": "docker-compose down",
     "docker:test": "docker-compose run pgtap",
     "wesley": "node packages/wesley-host-node/bin/wesley.mjs",
+    "meta:fix-packages": "node scripts/fix-package-metadata.mjs",
     "ci": "pnpm validate && pnpm generate:example && pnpm exec wesley validate-bundle --bundle example/.wesley --schemas schemas/"
   },
   "keywords": [
@@ -35,7 +36,7 @@
     "postgresql",
     "schema-first"
   ],
-  "author": "Captain James",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -47,7 +48,7 @@
   "homepage": "https://github.com/flyingrobots/wesley#readme",
   "packageManager": "pnpm@9.15.9",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17"
   },
   "dependencies": {
     "@supabase/pg-parser": "^0.1.3"

--- a/packages/wesley-cli/package.json
+++ b/packages/wesley-cli/package.json
@@ -32,7 +32,7 @@
     "schema",
     "generator"
   ],
-  "author": "Captain James",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",

--- a/packages/wesley-core/package.json
+++ b/packages/wesley-core/package.json
@@ -38,7 +38,7 @@
     "domain",
     "hexagonal"
   ],
-  "author": "Captain James",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",

--- a/packages/wesley-generator-js/package.json
+++ b/packages/wesley-generator-js/package.json
@@ -27,7 +27,7 @@
     "code-generation",
     "models"
   ],
-  "author": "Wesley Team",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -37,5 +37,8 @@
   "bugs": {
     "url": "https://github.com/flyingrobots/wesley/issues"
   },
-  "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-generator-js#readme"
+  "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-generator-js#readme",
+  "engines": {
+    "node": ">=18.17"
+  }
 }

--- a/packages/wesley-generator-supabase/package.json
+++ b/packages/wesley-generator-supabase/package.json
@@ -27,7 +27,7 @@
     "sql-generation",
     "rls-policies"
   ],
-  "author": "Wesley Team",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -37,5 +37,8 @@
   "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-generator-supabase#readme",
   "bugs": {
     "url": "https://github.com/flyingrobots/wesley/issues"
+  },
+  "engines": {
+    "node": ">=18.17"
   }
 }

--- a/packages/wesley-holmes/package.json
+++ b/packages/wesley-holmes/package.json
@@ -4,15 +4,15 @@
   "type": "module",
   "description": "SHA-lock HOLMES - Schema intelligence sidecar for Wesley",
   "main": "./src/index.mjs",
-  "bin": { 
-    "wesley-holmes": "./src/cli.mjs" 
+  "bin": {
+    "wesley-holmes": "./src/cli.mjs"
   },
   "exports": "./src/index.mjs",
   "files": [
     "src/"
   ],
-  "engines": { 
-    "node": ">=18.17" 
+  "engines": {
+    "node": ">=18.17"
   },
   "scripts": {
     "test": "node --test"
@@ -20,8 +20,14 @@
   "dependencies": {
     "@wesley/core": "workspace:*"
   },
-  "keywords": ["holmes", "watson", "moriarty", "verification", "prediction"],
-  "author": "Captain James",
+  "keywords": [
+    "holmes",
+    "watson",
+    "moriarty",
+    "verification",
+    "prediction"
+  ],
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",

--- a/packages/wesley-host-node/package.json
+++ b/packages/wesley-host-node/package.json
@@ -38,7 +38,7 @@
     "node",
     "adapters"
   ],
-  "author": "Captain James",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",

--- a/packages/wesley-scaffold-multitenant/package.json
+++ b/packages/wesley-scaffold-multitenant/package.json
@@ -27,7 +27,7 @@
     "saas",
     "graphql-schema"
   ],
-  "author": "Wesley Team",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -37,5 +37,8 @@
   "bugs": {
     "url": "https://github.com/flyingrobots/wesley/issues"
   },
-  "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-scaffold-multitenant#readme"
+  "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-scaffold-multitenant#readme",
+  "engines": {
+    "node": ">=18.17"
+  }
 }

--- a/packages/wesley-slaps/package.json
+++ b/packages/wesley-slaps/package.json
@@ -29,7 +29,7 @@
     "execution-engine",
     "concurrency"
   ],
-  "author": "Wesley Team",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -39,5 +39,8 @@
   "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-slaps#readme",
   "bugs": {
     "url": "https://github.com/flyingrobots/wesley/issues"
+  },
+  "engines": {
+    "node": ">=18.17"
   }
 }

--- a/packages/wesley-stack-supabase-nextjs/package.json
+++ b/packages/wesley-stack-supabase-nextjs/package.json
@@ -16,5 +16,9 @@
   "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-stack-supabase-nextjs#readme",
   "scripts": {
     "test": "node -e \"console.log('No tests for stack template')\""
+  },
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
+  "engines": {
+    "node": ">=18.17"
   }
 }

--- a/packages/wesley-tasks/package.json
+++ b/packages/wesley-tasks/package.json
@@ -24,7 +24,7 @@
     "dependency-resolution",
     "orchestration"
   ],
-  "author": "Wesley Team",
+  "author": "Wesley Authors <oss@flyingrobots.dev>",
   "license": "LicenseRef-MIND-UCAL-1.0",
   "repository": {
     "type": "git",
@@ -34,5 +34,8 @@
   "homepage": "https://github.com/flyingrobots/wesley/tree/main/packages/wesley-tasks#readme",
   "bugs": {
     "url": "https://github.com/flyingrobots/wesley/issues"
+  },
+  "engines": {
+    "node": ">=18.17"
   }
 }

--- a/scripts/fix-package-metadata.mjs
+++ b/scripts/fix-package-metadata.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '..');
+const packagesDir = path.join(root, 'packages');
+const repoUrl = 'https://github.com/flyingrobots/wesley.git';
+const apiIssues = 'https://github.com/flyingrobots/wesley/issues';
+const author = 'Wesley Authors <oss@flyingrobots.dev>';
+const engines = { node: '>=18.17' };
+
+const packages = await fs.readdir(packagesDir, { withFileTypes: true });
+
+function sortKeys(obj) {
+  const ordered = {};
+  Object.keys(obj).sort().forEach((key) => {
+    ordered[key] = obj[key];
+  });
+  return ordered;
+}
+
+for (const entry of packages) {
+  if (!entry.isDirectory()) continue;
+  const pkgPath = path.join(packagesDir, entry.name, 'package.json');
+  try {
+    const pkgData = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
+
+    pkgData.author = author;
+    pkgData.license = pkgData.license ?? 'LicenseRef-MIND-UCAL-1.0';
+    pkgData.repository = {
+      type: 'git',
+      url: repoUrl,
+      directory: `packages/${entry.name}`
+    };
+    pkgData.bugs = { url: apiIssues };
+    pkgData.homepage = `https://github.com/flyingrobots/wesley/tree/main/packages/${entry.name}#readme`;
+    pkgData.engines = engines;
+
+    if (!pkgData.version) {
+      pkgData.version = '0.1.0';
+    }
+
+    const json = JSON.stringify(pkgData, null, 2) + '\n';
+    await fs.writeFile(pkgPath, json);
+    console.log('Updated', pkgPath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.error('Error updating', pkgPath, err);
+      process.exitCode = 1;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Quick Start + lifecycle link in README and tweak compatibility note (#62)
- standardise package metadata across all workspaces and add a fixer script (#61)
- refresh CONTRIBUTING / SECURITY / CODE_OF_CONDUCT and document label taxonomy (#59/#36)

## Testing
- pnpm run preflight