### PR TITLE
chore(release): v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Git identity release guard**: Added collaborator-neutral preflight and Rust
+  release guard checks that reject known fixture identities in repo-local Git
+  config and the release `HEAD` author/committer metadata before publish prep
+  can proceed.
 - **Nested GraphQL list lowering and emission**: L1 type references now retain
   nested list wrapper depth, and the Rust and TypeScript emitters project nested
   GraphQL lists as nested vectors/arrays instead of flattening to one level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.0.1] - 2026-05-09
+
 ### Added
 
 - **Crates.io alpha publishing metadata**: Prepared the Rust-native crates for
@@ -806,4 +808,5 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.1.0] - 2025-09-01
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/flyingrobots/wesley/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ cargo wesley emit typescript --schema test/fixtures/consumer-models/jedit-hot-te
 
 Echo-owned tooling owns Echo-specific footprint honesty checks.
 
+## What's New in v0.0.1
+
+Wesley's first Rust-native alpha publishes the core compiler path to crates.io:
+`wesley-core`, `wesley-emit-rust`, `wesley-emit-typescript`, and `wesley-cli`.
+The installable crate is `wesley-cli`, which provides the `wesley` binary.
+
+This release centers the Rust front door. It lowers GraphQL SDL to domain-empty
+L1 IR, hashes schemas, diffs schema structure, lists schema root operations,
+emits Rust and TypeScript model/operation bindings, resolves operation
+selection paths, and extracts operation directive arguments without requiring an
+npm entry point. See [CHANGELOG.md](./CHANGELOG.md) for the full release notes.
+
 ## Rust-Native Front Door
 
 Wesley core work now starts from Cargo.
@@ -94,6 +106,19 @@ Wesley core work now starts from Cargo.
 The distinction matters: `wesley` is the user-facing compiler command, while
 `xtask` is for maintaining this repository. Avoid adding new core workflows to
 `pnpm wesley`; new compiler behavior should land in Rust first.
+
+### Extending Wesley
+
+Extend Wesley at the narrowest boundary that owns the meaning:
+
+- Add generic GraphQL compiler facts in `crates/wesley-core`.
+- Add user-facing Rust commands in `crates/wesley-cli`.
+- Add generic Rust or TypeScript projections in the existing Rust emitter crates
+  when the projection is domain-empty and broadly reusable.
+- Put domain targets, policies, witnesses, and runtime conventions in external
+  modules or crates owned by that domain.
+
+The practical extension guide is [docs/guides/extending.md](./docs/guides/extending.md).
 
 ### Native Install And Release
 
@@ -188,6 +213,9 @@ Progress: 61% → Alpha
 - **[Wesley Glossary](./docs/WESLEY_GLOSSARY.md)**: The main nouns, layers, and boundary terms for Wesley and its surrounding toolchain.
 - **[Advanced Guide](./docs/ADVANCED_GUIDE.md)**: Deep dives into the IR model, custom directives, and the "Holmes" policy engine.
 - **[Architecture](./docs/ARCHITECTURE.md)**: The authoritative system map (Base Platform, Modules, Workspace, and bundle pipeline).
+- **[Extending Wesley](./docs/guides/extending.md)**: How to add Rust compiler
+  behavior, native CLI surfaces, emitter projections, or external modules
+  without breaking the core boundary.
 - **[Realization Admission and Witness](./docs/design/0004-realization-admission-and-witness/realization-admission-and-witness.md)**: The release-line doctrine for authored source, IR, realization shells, and bounded witness claims.
 - **[Module Contract](./docs/design/wesley-module-contract.md)**: The boundary between the Wesley compiler kernel and external target modules.
 - **[Module Capability Contract](./docs/design/wesley-module-capability-contract.md)**: The capability surfaces external modules bring to Wesley.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -95,6 +95,8 @@ they are not the same thing as the core compile act.
 For the exact boundary, see
 [architecture/wesley-core-vs-toolchain.md](./architecture/wesley-core-vs-toolchain.md).
 
+For practical extension rules, see [guides/extending.md](./guides/extending.md).
+
 For the noun-by-noun version of that split, see
 [WESLEY_GLOSSARY.md](./WESLEY_GLOSSARY.md).
 
@@ -112,8 +114,9 @@ Wesley is a tiered engine designed to enforce contract integrity across platform
 - [ ] **I am setting up Rust core work**: Run `cargo xtask preflight`.
 - [ ] **I am changing docs or legacy packages**: Run `pnpm install` and `cargo xtask legacy-preflight`.
 - [ ] **I am modifying a schema**: Always start in the `.graphql` file.
