### PR TITLE
chore(release): v0.0.2

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -137,12 +137,13 @@ jobs:
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
+          notes_file="${RUNNER_TEMP}/release-notes.md"
           awk -v version="$version" '
             $0 ~ "^## \\[v?" version "\\]" { in_section=1; print; next }
             in_section && $0 ~ "^## \\[" { exit }
             in_section { print }
-          ' CHANGELOG.md > release-notes.md
-          if [ ! -s release-notes.md ]; then
+          ' CHANGELOG.md > "$notes_file"
+          if [ ! -s "$notes_file" ]; then
             echo "No CHANGELOG.md section found for ${version}"
             exit 1
           fi
@@ -152,14 +153,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft > release-draft-state.txt 2>/dev/null; then
-            if [ "$(cat release-draft-state.txt)" != "true" ]; then
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+          draft_state_file="${RUNNER_TEMP}/release-draft-state.txt"
+          if gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft > "$draft_state_file" 2>/dev/null; then
+            if [ "$(cat "$draft_state_file")" != "true" ]; then
               echo "Release ${GITHUB_REF_NAME} already exists and is not a draft"
               exit 1
             fi
-            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md --draft --verify-tag
+            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file "$notes_file" --draft --verify-tag
           else
-            gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME" --notes-file release-notes.md --verify-tag
+            gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME" --notes-file "$notes_file" --verify-tag
           fi
 
       - name: Publish crates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.0.2] - 2026-05-09
+
+### Fixed
+
+- **Crates.io release clean-worktree recovery**: The release workflow now keeps
+  GitHub Release scratch files in the runner temp directory so draft release
+  preparation no longer dirties the checkout before `cargo xtask
+  publish-crates` enforces the real-publish clean-worktree guard.
+
 ## [0.0.1] - 2026-05-09
 
 ### Added
@@ -812,5 +821,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.1.0] - 2025-09-01
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.1...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/flyingrobots/wesley/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/flyingrobots/wesley/releases/tag/v0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "pretty_assertions",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -76,17 +76,19 @@ cargo wesley emit typescript --schema test/fixtures/consumer-models/jedit-hot-te
 
 Echo-owned tooling owns Echo-specific footprint honesty checks.
 
-## What's New in v0.0.1
+## What's New in v0.0.2
 
-Wesley's first Rust-native alpha publishes the core compiler path to crates.io:
-`wesley-core`, `wesley-emit-rust`, `wesley-emit-typescript`, and `wesley-cli`.
-The installable crate is `wesley-cli`, which provides the `wesley` binary.
+Wesley's `0.0.2` alpha hardens the Rust-native crates.io release path. The
+GitHub Actions release workflow now keeps temporary GitHub Release notes and
+draft-state files outside the repository checkout, so the real-publish
+clean-worktree guard can run immediately before registry mutation.
 
-This release centers the Rust front door. It lowers GraphQL SDL to domain-empty
-L1 IR, hashes schemas, diffs schema structure, lists schema root operations,
-emits Rust and TypeScript model/operation bindings, resolves operation
-selection paths, and extracts operation directive arguments without requiring an
-npm entry point. See [CHANGELOG.md](./CHANGELOG.md) for the full release notes.
+The native alpha line still centers the Rust front door: it lowers GraphQL SDL
+to domain-empty L1 IR, hashes schemas, diffs schema structure, lists schema root
+operations, emits Rust and TypeScript model/operation bindings, resolves
+operation selection paths, and extracts operation directive arguments without
+requiring an npm entry point. See [CHANGELOG.md](./CHANGELOG.md) for the full
+release notes.
 
 ## Rust-Native Front Door
 
