### PR TITLE
[codex] Clarify current TTD protocol compiler surface

### DIFF
--- a/docs/features/ttd-protocol-compiler.md
+++ b/docs/features/ttd-protocol-compiler.md
@@ -6,6 +6,27 @@
 
 The TTD (Type-Driven Development) Protocol Compiler extends Wesley to generate deterministic protocol definitions from annotated GraphQL schemas. It produces typed protocols, registries, enforcement tables, and verification infrastructure for the Echo Time Travel Debugger.
 
+## Current Repo Truth
+
+Wesley's repo-local authored TTD schema currently lives in
+[`schemas/ttd-protocol.graphql`](../../schemas/ttd-protocol.graphql). The
+current local compile path is:
+
+```bash
+pnpm wesley compile-ttd --schema schemas/ttd-protocol.graphql --dry-run --json
+```
+
+That command currently validates the checked-in schema and reports generated
+`manifest/*.json` and `typescript/*.ts` outputs. Those files are derived
+artifacts from SDL, not a second authored source surface.
+
+The shipped directive contract for this path is the `@wes_*` TTD family
+documented in [`docs/DIRECTIVES.md`](../DIRECTIVES.md) and implemented in
+[`packages/wesley-core/src/ttd/directives.mjs`](../../packages/wesley-core/src/ttd/directives.mjs).
+The broader cross-repo publication boundary is still tracked as active backlog
+work in
+[`SOURCE_WESLEY_protocol-surface-cutover`](../method/backlog/asap/SOURCE_WESLEY_protocol-surface-cutover.md).
+
 ### Key Doctrine
 
 > "schema_hash is the universe identity"
@@ -19,20 +40,23 @@ The TTD (Type-Driven Development) Protocol Compiler extends Wesley to generate d
 ### CLI Usage
 
 ```bash
+# Compile the checked-in Wesley TTD schema
+pnpm wesley compile-ttd --schema schemas/ttd-protocol.graphql --out-dir .wesley-cache/ttd-out
+
 # Basic compilation
-wesley compile-ttd schema.graphql --out-dir ttd-out/
+pnpm wesley compile-ttd --schema schema.graphql --out-dir ttd-out/
 
 # Specify targets
-wesley compile-ttd schema.graphql --target manifest,typescript
+pnpm wesley compile-ttd --schema schema.graphql --target manifest,typescript
 
 # Dry-run to preview
-wesley compile-ttd schema.graphql --dry-run
+pnpm wesley compile-ttd --schema schema.graphql --dry-run
 
 # JSON output for scripting
-wesley compile-ttd schema.graphql --json
+pnpm wesley compile-ttd --schema schema.graphql --dry-run --json
 
 # Read from stdin
-cat schema.graphql | wesley compile-ttd --schema - --out-dir ttd-out/
+cat schema.graphql | pnpm wesley compile-ttd --schema - --out-dir ttd-out/
 ```
 
 ### Simple Schema Example
@@ -77,6 +101,11 @@ type OrderSystem
 
 ## Directives Reference
 
+The current shipped directive surface for `wesley compile-ttd` is the
+`@wes_*` family below. The newer `@channel` / `@op` / `@rule` noun vocabulary
+described in the extracted plan doc is still target-state design work, not the
+checked-in compiler contract on `main`.
+
 ### Channel Directives
 
 | Directive | Purpose | Example |
@@ -109,6 +138,8 @@ type OrderSystem
 | `@wes_invariant` | System-level invariant | `@wes_invariant(name: "bounds", expr: "...", severity: "error")` |
 
 ## Generated Outputs
+
+All generated files in this section are derived outputs from the SDL input.
 
 ### Manifest Files
 

--- a/docs/plans/ttd-protocol-compiler.md
+++ b/docs/plans/ttd-protocol-compiler.md
@@ -3,7 +3,7 @@
 
 # TTD Protocol Compiler Plan
 
-**Status:** Complete (Phase 1a/1b/1c + CLI Integration)
+**Status:** Current repo-local compiler shipped; broader Continuum protocol cutover still open
 **Created:** 2026-01-25
 **Origin:** Extracted from `flyingrobots/echo` TTD Master Plan
 **Scope:** Extend Wesley to compile deterministic protocol schemas for the Echo Time Travel Debugger