-- [ ] **I am adding a new generic generator**: Check `packages/wesley-generator-js` for a baseline.
+- [ ] **I am adding a generic projection**: Start in `crates/wesley-emit-rust` or `crates/wesley-emit-typescript`, and only touch legacy Node generators for legacy package work.
 - [ ] **I am adding a domain target**: Put it in an external module repo and load it into Wesley.
+- [ ] **I am extending Wesley**: Use `docs/guides/extending.md` to pick the Rust core, native CLI, emitter, external module, or `xtask` boundary.
 - [ ] **I am contributing to Wesley**: Read `METHOD.md` and `BEARING.md`.
 - [ ] **I am touching Continuum behavior**: Work in the Continuum-owned module/repo, not here.
 - [ ] **I am touching PostgreSQL or Supabase behavior**: Work in `wesley-postgres`, not here.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ which signpost is supposed to answer which question.
 | [LEGACY_NODE_MIGRATION.md](./LEGACY_NODE_MIGRATION.md) | Deletion map for the historical Node CLI, packages, generators, hosts, and evidence tooling. |
 | [WESLEY_GLOSSARY.md](./WESLEY_GLOSSARY.md) | Fast noun map for the Wesley base platform, modules, and project workspace. |
 | [BEARING](./BEARING.md) | Current direction, what is already real in the repo, and the tensions that still matter. |
+| [Extending Wesley](./guides/extending.md) | How to add Rust compiler behavior, native CLI commands, emitter projections, or external modules. |
 | [VISION](./VISION.md) | Bounded executive synthesis grounded in repo-visible truth. |
 | [Design Packets](./design/README.md) | Active design packets and doctrinal boundary notes. |
 | [METHOD Process](./method/process.md) | How cycles run, close, and reconcile in this repo. |
@@ -61,6 +62,7 @@ It also now has a more explicit METHOD closeout surface under
 - [Design Packets](./design/README.md)
 - [Architecture Overview](./architecture/overview.md)
 - [Wesley Core Versus Toolchain](./architecture/wesley-core-vs-toolchain.md)
+- [Extending Wesley](./guides/extending.md)
 - [Module Contract](./design/wesley-module-contract.md)
 
 ### Continuum Orientation

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -1,82 +1,162 @@
 # Extending Wesley
 
-This guide explains how to extend Wesley safely by adding new generators and adapters without breaking the core's purity or public APIs.
+Wesley is now a Rust-first GraphQL compiler kernel with a native CLI. Extend it
+by choosing the boundary that owns the meaning you are adding. The default is
+not "add another generator to core"; the default is "keep the core semantic and
+put domain behavior where that domain lives."
 
-- Core stays pure (no node:*). Add pure utilities under `packages/wesley-core/src/util/` when needed.
-- Add adapters (filesystem, shell, network) in `@wesley/host-node` and inject via the CLI.
-- For new outputs (e.g., additional SQL dialects), create a generator plugin and cover with snapshot tests.
+## Extension Decision Table
 
-See also: docs/README.md → Implementation and CI boundaries.
+| Goal | Put It Here | Why |
+| --- | --- | --- |
+| Parse or lower more domain-empty GraphQL semantics | `crates/wesley-core` | Core owns GraphQL syntax, L1 IR, schema diffs, operation catalogs, selection resolution, and directive argument extraction. |
+| Add a native user command over existing Rust facts | `crates/wesley-cli` | The CLI is the Rust product front door and should stay a thin shell around library APIs. |
+| Emit generic Rust data models or operation bindings | `crates/wesley-emit-rust` | The projection is reusable and does not smuggle database, Echo, or product assumptions into core. |
+| Emit generic TypeScript declarations or operation bindings | `crates/wesley-emit-typescript` | The projection is reusable and derived from L1 IR plus schema operation data. |
+| Add PostgreSQL, Echo, Continuum, jedit, or other domain behavior | External module or external crate | Domain targets own their policy, runtime semantics, witnesses, and release conventions. |
+| Add release or repository automation | `xtask` | `xtask` is the maintenance front door, not user-facing compiler behavior. |
 
----
+## Rust Core Extensions
 
-## Generator Plugins (E0.1+)
+Core extensions should be pure data transformations. They should not read files,
+write files, shell out, load user code, or assume a database or runtime.
 
-Wesley provides a stable `GeneratorPlugin` contract for code generation. All generators conform to one lifecycle: **init → plan → generate** (pure data return, no I/O).
+Use this shape:
 
-### The GeneratorPlugin Contract
+1. Add or adjust domain data in `crates/wesley-core/src/domain/`.
+2. Add parser/lowering behavior in `crates/wesley-core/src/adapters/apollo.rs`.
+3. Expose stable functions from `crates/wesley-core/src/lib.rs`.
+4. Add tests under `crates/wesley-core/tests/`.
+5. Keep fixtures domain-empty unless the fixture is explicitly testing generic
+   directive preservation.
 