@@ -124,7 +126,7 @@ The practical extension guide is [docs/guides/extending.md](./docs/guides/extend
 
 Install the published alpha native binary from crates.io.
 ```bash
-cargo install wesley-cli --version 0.0.1
+cargo install wesley-cli --version 0.0.2
 wesley --help
 ```
 

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.1" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.1" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.1" }
+wesley-core = { path = "../wesley-core", version = "0.0.2" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.2" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.2" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "AST-based Rust emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.1" }
+wesley-core = { path = "../wesley-core", version = "0.0.2" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "AST-based TypeScript emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.1" }
+wesley-core = { path = "../wesley-core", version = "0.0.2" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -52,7 +52,7 @@ timeline
   moving away from npm scripts. Native preflight now includes Rust docs checks,
   Rust tests, and native CLI help.
 - Keeping native install/release checks on the Cargo path with
-  `cargo install wesley-cli --version 0.0.1`,
+  `cargo install wesley-cli --version 0.0.2`,
   `cargo install --locked --path crates/wesley-cli`, and
   `cargo xtask release-check`.
 - Treating `pnpm wesley` as legacy package tooling until its remaining useful

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -11,7 +11,7 @@ For installed alpha builds, the crates.io package is `wesley-cli` and the
 installed command is `wesley`:
 
 ```bash
-cargo install wesley-cli --version 0.0.1
+cargo install wesley-cli --version 0.0.2
 wesley --help
 ```
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -12,7 +12,7 @@ If you need the main Wesley nouns and the layer split before reading anything el
 Compile authored GraphQL into generic or explicitly selected generated
 artifacts.
 - **Inspect native CLI**: `cargo wesley --help`
-- **Install alpha from crates.io**: `cargo install wesley-cli --version 0.0.1`
+- **Install alpha from crates.io**: `cargo install wesley-cli --version 0.0.2`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Rust preflight**: `cargo xtask preflight`
 - **Release check**: `cargo xtask release-check`
@@ -23,7 +23,7 @@ native binary stays small while core behavior moves into the Rust library.
 selection paths and extracting directive arguments; Echo-owned tooling owns
 Echo-specific footprint honesty checks.
 
-Use `cargo install wesley-cli --version 0.0.1` when you want the published
+Use `cargo install wesley-cli --version 0.0.2` when you want the published
 alpha `wesley` binary on your PATH. Use
 `cargo install --locked --path crates/wesley-cli` when working from this
 checkout. Use `cargo xtask release-check` before cutting native release

--- a/test/ci-workflows.bats
+++ b/test/ci-workflows.bats
@@ -164,6 +164,24 @@ load 'bats-plugins/bats-assert/load'
   [ "$verify_line" -lt "$finalize_line" ]
 }
 
+@test "release crates workflow keeps release scratch files outside repository" {
+  run bash -lc "grep -F '\${RUNNER_TEMP}/release-notes.md' .github/workflows/release-crates.yml | wc -l"
+  assert_success
+  [ "$output" -ge 2 ]
+
+  run bash -lc "grep -F '\${RUNNER_TEMP}/release-draft-state.txt' .github/workflows/release-crates.yml | wc -l"
+  assert_success
+  [ "$output" -ge 1 ]
+
+  run bash -lc "grep -F 'release-notes.md' .github/workflows/release-crates.yml | grep -v '\${RUNNER_TEMP}'"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+
+  run bash -lc "grep -F 'release-draft-state.txt' .github/workflows/release-crates.yml | grep -v '\${RUNNER_TEMP}'"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
 @test "release crates workflow checks version milestones and labels" {
   run bash -lc "grep -F -- '--milestone' .github/workflows/release-crates.yml | wc -l"
   assert_success


### PR DESCRIPTION
## Summary

- Bump Wesley Rust crates and install docs to 0.0.2.
- Keep release workflow scratch files under `$RUNNER_TEMP` so the crates.io publish guard sees a clean worktree.
- Add a Bats regression check for release scratch-file placement.

## Validation

- `cargo check --workspace --all-targets`
- `bats test/ci-workflows.bats`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo xtask release-prep-guard --version 0.0.2`
- `cargo xtask package-crates --tag v0.0.2`
- `cargo xtask preflight`
- `pnpm run preflight`
- pre-push repo preflight and Bats smoke suite

Note: `cargo xtask publish-crates --tag v0.0.2` was also run locally and intentionally reported dependent dry-runs as incomplete because internal 0.0.2 crates are not indexed yet; the GitHub Actions publish path publishes and waits in dependency order.