@@ -13,6 +13,23 @@
 ## Executive Summary
 
 This plan extends Wesley with a new **TTD Protocol Compiler** capability. The goal is to generate typed protocols, registries, enforcement tables, and verification infrastructure from annotated GraphQL SDL—enabling Echo's Time Travel Debugger to prove determinism through content-addressed, hashable protocol definitions.
+
+## Current Repo Truth
+
+Wesley currently ships a repo-local `compile-ttd` path that parses the
+`@wes_*` TTD directives documented in [`../DIRECTIVES.md`](../DIRECTIVES.md)
+and implemented in
+[`../../packages/wesley-core/src/ttd/directives.mjs`](../../packages/wesley-core/src/ttd/directives.mjs).
+The authored schema Wesley compiles today lives at
+[`../../schemas/ttd-protocol.graphql`](../../schemas/ttd-protocol.graphql),
+and the generated manifest / TypeScript outputs are derived artifacts rather
+than peer authorities.
+
+The sections below describe the extracted target-state design from Echo. They
+are still useful for direction, but they should not be read as proof that
+`main` already accepts the `@channel` / `@op` / `@rule` vocabulary or that the
+cross-repo protocol publication boundary is settled. That cutover is tracked in
+[`SOURCE_WESLEY_protocol-surface-cutover`](../method/backlog/asap/SOURCE_WESLEY_protocol-surface-cutover.md).
 
 ### Key Doctrine
 
@@ -24,7 +41,7 @@ This plan extends Wesley with a new **TTD Protocol Compiler** capability. The go
 
 ---
 
-## Part 1: New Directive Vocabulary
+## Part 1: Target-State Directive Vocabulary
 
 Wesley's existing `@wes_*` directives handle database DDL. The TTD Protocol Compiler adds a parallel set of directives for **deterministic protocol compilation**.
 
@@ -171,7 +188,7 @@ directive @invariant(
 
 ---
 
-## Part 2: Example Schema Usage
+## Part 2: Target-State Example Schema Usage
 
 ```graphql
 schema
@@ -218,7 +235,7 @@ type RuleContract_MovePlayer
 
 ---
 
-## Part 3: Compiler Outputs
+## Part 3: Target-State Compiler Outputs
 
 ### 3.1 Type/Codegen Outputs (what devs use)
 

--- a/schemas/ttd-protocol.graphql
+++ b/schemas/ttd-protocol.graphql
@@ -1,10 +1,11 @@
 # TTD Protocol Schema for Echo Time-Travel Debugger
-# Defines channels, operations, rules, and invariants for the TTD system.
+# Repo-local authored input for Wesley's current `compile-ttd` path.
 #
-# This schema is the source of truth for:
-# - Rust types in Echo (via echo-ttd-gen)
-# - TypeScript types in ttd-app (via Wesley compile-ttd)
-# - Manifest files for compliance checking
+# Current source-surface truth in this repo:
+# - this SDL is the authored input Wesley compiles today
+# - manifest JSON and TypeScript outputs are derived artifacts
+# - the cross-repo publication boundary is still tracked separately in
+#   docs/method/backlog/asap/SOURCE_WESLEY_protocol-surface-cutover.md
 
 scalar JSON
 scalar Hash  # SHA-256 hash: 32 bytes binary, 64-character hex string


### PR DESCRIPTION
## What changed
- clarified that `schemas/ttd-protocol.graphql` is Wesley's current repo-local authored input for `compile-ttd`
- updated the feature doc to show the real CLI surface, including `--schema` and a repo-local compile example
- marked the extracted TTD plan's `@channel` / `@op` vocabulary and output sections as target-state design rather than shipped behavior

## Why
The Continuum protocol-surface cutover packet requires a truthful ownership story. Before this change, the feature doc showed incorrect CLI examples, the plan read like newer directive vocabulary was already implemented, and the schema header overstated cross-repo source authority.

## Impact
This is a docs/schema-comment truth pass. It does not change runtime behavior, but it makes the current source surface, derived outputs, and cutover boundary inspectable for maintainers and agents.

## Validation
- `pnpm wesley compile-ttd --schema schemas/ttd-protocol.graphql --dry-run --json`
- `node scripts/check-doc-links.mjs`
- `node scripts/lint-docs-whitespace.mjs`
- `node scripts/check-doc-truth.mjs`
- `git diff --check`
- `pnpm run preflight`