### PR TITLE
ci(#276): speed up Playwright + pnpm in smokes

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
 
       - name: Enable corepack (pnpm)
         run: corepack enable
@@ -27,6 +28,17 @@ jobs:
 
       - name: Preflight
         run: pnpm run -s preflight
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Set Playwright env
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> $GITHUB_ENV
 
       - name: Install bats
         run: sudo apt-get update && sudo apt-get install -y bats jq

--- a/.github/workflows/runtime-smokes.yml
+++ b/.github/workflows/runtime-smokes.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
       - name: Enable corepack (pnpm)
         run: corepack enable
       - name: Install deps (frozen)


### PR DESCRIPTION
- Cache Playwright browsers (actions/cache) and set PLAYWRIGHT_BROWSERS_PATH\n- Cache pnpm in Node-using jobs\n- Conditional Playwright install in scripts/host_contracts_browser.mjs (skip if cached)\n\nShould shave ~15–30s per job. Refs #276