### PR TITLE
[codex] Add cool ideas backlog packets

### DIFF
--- a/docs/method/backlog/cool-ideas/EVIDENCE_holmes-artifact-diagnostic-sidecar.md
+++ b/docs/method/backlog/cool-ideas/EVIDENCE_holmes-artifact-diagnostic-sidecar.md
@@ -1,0 +1,42 @@
+# Holmes Artifact Diagnostic Sidecar
+
+- Lane: `cool-ideas`
+- Legend: `EVIDENCE`
+
+## Why now
+
+The Holmes comment loader now preserves report and markdown parse/read
+diagnostics, but the human PR comment intentionally stays calm and high-signal.
+That leaves a useful middle layer unclaimed: a maintainer-friendly diagnostic
+surface that exposes malformed or unreadable artifact reasons without dumping
+debug noise into the reviewer-facing summary.
+
+## Hill
+
+A maintainer can open one Holmes-side diagnostic artifact or workflow summary
+surface and see exactly why a report artifact was missing, invalid, or
+unreadable, while the public PR comment remains concise and glossary-backed.
+
+## Done looks like
+
+- Holmes artifact loader diagnostics are emitted to one inspectable sidecar
+  surface during comment/report generation
+- the public PR comment stays human-friendly and does not leak raw parser noise
+- workflow operators can tell the difference between malformed JSON, unreadable
+  markdown, and simply missing artifacts without reproducing locally
+- tests pin the diagnostic sidecar contract
+- the diagnostic surface remains reproducible from local artifact inputs
+
+## Repo Evidence
+
+- `packages/wesley-holmes/src/pr-comment.mjs`
+- `packages/wesley-holmes/test/pr-comment.test.mjs`
+- `.github/workflows/wesley-holmes.yml`
+- `docs/architecture/holmes-architecture.md`
+- `docs/invariants/evidence-truth.md`
+
+## Related Carry-Over
+
+- `#224`
+- `#451`
+- `#466`

--- a/docs/method/backlog/cool-ideas/EVIDENCE_pr-feedback-session-witness.md
+++ b/docs/method/backlog/cool-ideas/EVIDENCE_pr-feedback-session-witness.md
@@ -1,0 +1,38 @@
+# PR Feedback Session Witness
+
+- Lane: `cool-ideas`
+- Legend: `EVIDENCE`
+
+## Why now
+
+Closing out a review session on PR #467 required building the same witness by
+hand in multiple places: issue-to-SHA mapping, validation commands, unresolved
+thread count, bot verdict, and current merge blockers. That information exists,
+but the witness is assembled manually rather than emitted from one reproducible
+surface.
+
+## Hill
+
+A maintainer can generate one review-session witness artifact that records what
+feedback was addressed, which SHAs carried each fix, what validation ran, and
+what blockers remained at session close.
+
+## Done looks like
+
+- one local-first artifact captures issue-to-SHA mapping for a review session
+- validation commands and outcomes are recorded alongside the fix summary
+- unresolved-thread count and live merge blockers are captured at generation
+  time
+- the witness can be rendered into a PR comment table without hand-copying
+- the artifact is boring enough to reuse across agent or human review passes
+
+## Repo Evidence
+
+- `docs/invariants/evidence-truth.md`
+- `docs/invariants/provenance-visibility.md`
+- `docs/method/retro/README.md`
+- `docs/method/backlog/inbox/RUNTIME_gh-447-tooling-gh-add-a-deterministic-pr-review-thread-helper-for.md`
+
+## Related Carry-Over
+
+- `#447`

--- a/docs/method/backlog/cool-ideas/README.md
+++ b/docs/method/backlog/cool-ideas/README.md
@@ -2,3 +2,10 @@
 
 Ideas here are real enough to name, but not committed. Keep them explicit and
 honest.