-```js
-import { GeneratorPlugin } from '@wesley/core';
+Good core APIs look like this:
 
-class MyPlugin extends GeneratorPlugin {
-  get apiVersion() { return '1'; }       // Must match a supported version
-  get name()       { return 'my-gen'; }  // Unique, non-empty identifier
+```rust
+pub fn lower_schema_sdl(schema_sdl: &str) -> Result<WesleyIR, WesleyError>;
+pub fn diff_schema_sdl(old_sdl: &str, new_sdl: &str) -> Result<SchemaDelta, WesleyError>;
+pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperation>, WesleyError>;
+pub fn resolve_operation_selections(operation_sdl: &str) -> Result<Vec<String>, WesleyError>;
+pub fn extract_operation_directive_args(
+    operation_sdl: &str,
+    directive_name: &str,
+) -> Result<Vec<OperationDirectiveArgs>, WesleyError>;
+```
 
-  init(config) {
-    // Optional setup from wesley.config.mjs (no-op by default)
-  }
+Bad core APIs are APIs that decide what PostgreSQL tables mean, what Echo
+footprints mean, where files should be written, or how a product runtime should
+admit an operation. Those belong outside core.
 
-  async plan(schema, context) {
-    // Declare what artifacts you will produce
-    return {
-      artifacts: [
-        { path: 'output.ts', reason: 'Generated types' },
+## Native CLI Extensions
+
+Add CLI behavior only after the underlying Rust library function exists. The CLI
+should parse arguments, call the library, format output, and choose process exit
+codes. It should not become a second implementation of compiler logic.
+
+Use this shape:
+
+1. Add the library function and tests first.
+2. Wire the command in `crates/wesley-cli/src/main.rs`.
+3. Add integration coverage in `crates/wesley-cli/tests/cli.rs`.
+4. Update README and guide examples when command names or output contracts
+   change.
+
+For example, schema diffing belongs in `wesley-core` as `diff_schema_sdl`, while
+`wesley schema diff --old old.graphql --new new.graphql --exit-code` is just the
+native command wrapper.
+
+## Emitter Extensions
+
+The Rust and TypeScript emitters are AST/printer crates. They should consume
+Wesley L1 IR and schema operation data, build structured in-memory declaration
+models, and print those models. Do not add regex-based code generation or
+string-splicing logic for semantic structure.
+
+Use this shape:
+
+1. Lower source GraphQL through `wesley-core`.
+2. Convert L1 IR into an emitter-owned AST.
+3. Print from the AST.
+4. Add tests that assert both the semantic output and parser validity when a
+   parser is available.
+
+The current examples are:
+
+- `crates/wesley-emit-rust`
+- `crates/wesley-emit-typescript`
+
+## External Module Extensions
+
+Domain-specific targets should live outside the Wesley core repo unless there is
+a deliberate temporary migration reason. Examples include Echo footprint
+honesty, PostgreSQL migrations, Continuum family witnesses, jedit runtime
+contracts, and agent policy apertures.
+
+External modules may bring:
+
+- target semantics
+- generators
+- policy checks
+- witness scopes
+- runtime admission guards
+- release conventions
+
+Wesley should provide the generic compiler facts those modules need. The module
+should decide what those facts mean for its domain.
+
+## Legacy Node Module Notes
+
+The repository still contains historical Node package surfaces while the
+Rust-native front door takes over. If you must touch the legacy module loader,
+use the current module entry shape, not the obsolete top-level `generators`
+shape.
+
+Use `wesley.config.mjs` like this:
+
+```mjs
+export default {
+  modules: [
+    {
+      specifier: './my-wesley-module.mjs',
+      config: {
+        output: 'generated',
+      },
+    },
+  ],
+};
+```
+
+A module advertises capabilities:
+
+```mjs
+export default {
+  name: 'my-domain-module',
+  capabilities: {
+    wesley: {
+      targets: [
+        {
+          name: 'my-domain',
+          description: 'Emit my-domain artifacts from Wesley compiler facts',
+        },
       ],
-    };
-  }
-
-  async generate(plan, context) {
-    // Return artifacts as Record<string, string|Uint8Array>
-    // NO filesystem I/O — the runner handles writing
-    return {
-      'output.ts': `// Generated from ${plan.metadata?.name ?? 'schema'}\n`,
-    };
-  }
-}
+    },
+  },
+};
 ```
 
-### Key Rules
+Treat loaded modules as trusted code. Use `WESLEY_DISABLE_MODULES=1` for a
+no-module diagnostic run, and use `WESLEY_MODULE_ALLOWLIST` in CI when only
+approved module specifiers may load.
 
-1. **Pure generate()** — Return `Record<string, string|Uint8Array>`. The runner's caller writes files.
-2. **Plan is enforced** — `plan()` must return an `artifacts` array with `path` strings. Undeclared artifact paths in generate output trigger a warning.
-3. **Duck typing** — You can use a plain object instead of extending the class. `validatePlugin()` checks shape, not `instanceof`.
-4. **Frozen context** — The `PluginContext` passed to `plan()` and `generate()` is `Object.freeze()`'d. It contains `{ logger, clock, config, runId, emission }`, and `emission.outDir` is the explicit place to read output routing.
-5. **apiVersion** — Must be an exact string from `SUPPORTED_API_VERSIONS` (currently `"1"`). Numbers and semver strings are rejected with actionable error messages.
+## Validation Checklist
 
-### Running Plugins
+Before sending an extension:
 
-```js
-import { PluginRunner } from '@wesley/core';
+- Run `cargo xtask preflight`.
+- Run `cargo test --workspace --all-features` for Rust behavior.
+- Run `cargo clippy --workspace --all-targets -- -D warnings` for Rust changes.
+- Run `cargo xtask legacy-preflight` when changing legacy Node package surfaces.
+- Update `CHANGELOG.md` when public behavior changes.
 
