### PR TITLE
Clean up README by removing badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Wesley
-<!-- docs-truth: status=experimental owner=@flyingrobots -->
+<div align="center">
+<img src="https://github.com/user-attachments/assets/0c03a527-dc36-466f-a212-a3a24731acf8" />
+</div>
+
 
 A schema-first contract compiler for trustworthy change. Wesley ensures that shared protocols, database migrations, and cross-language boundaries remain technically truthful through bit-exact code generation and evidence-backed conformance.
 
 Wesley is designed for the systems architect who demands a sovereign boundary for their contracts. It scales from automated PostgreSQL migration planning to the compilation of the global Continuum causal protocol.
-
-[![Overall](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/flyingrobots/wesley/main/meta/badges/overall.json)](README.md)
-[![License](https://img.shields.io/github/license/wesley)](./LICENSE)
 
 ## Why Wesley?
 


### PR DESCRIPTION
Removed unnecessary badges from the README.

## Summary
- What problem does this PR solve? Link issues/PRs.

## Why
- Rationale for this approach. Mention alternatives considered and trade‑offs.

## Changes
- Bulleted list of focused changes (keep it surgical).

## Risk
- User‑facing or CI risk and mitigations. Rollout/enablement notes if any.

## Backout
- How to revert safely; follow‑up cleanup if rollback happens.

## Testing
- Unit: `pnpm -w -F @wesley/core test:unit`
- Snapshots: `UPDATE_SNAPSHOTS=1 pnpm -w -F @wesley/core test:snapshots` (only when intentionally updating)
- CLI Bats: `pnpm -w -F @wesley/cli test`
- Preflight: `pnpm run preflight`

## EvidenceMap / SourceMap (if applicable)
- Confirm UIDs use `tbl:Table` and `col:Table.field`.
- If mapping SQL→SDL, verify `.wesley-cache/bundle.json` exists and SourceMap finds SDL.

## Screenshots / Logs (optional)

## Merge Strategy
- Merge commit only; no rebase.
- Delete branch after merge.

## Checklist
- [ ] One‑topic PR with tight diff
- [ ] Tests green locally (unit, snapshots, CLI Bats as relevant)
- [ ] Preflight passes (`pnpm run preflight`)
- [ ] No widened permissions/secrets in workflows
- [ ] Docs updated if behavior changed