+
+- [Holmes Comment Loader Policy Module](RUNTIME_holmes-comment-loader-policy-module.md)
+- [Workflow YAML Assertion Helper](RUNTIME_workflow-yaml-assertion-helper.md)
+- [Holmes Artifact Diagnostic Sidecar](EVIDENCE_holmes-artifact-diagnostic-sidecar.md)
+- [PR Merge Gate Status Helper](RUNTIME_pr-merge-gate-status-helper.md)
+- [Review Supersession Explainer](RUNTIME_review-supersession-explainer.md)
+- [PR Feedback Session Witness](EVIDENCE_pr-feedback-session-witness.md)

--- a/docs/method/backlog/cool-ideas/RUNTIME_holmes-comment-loader-policy-module.md
+++ b/docs/method/backlog/cool-ideas/RUNTIME_holmes-comment-loader-policy-module.md
@@ -1,0 +1,44 @@
+# Holmes Comment Loader Policy Module
+
+- Lane: `cool-ideas`
+- Legend: `RUNTIME`
+
+## Why now
+
+The recent PR #467 review loop exposed that Holmes comment loading policy is
+real logic, not just glue: artifact discovery, explicit-status handling,
+diagnostic preservation, and markdown/report truth all live close together.
+Today that policy is mostly embedded in `pr-comment.mjs`, with the CLI acting as
+an adjacent caller rather than a clearly separate consumer of one loader
+surface.
+
+## Hill
+
+A maintainer can inspect one small Holmes artifact-loader module, understand the
+policy for report discovery and fallback behavior, and reuse it from both the
+PR comment builder and the CLI without re-deriving the rules from a large file.
+
+## Done looks like
+
+- one focused Holmes artifact-loader/helper module owns discovery, parse, and
+  diagnostic policy
+- the PR comment builder consumes the helper instead of carrying low-level
+  loading concerns inline
+- the CLI and tests use the same helper contract
+- fixture coverage proves success, missing, invalid, and unreadable-artifact
+  paths without duplicated setup logic
+- the module stays local-first and does not add ambient network or workflow
+  assumptions
+
+## Repo Evidence
+
+- `packages/wesley-holmes/src/pr-comment.mjs`
+- `packages/wesley-holmes/src/pr-comment-cli.mjs`
+- `packages/wesley-holmes/test/pr-comment.test.mjs`
+- `packages/wesley-holmes/test/fixtures/sample-reports.mjs`
+- `docs/invariants/local-first-operation.md`
+
+## Related Carry-Over
+
+- `#466`
+

--- a/docs/method/backlog/cool-ideas/RUNTIME_pr-merge-gate-status-helper.md
+++ b/docs/method/backlog/cool-ideas/RUNTIME_pr-merge-gate-status-helper.md
@@ -1,0 +1,39 @@
+# PR Merge Gate Status Helper
+
+- Lane: `cool-ideas`
+- Legend: `RUNTIME`
+
+## Why now
+
+The end of PR #467 was technically calm but operationally noisy: checks were
+green, review threads were closed, CodeRabbit approved, and yet the PR still
+was not merge-ready because the approval count and GitHub review state needed a
+separate manual read. That merge gate accounting is real operator work, but
+today it is spread across `gh pr checks`, `gh pr view`, and thread-aware review
+queries.
+
+## Hill
+
+A maintainer can run one local helper and see the real merge blockers for a PR:
+checks, approvals, unresolved threads, bot verdict, and the specific reason the
+PR is still merge-gated.
+
+## Done looks like
+
+- one command or script emits a short human-readable merge-gate summary
+- the same surface can emit machine-readable JSON for agents and automation
+- unresolved threads, review counts, and check families are shown together
+- the output distinguishes code blockers from process blockers cleanly
+- the helper remains local-first and does not guess at branch-protection policy
+
+## Repo Evidence
+
+- `AGENTS.md`
+- `docs/method/guide.md`
+- `docs/method/backlog/inbox/RUNTIME_gh-447-tooling-gh-add-a-deterministic-pr-review-thread-helper-for.md`
+- `docs/invariants/local-first-operation.md`
+
+## Related Carry-Over
+
+- `#447`
+