-const runner = new PluginRunner({ logger, clock, config, bestEffort: false });
-const { results, success, totalArtifacts, runId } = await runner.run([plugin], schema);
-```
-
-- Plugins run sequentially in input order (deterministic).
-- Default mode throws after first failure, attaching `pluginResults` to the error.
-- `bestEffort: true` continues through all plugins; success = at least one `'ok'`.
-
-### Error Codes
-
-| Code | When |
-|---|---|
-| `WPLY001` | Plugin doesn't conform to contract (shape/version/name/methods) |
-| `WPLY002` | Plugin threw during init(), plan(), or generate() |
-| `WPLY003` | generate() returned wrong type (not Record/object) |
-| `WPLY004` | plan() returned invalid shape (missing/malformed artifacts) |
-
-### Example: VuePlugin
-
-See `packages/wesley-generator-vue/src/VuePlugin.mjs` for a real-world adapter
-that wraps the existing `generateVue()` function in the plugin contract.
+The core rule is simple: Wesley core compiles GraphQL into honest, domain-empty
+facts. Extensions decide what those facts become.

--- a/docs/guides/generator-plugins.md
+++ b/docs/guides/generator-plugins.md
@@ -1,8 +1,12 @@
-# Generator Plugins
+# Legacy Generator Plugins
 
-Wesley uses a plugin system to turn parsed GraphQL schemas into output artifacts (SQL, TypeScript, Zod schemas, IR files, etc.). Each generator plugin receives a schema, declares what it will produce, then generates the artifacts as pure data. Wesley handles all file I/O.
+Wesley's current extension direction is Rust-first core APIs plus external
+modules for domain targets. This page documents the legacy Node generator plugin
+contract that still exists while the older package surfaces are being retired or
+extracted.
 
-This guide will get you writing your own generator plugin in under 30 minutes.
+For new work, start with [Extending Wesley](./extending.md). Add generic
+compiler facts in Rust, and put domain targets in external modules or crates.
 
 ---
 
@@ -40,12 +44,32 @@ export class HelloPlugin extends GeneratorPlugin {
 export default HelloPlugin;
 ```
 
-Register it in `wesley.config.mjs` and you are done:
+Expose it from a Wesley module and register that module in `wesley.config.mjs`:
 
 ```mjs
+// my-wesley-module.mjs
+import HelloPlugin from './my-plugin.mjs';
+
 export default {
-  generators: [
-    { package: './my-plugin.mjs' },
+  name: 'hello-module',
+  capabilities: {
+    wesley: {
+      generators: [
+        {
+          name: 'hello',
+          plugin: new HelloPlugin(),
+        },
+      ],
+    },
+  },
+};
+```
+
+```mjs
+// wesley.config.mjs
+export default {
+  modules: [
+    { specifier: './my-wesley-module.mjs' },
   ],
 };
 ```
@@ -235,39 +259,56 @@ The harness uses a deterministic clock (`2020-01-01T00:00:00.000Z`), a null logg
 
 ## Configuration
 
