### PR TITLE
fix(holmes): git adapter security and reliability improvements

### DIFF
--- a/packages/wesley-holmes/src/Moriarty.mjs
+++ b/packages/wesley-holmes/src/Moriarty.mjs
@@ -445,7 +445,11 @@ export class Moriarty {
     const sinceIso = new Date(Date.now() - windowHours * 3600 * 1000).toISOString();
     // Use a log format that marks commit boundaries so we can parse numstat blocks.
     const raw = this.git.log({ since: sinceIso, format: '--%ct', numstat: true, noMerges: true });
-    if (!raw || !raw.trim()) {
+    // Distinguish git failures (null) from genuine no-activity (empty string)
+    if (raw === null) {
+      return null;
+    }
+    if (!raw.trim()) {
       return { windowHours, commits: 0, relevantCommits: 0, commitsPerDay: 0, linesChanged: 0, relevantLinesChanged: 0 };
     }
 
@@ -552,7 +556,11 @@ export class Moriarty {
       if (!mergeBase) return null;
       // Collect PR-only commits
       const raw = this.git.log({ range: `${mergeBase}..HEAD`, format: '--%ct', numstat: true, noMerges: true });
-      if (!raw || !raw.trim()) {
+      // Distinguish git failures (null) from genuine no-activity (empty string)
+      if (raw === null) {
+        return null;
+      }
+      if (!raw.trim()) {
         return { commits: 0, relevantCommits: 0, days: 0, commitsPerDay: 0, linesChanged: 0, relevantLinesChanged: 0 };
       }
       const lines = raw.split(/\r?\n/);

--- a/packages/wesley-holmes/src/ports/git.mjs
+++ b/packages/wesley-holmes/src/ports/git.mjs
@@ -91,7 +91,7 @@ export const realGitAdapter = {
     try {
       return execFileSync('git', args, { encoding: 'utf8' });
     } catch {
-      return '';
+      return null;
     }
   }
 };
@@ -104,7 +104,7 @@ export const nullGitAdapter = {
   isInsideWorkTree: () => false,
   fetch: () => false,
   mergeBase: () => null,
-  log: () => ''
+  log: () => null
 };
 
 /**


### PR DESCRIPTION
## Summary
- Make CLI tests deterministic by disabling git activity during tests
- Prevent command injection in git port by validating refs and using execFileSync with args arrays
- Distinguish git log failures from zero activity to avoid misleading reports

## Test plan
- [x] All existing tests pass
- [x] Pre-push hooks verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)