### PR TITLE
ci(holmes): detect schema and wire outputs

### DIFF
--- a/.github/workflows/wesley-holmes.yml
+++ b/.github/workflows/wesley-holmes.yml
@@ -23,6 +23,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: "🕵️ Detect Schema"
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${WESLEY_SCHEMA:-}" ] && [ -f "$WESLEY_SCHEMA" ]; then
+            schema="$WESLEY_SCHEMA"
+          else
+            mapfile -t files < <(git ls-files "**/*.graphql" 2>/dev/null || true)
+            picked=""
+            if [ ${#files[@]} -gt 0 ]; then
+              for f in "${files[@]}"; do
+                if [ "${f##*/}" = "schema.graphql" ]; then picked="$f"; break; fi
+              done
+              if [ -z "$picked" ]; then picked="${files[0]}"; fi
+            fi
+            schema="${picked:-$HOLMES_SCHEMA}"
+          fi
+          base_dir="$(dirname "$schema")"
+          bundle_dir="$base_dir/.wesley"
+          echo "schema=$schema" >> "$GITHUB_OUTPUT"
+          echo "bundle_dir=$bundle_dir" >> "$GITHUB_OUTPUT"
+          echo "Detected schema: $schema"
+          echo "Bundle dir: $bundle_dir"
       
       - name: "🛠️ Setup HOLMES environment"
         uses: ./.github/actions/holmes-setup


### PR DESCRIPTION
Extracted from #214: add a schema detection step and expose bundle_dir/schema via step outputs for later wiring. No behavior change yet; a follow-up PR can switch downstream steps to use needs.wesley-generate.outputs. Partial extraction to reduce scope and unblock CI refinement.