-Register plugins in `wesley.config.mjs` under the `generators` array:
+Register plugins through module capabilities. Do not use the obsolete top-level
+`generators` array for new code.
+
+```mjs
+// my-wesley-module.mjs
+import { MyPlugin } from './my-plugin.mjs';
+import { ExperimentalPlugin } from './experimental-plugin.mjs';
+
+export default {
+  name: 'my-generators',
+  capabilities: {
+    wesley: {
+      generators: [
+        {
+          name: 'my-generator',
+          plugin: new MyPlugin(),
+          config: { format: 'yaml', verbose: true },
+        },
+        {
+          name: 'experimental',
+          plugin: new ExperimentalPlugin(),
+          enabled: false,
+        },
+      ],
+    },
+  },
+};
+```
 
 ```mjs
 // wesley.config.mjs
 export default {
-  generators: [
-    // Minimal: just a package specifier
-    { package: '@wesley/generator-vue' },
-
-    // With per-plugin config passed to init()
-    {
-      package: './my-plugin.mjs',
-      config: { format: 'yaml', verbose: true },
-    },
-
-    // Disabled (skipped during discovery)
-    {
-      package: '@wesley/generator-experimental',
-      enabled: false,
-    },
+  modules: [
+    { specifier: './my-wesley-module.mjs' },
   ],
 };
 ```
 
-Each entry in the `generators` array supports:
+Each generator capability supports:
 
 | Field     | Type      | Required | Description                              |
 |-----------|-----------|----------|------------------------------------------|
-| `package` | `string`  | yes      | npm package name or relative file path   |
+| `name`    | `string`  | yes      | Unique generator name within the module  |
+| `plugin`  | `object`  | yes      | GeneratorPlugin instance or duck-typed object |
 | `config`  | `object`  | no       | Passed to `plugin.init(config)`          |
 | `enabled` | `boolean` | no       | Set to `false` to skip (default: `true`) |
 
-Plugin discovery resolves each package, looks for a `default`, `plugin`, or `Plugin` export, instantiates it if it is a class, validates the contract, and calls `init()` with the entry's `config` if provided.
+Module discovery resolves each configured module specifier, reads its
+`capabilities.wesley.generators` entries, validates each plugin contract, and
+calls `init()` with the entry's `config` if provided.
 
 ---
 