--- a/docs/method/backlog/cool-ideas/RUNTIME_review-supersession-explainer.md
+++ b/docs/method/backlog/cool-ideas/RUNTIME_review-supersession-explainer.md
@@ -1,0 +1,40 @@
+# Review Supersession Explainer
+
+- Lane: `cool-ideas`
+- Legend: `RUNTIME`
+
+## Why now
+
+GitHub's review model keeps historical `CHANGES_REQUESTED` reviews visible even
+after every actionable thread has been resolved and a later bot review has
+approved the new push. During PR #467, that made `reviewDecision` and the raw
+review list look harsher than the live thread state actually was.
+
+## Hill
+
+A maintainer can tell which review requests are still live, which ones are
+historical but superseded, and why GitHub's aggregate review state does or does
+not match the actual unresolved feedback surface.
+
+## Done looks like
+
+- one report distinguishes active change requests from superseded review history
+- the explanation names which unresolved threads, approvals, or later commits
+  changed the effective state
+- historical review noise no longer forces maintainers to hand-audit every
+  review event
+- the output stays explainable enough to paste into PR summary comments if
+  needed
+- the logic is documented so future agents do not reinvent the same heuristics
+
+## Repo Evidence
+
+- `AGENTS.md`
+- `docs/method/process.md`
+- `docs/method/guide.md`
+- `docs/invariants/docs-runtime-honesty.md`
+
+## Related Carry-Over
+
+- `#447`
+

--- a/docs/method/backlog/cool-ideas/RUNTIME_workflow-yaml-assertion-helper.md
+++ b/docs/method/backlog/cool-ideas/RUNTIME_workflow-yaml-assertion-helper.md
@@ -1,0 +1,40 @@
+# Workflow YAML Assertion Helper
+
+- Lane: `cool-ideas`
+- Legend: `RUNTIME`
+
+## Why now
+
+The repo's workflow bats coverage is valuable, but some checks still rely on
+grep windows and line-oriented shell snippets that are more brittle than the
+workflow contracts they are trying to protect. The PR #467 review pass improved
+that locally, but the pattern is still ad hoc.
+
+## Hill
+
+A maintainer can express workflow-policy assertions through one small helper
+surface that targets jobs, steps, permissions, and script snippets without
+relying on fragile text windows or emoji-labeled boundaries.
+
+## Done looks like
+
+- one reusable helper can extract named workflow jobs or step blocks for tests
+- `test/ci-workflows.bats` asserts contract-level intent rather than incidental
+  formatting
+- step-name wording changes no longer break unrelated workflow checks
+- the helper is deterministic and cheap enough to keep in pre-push routing
+- failures explain which workflow contract drifted
+
+## Repo Evidence
+
+- `test/ci-workflows.bats`
+- `scripts/smoke/repo-bats-prepush.sh`
+- `.github/workflows/cert-shipme.yml`
+- `.github/workflows/wesley-holmes.yml`
+- `docs/invariants/docs-runtime-honesty.md`
+
+## Related Carry-Over
+
+- `#449`
+- `#447`
+


### PR DESCRIPTION
## What changed
Added six `cool-ideas` backlog packets and updated the lane index under `docs/method/backlog/cool-ideas/`.

## Why
These ideas came out of the PR feedback/merge work and should be captured on the repo-visible METHOD backlog instead of living only in session memory.

## Impact
This is docs-only backlog curation. It adds candidate follow-up packets for Holmes artifact diagnostics, workflow assertion helpers, review/merge status helpers, and PR feedback witness surfaces.

## Validation
- `node scripts/check-doc-links.mjs`
- `node scripts/lint-docs-whitespace.mjs`
- `git diff --check`
- `pnpm run preflight`