--- a/scripts/check-git-identity.mjs
+++ b/scripts/check-git-identity.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const forbiddenGitIdentityValues = new Set([
+  'Wesley Tests',
+  'wesley-tests@example.com',
+  'Wesley CLI Test',
+  'wesley@example.test',
+  'Local Test',
+  'test@local.dev',
+  'CI Test',
+  'test@ci.com'
+]);
+
+export function gitIdentityFailures({
+  name,
+  email,
+  authorName,
+  authorEmail,
+  committerName,
+  committerEmail
+}) {
+  const failures = [];
+  if (name && forbiddenGitIdentityValues.has(name)) {
+    failures.push(`local git user.name is a test identity: ${name}`);
+  }
+  if (email && forbiddenGitIdentityValues.has(email)) {
+    failures.push(`local git user.email is a test identity: ${email}`);
+  }
+  if (authorName && forbiddenGitIdentityValues.has(authorName)) {
+    failures.push(`HEAD author name is a test identity: ${authorName}`);
+  }
+  if (authorEmail && forbiddenGitIdentityValues.has(authorEmail)) {
+    failures.push(`HEAD author email is a test identity: ${authorEmail}`);
+  }
+  if (committerName && forbiddenGitIdentityValues.has(committerName)) {
+    failures.push(`HEAD committer name is a test identity: ${committerName}`);
+  }
+  if (committerEmail && forbiddenGitIdentityValues.has(committerEmail)) {
+    failures.push(`HEAD committer email is a test identity: ${committerEmail}`);
+  }
+  return failures;
+}
+
+function localGitConfig(key, cwd) {
+  const result = spawnSync('git', ['config', '--local', '--get', key], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.status === 1) return null;
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git config --local --get ${key} failed`);
+  }
+  return result.stdout.trim() || null;
+}
+
+function repositoryRoot(cwd) {
+  const result = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.status !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+function headGitIdentity(cwd) {
+  const result = spawnSync(
+    'git',
+    ['log', '-1', '--format=%an%x00%ae%x00%cn%x00%ce', 'HEAD'],
+    {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
+  if (result.status === 128) return {};
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || 'git log -1 identity lookup failed');
+  }
+
+  const [authorName, authorEmail, committerName, committerEmail] = result.stdout
+    .replace(/\n$/, '')
+    .split('\0');
+
+  return {
+    authorName: authorName || null,
+    authorEmail: authorEmail || null,
+    committerName: committerName || null,
+    committerEmail: committerEmail || null
+  };
+}
+
+export function checkCurrentRepositoryGitIdentity(cwd = process.cwd()) {
+  const root = repositoryRoot(cwd);
+  if (!root) return [];
+
+  return gitIdentityFailures({
+    name: localGitConfig('user.name', root),
+    email: localGitConfig('user.email', root),
+    ...headGitIdentity(root)
+  });
+}
+
+function main() {
+  let failures;
+  try {
+    failures = checkCurrentRepositoryGitIdentity();
+  } catch (error) {
+    console.error(`Git identity guard failed: ${error?.message || error}`);
+    process.exit(1);
+  }
+
+  if (failures.length === 0) return;
+
+  console.error('Git identity guard failed: test identity configured in this repository.');
+  for (const failure of failures) {
+    console.error(` - ${failure}`);
+  }
+  console.error('Remove the repo-local override or set a real verified signing identity.');
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-git-identity.test.mjs
+++ b/scripts/check-git-identity.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { gitIdentityFailures } from './check-git-identity.mjs';
+
+test('git identity guard accepts unset or collaborator local identities', () => {
+  assert.deepEqual(gitIdentityFailures({ name: null, email: null }), []);
+  assert.deepEqual(
+    gitIdentityFailures({
+      name: 'Example Contributor',
+      email: 'contributor@company.dev',
+      authorName: 'Another Contributor',
+      authorEmail: 'another@company.dev',
+      committerName: 'Release Operator',
+      committerEmail: 'release@company.dev'
+    }),
+    []
+  );
+});
+
+test('git identity guard rejects test names and emails independently', () => {
+  assert.deepEqual(
+    gitIdentityFailures({ name: 'Wesley Tests', email: 'contributor@company.dev' }),
+    ['local git user.name is a test identity: Wesley Tests']
+  );
+  assert.deepEqual(
+    gitIdentityFailures({ name: 'Example Contributor', email: 'wesley-tests@example.com' }),
+    ['local git user.email is a test identity: wesley-tests@example.com']
+  );
+});
+
+test('git identity guard rejects known local and CI fixture identities', () => {
+  assert.deepEqual(
+    gitIdentityFailures({ name: 'Local Test', email: 'test@local.dev' }),
+    [
+      'local git user.name is a test identity: Local Test',
+      'local git user.email is a test identity: test@local.dev'
+    ]
+  );
+  assert.deepEqual(
+    gitIdentityFailures({ name: 'CI Test', email: 'test@ci.com' }),
+    [
+      'local git user.name is a test identity: CI Test',
+      'local git user.email is a test identity: test@ci.com'
+    ]
+  );
+});
+
+test('git identity guard rejects fixture identities on HEAD commits', () => {
+  assert.deepEqual(
+    gitIdentityFailures({
+      authorName: 'Wesley Tests',
+      authorEmail: 'wesley-tests@example.com',
+      committerName: 'CI Test',
+      committerEmail: 'test@ci.com'
+    }),
+    [
+      'HEAD author name is a test identity: Wesley Tests',
+      'HEAD author email is a test identity: wesley-tests@example.com',
+      'HEAD committer name is a test identity: CI Test',
+      'HEAD committer email is a test identity: test@ci.com'
+    ]
+  );
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -14,6 +14,13 @@ const failures = [];
 
 function fail(msg) { ok = false; failures.push(msg); }
 
+const gitIdentityChk = spawnSync(
+  process.execPath,
+  ['scripts/check-git-identity.mjs'],
+  { stdio: 'inherit' }
+);
+if (gitIdentityChk.status !== 0) fail('Git identity guard failed');
+
 // 1) .gitignore contains .wesley-cache/ and out/
 try {
   const gi = readFileSync(resolve('.gitignore'), 'utf8');

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,16 @@ const EXIT_OK: u8 = 0;
 const EXIT_FAILURE: u8 = 1;
 const EXIT_USAGE: u8 = 2;
 const ALPHA_VERSION: &str = "0.0.1";
+const FORBIDDEN_GIT_IDENTITIES: &[&str] = &[
+    "Wesley Tests",
+    "wesley-tests@example.com",
+    "Wesley CLI Test",
+    "wesley@example.test",
+    "Local Test",
+    "test@local.dev",
+    "CI Test",
+    "test@ci.com",
+];
 const PUBLISH_CRATES: &[PublishCrate] = &[
     PublishCrate {
         name: "wesley-core",
@@ -71,6 +81,7 @@ fn run(args: Vec<OsString>) -> Result<(), Error> {
         }
         "test" => run_command("cargo", &["test", "--workspace"]),
         "preflight" => {
+            check_git_identity_guard()?;
             run_docs_check()?;
             run_command("cargo", &["test", "--workspace"])?;
             run_command("cargo", &["run", "--bin", "wesley", "--", "--help"])
@@ -411,6 +422,7 @@ fn run_release_guard(args: &[OsString]) -> Result<(), Error> {
 fn run_release_prep_guard(args: &[OsString]) -> Result<(), Error> {
     let options = ReleasePrepOptions::parse(args)?;
     let tag = format!("v{}", options.version);
+    check_git_identity_guard()?;
     check_publish_manifest_versions(&options.version)?;
     check_release_required_files(&options.version)?;
     check_release_backlog_clear(&tag, &options.version)?;
@@ -421,6 +433,7 @@ fn run_release_prep_guard(args: &[OsString]) -> Result<(), Error> {
 
 fn run_release_guard_for_tag(tag: &str) -> Result<(), Error> {
     let version = version_from_tag(tag)?;
+    check_git_identity_guard()?;
     check_release_tag_points_to_head(tag)?;
     check_release_tag_is_on_main(tag)?;
     check_publish_manifest_versions(&version)?;
@@ -457,6 +470,135 @@ fn version_from_release_arg(version: &str) -> Result<String, Error> {
         });
     }
     Ok(parsed.to_string())
+}
+
+fn check_git_identity_guard() -> Result<(), Error> {
+    let local_name = git_local_config_value("user.name")?;
+    let local_email = git_local_config_value("user.email")?;
+    let head_identity = git_head_identity()?;
+    let failures = git_identity_failures(GitIdentityInput {
+        local_name: local_name.as_deref(),
+        local_email: local_email.as_deref(),
+        head_author_name: head_identity.author_name.as_deref(),
+        head_author_email: head_identity.author_email.as_deref(),
+        head_committer_name: head_identity.committer_name.as_deref(),
+        head_committer_email: head_identity.committer_email.as_deref(),
+    });
+    finish_check("git identity", failures)
+}
+
+#[derive(Default)]
+struct GitIdentityInput<'a> {
+    local_name: Option<&'a str>,
+    local_email: Option<&'a str>,
+    head_author_name: Option<&'a str>,
+    head_author_email: Option<&'a str>,
+    head_committer_name: Option<&'a str>,
+    head_committer_email: Option<&'a str>,
+}
+
+#[derive(Default)]
+struct HeadGitIdentity {
+    author_name: Option<String>,
+    author_email: Option<String>,
+    committer_name: Option<String>,
+    committer_email: Option<String>,
+}
+
+fn git_identity_failures(input: GitIdentityInput<'_>) -> Vec<String> {
+    let mut failures = Vec::new();
+    if let Some(name) = input.local_name {
+        if is_forbidden_git_identity(name) {
+            failures.push(format!("local git user.name is a test identity: {name}"));
+        }
+    }
+    if let Some(email) = input.local_email {
+        if is_forbidden_git_identity(email) {
+            failures.push(format!("local git user.email is a test identity: {email}"));
+        }
+    }
+    if let Some(name) = input.head_author_name {
+        if is_forbidden_git_identity(name) {
+            failures.push(format!("HEAD author name is a test identity: {name}"));
+        }
+    }
+    if let Some(email) = input.head_author_email {
+        if is_forbidden_git_identity(email) {
+            failures.push(format!("HEAD author email is a test identity: {email}"));
+        }
+    }
+    if let Some(name) = input.head_committer_name {
+        if is_forbidden_git_identity(name) {
+            failures.push(format!("HEAD committer name is a test identity: {name}"));
+        }
+    }
+    if let Some(email) = input.head_committer_email {
+        if is_forbidden_git_identity(email) {
+            failures.push(format!("HEAD committer email is a test identity: {email}"));
+        }
+    }
+    failures
+}
+
+fn is_forbidden_git_identity(value: &str) -> bool {
+    FORBIDDEN_GIT_IDENTITIES.contains(&value)
+}
+
+fn git_local_config_value(key: &str) -> Result<Option<String>, Error> {
+    let label = command_label("git", &["config", "--local", "--get", key]);
+    let output = Command::new("git")
+        .args(["config", "--local", "--get", key])
+        .output()
+        .map_err(|source| Error::Usage(format!("failed to spawn `{label}`: {source}")))?;
+
+    if output.status.success() {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok((!value.is_empty()).then_some(value))
+    } else if output.status.code() == Some(1) {
+        Ok(None)
+    } else {
+        Err(Error::CommandFailed {
+            command: label,
+            code: output.status.code().unwrap_or(EXIT_FAILURE as i32),
+        })
+    }
+}
+
+fn git_head_identity() -> Result<HeadGitIdentity, Error> {
+    let label = command_label(
+        "git",
+        &["log", "-1", "--format=%an%x00%ae%x00%cn%x00%ce", "HEAD"],
+    );
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=%an%x00%ae%x00%cn%x00%ce", "HEAD"])
+        .output()
+        .map_err(|source| Error::Usage(format!("failed to spawn `{label}`: {source}")))?;
+
+    if !output.status.success() {
+        if output.status.code() == Some(128) {
+            return Ok(HeadGitIdentity::default());
+        }
+        return Err(Error::CommandFailed {
+            command: label,
+            code: output.status.code().unwrap_or(EXIT_FAILURE as i32),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parts = stdout
+        .trim_end_matches('\n')
+        .split('\0')
+        .collect::<Vec<_>>();
+    Ok(HeadGitIdentity {
+        author_name: parts.first().and_then(|value| non_empty_string(value)),
+        author_email: parts.get(1).and_then(|value| non_empty_string(value)),
+        committer_name: parts.get(2).and_then(|value| non_empty_string(value)),
+        committer_email: parts.get(3).and_then(|value| non_empty_string(value)),
+    })
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 fn check_release_tag_points_to_head(tag: &str) -> Result<(), Error> {
@@ -1454,6 +1596,70 @@ mod tests {
     fn semver_rejects_leading_zeroes_and_empty_prereleases() {
         assert!(version_from_tag("v01.2.3").is_err());
         assert!(version_from_tag("v1.2.3-").is_err());
+    }
+
+    #[test]
+    fn git_identity_guard_accepts_unset_or_collaborator_identities() {
+        assert!(git_identity_failures(GitIdentityInput::default()).is_empty());
+        assert!(git_identity_failures(GitIdentityInput {
+            local_name: Some("Example Contributor"),
+            local_email: Some("contributor@company.dev"),
+            head_author_name: Some("Another Contributor"),
+            head_author_email: Some("another@company.dev"),
+            head_committer_name: Some("Release Operator"),
+            head_committer_email: Some("release@company.dev"),
+        })
+        .is_empty());
+    }
+
+    #[test]
+    fn git_identity_guard_rejects_known_fixture_identities() {
+        assert_eq!(
+            git_identity_failures(GitIdentityInput {
+                local_name: Some("Wesley Tests"),
+                local_email: Some("contributor@company.dev"),
+                ..GitIdentityInput::default()
+            }),
+            vec!["local git user.name is a test identity: Wesley Tests"]
+        );
+        assert_eq!(
+            git_identity_failures(GitIdentityInput {
+                local_name: Some("Example Contributor"),
+                local_email: Some("wesley-tests@example.com"),
+                ..GitIdentityInput::default()
+            }),
+            vec!["local git user.email is a test identity: wesley-tests@example.com"]
+        );
+        assert_eq!(
+            git_identity_failures(GitIdentityInput {
+                local_name: Some("CI Test"),
+                local_email: Some("test@ci.com"),
+                ..GitIdentityInput::default()
+            }),
+            vec![
+                "local git user.name is a test identity: CI Test",
+                "local git user.email is a test identity: test@ci.com"
+            ]
+        );
+    }
+
+    #[test]
+    fn git_identity_guard_rejects_fixture_identities_on_head_commits() {
+        assert_eq!(
+            git_identity_failures(GitIdentityInput {
+                head_author_name: Some("Wesley Tests"),
+                head_author_email: Some("wesley-tests@example.com"),
+                head_committer_name: Some("CI Test"),
+                head_committer_email: Some("test@ci.com"),
+                ..GitIdentityInput::default()
+            }),
+            vec![
+                "HEAD author name is a test identity: Wesley Tests",
+                "HEAD author email is a test identity: wesley-tests@example.com",
+                "HEAD committer name is a test identity: CI Test",
+                "HEAD committer email is a test identity: test@ci.com"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prepare the Wesley v0.0.1 crates.io release notes and extension docs
- recreate the release-prep commit with a verified signed identity
- add collaborator-neutral git identity guards to Node preflight and Rust xtask release guards

## Validation
- node --test scripts/check-git-identity.test.mjs
- node scripts/check-git-identity.mjs
- cargo test -p xtask
- cargo xtask release-prep-guard --version 0.0.1
- cargo xtask preflight
- pnpm run preflight
- git verify-commit HEAD
- git verify-commit HEAD~1

## Notes
- replaces the rejected local release commit d852a5e, which was signed but authored/committed with a fixture identity from repo-local git config
- no force push, amend, or rebase was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Published v0.0.1 release notes with details on new components and alpha CLI capabilities
* Introduced comprehensive Rust-first extension guides covering extension boundaries, design patterns, and implementation checklist
* Added new "Extending Wesley" documentation section with multiple navigation entry points and reference material
* Reframed generator plugins documentation to guide users toward Rust-native extension approach

## Chores
* Integrated release process validations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->