### PR TITLE
test(stack): add Stack Witness 0001 fixture artifact shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **Stack Witness 0001 fixture artifact shape**: Added a hermetic
+  jedit-through-Echo file-history fixture with operation ids, canonical vars
+  bytes, declared footprints, EINT and QueryView helper shapes, fixture vectors,
+  and Rust/TypeScript operation binding coverage.
+
 ## [0.0.2] - 2026-05-09
 
 ### Fixed

--- a/crates/wesley-core/tests/operation_analysis.rs
+++ b/crates/wesley-core/tests/operation_analysis.rs
@@ -303,6 +303,142 @@ fn lists_jedit_hot_text_runtime_schema_operations() {
 }
 
 #[test]
+fn lists_stack_witness_0001_fixture_artifact_shape() {
+    let operations = list_schema_operations_sdl(include_str!(
+        "../../../test/fixtures/consumer-models/stack-witness-0001-file-history.graphql"
+    ))
+    .expect("stack witness fixture operations should resolve");
+    let vectors: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../test/fixtures/consumer-models/stack-witness-0001-vectors.json"
+    ))
+    .expect("stack witness fixture vectors should parse");
+
+    assert_eq!(operations.len(), 3);
+    assert_eq!(
+        vectors["artifact"]["artifactId"],
+        serde_json::json!("fixture-file-history-v0")
+    );
+    assert_eq!(
+        vectors["artifact"]["schemaId"],
+        serde_json::json!("stack-witness-0001.file-history.v0")
+    );
+
+    let create_buffer = operations
+        .iter()
+        .find(|operation| operation.field_name == "createBuffer")
+        .expect("createBuffer mutation should exist");
+    let create_buffer_vector = vector_for(&vectors, "createBuffer");
+    assert_eq!(create_buffer.operation_type, OperationType::Mutation);
+    assert_eq!(create_buffer.arguments[0].r#type.base, "CreateBufferInput");
+    assert_eq!(create_buffer.result_type.base, "MutationReceipt");
+    assert_eq!(
+        create_buffer.directives["wes_artifact"]["artifactId"],
+        vectors["artifact"]["artifactId"]
+    );
+    assert_eq!(
+        create_buffer.directives["wes_stack_witness"]["opId"],
+        create_buffer_vector["opIdHex"]
+    );
+    assert_eq!(
+        create_buffer_vector["opIdDecimal"],
+        serde_json::json!(1398210561)
+    );
+    assert_eq!(
+        create_buffer.directives["wes_stack_witness"]["helperKind"],
+        serde_json::json!("EINT")
+    );
+    assert_eq!(
+        create_buffer_vector["helperShape"]["entrypoint"],
+        serde_json::json!("dispatch_intent")
+    );
+    assert_eq!(
+        create_buffer.directives["wes_stack_witness"]["canonicalVarsBytes"],
+        create_buffer_vector["canonicalVarsBytes"]
+    );
+    assert_eq!(
+        create_buffer.directives["wes_footprint"]["creates"],
+        create_buffer_vector["declaredFootprint"]["creates"]
+    );
+
+    let replace_range = operations
+        .iter()
+        .find(|operation| operation.field_name == "replaceRange")
+        .expect("replaceRange mutation should exist");
+    let replace_range_vector = vector_for(&vectors, "replaceRange");
+    assert_eq!(replace_range.operation_type, OperationType::Mutation);
+    assert_eq!(replace_range.arguments[0].r#type.base, "ReplaceRangeInput");
+    assert_eq!(
+        replace_range.directives["wes_stack_witness"]["opId"],
+        replace_range_vector["opIdHex"]
+    );
+    assert_eq!(
+        replace_range_vector["opIdDecimal"],
+        serde_json::json!(1398210562)
+    );
+    assert_eq!(
+        replace_range.directives["wes_stack_witness"]["canonicalVarsBytes"],
+        replace_range_vector["canonicalVarsBytes"]
+    );
+    assert_eq!(
+        replace_range.directives["wes_stack_witness"]["canonicalVarsBytes"],
+        serde_json::json!(
+            "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
+        )
+    );
+    assert_eq!(
+        replace_range.directives["wes_footprint"]["reads"],
+        replace_range_vector["declaredFootprint"]["reads"]
+    );
+    assert_eq!(
+        replace_range.directives["wes_footprint"]["writes"],
+        replace_range_vector["declaredFootprint"]["writes"]
+    );
+
+    let text_window = operations
+        .iter()
+        .find(|operation| operation.field_name == "textWindow")
+        .expect("textWindow query should exist");
+    let text_window_vector = vector_for(&vectors, "textWindow");
+    assert_eq!(text_window.operation_type, OperationType::Query);
+    assert_eq!(text_window.arguments[0].r#type.base, "TextWindowInput");
+    assert_eq!(text_window.result_type.base, "TextWindowReading");
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["opId"],
+        text_window_vector["opIdHex"]
+    );
+    assert_eq!(
+        text_window_vector["opIdDecimal"],
+        serde_json::json!(1398214657)
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["helperKind"],
+        serde_json::json!("QueryView")
+    );
+    assert_eq!(
+        text_window_vector["helperShape"]["entrypoint"],
+        serde_json::json!("observe")
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["canonicalVarsBytes"],
+        serde_json::json!(
+            "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
+        )
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["payloadCodec"],
+        serde_json::json!("QueryBytes")
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["envelope"],
+        serde_json::json!("ReadingEnvelope")
+    );
+    assert_eq!(
+        text_window.directives["wes_footprint"]["reads"],
+        text_window_vector["declaredFootprint"]["reads"]
+    );
+}
+
+#[test]
 fn extracts_wes_footprint_directive_args_as_generic_directive_data() {
     let directives = extract_operation_directive_args(
         r#"
@@ -479,4 +615,13 @@ fn rejects_invalid_operation_syntax() {
     let error = resolve_operation_selections("mutation {").expect_err("invalid syntax should fail");
 
     assert!(matches!(error, WesleyError::ParseError { .. }));
+}
+
+fn vector_for<'a>(vectors: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {
+    vectors["operations"]
+        .as_array()
+        .expect("fixture operations should be an array")
+        .iter()
+        .find(|operation| operation["name"].as_str() == Some(name))
+        .expect("fixture operation vector should exist")
 }

--- a/crates/wesley-core/tests/operation_analysis.rs
+++ b/crates/wesley-core/tests/operation_analysis.rs
@@ -322,6 +322,15 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
         vectors["artifact"]["schemaId"],
         serde_json::json!("stack-witness-0001.file-history.v0")
     );
+    assert_eq!(
+        vectors["artifact"]["familyId"],
+        serde_json::json!("stack-witness-0001.file-history")
+    );
+    assert_eq!(vectors["artifact"]["version"], serde_json::json!("0"));
+    assert_eq!(
+        vectors["canonicalVarsEncoding"],
+        serde_json::json!("utf8-semicolon-kv/v0")
+    );
 
     let create_buffer = operations
         .iter()
@@ -335,17 +344,23 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
         create_buffer.directives["wes_artifact"]["artifactId"],
         vectors["artifact"]["artifactId"]
     );
+    assert_artifact_identity_matches_vector(create_buffer, &vectors);
     assert_eq!(
         create_buffer.directives["wes_stack_witness"]["opId"],
         create_buffer_vector["opIdHex"]
     );
+    assert_op_id_forms_agree(create_buffer_vector, STACK_WITNESS_CREATE_BUFFER_OP_ID);
     assert_eq!(
         create_buffer_vector["opIdDecimal"],
-        serde_json::json!(1398210561)
+        serde_json::json!(STACK_WITNESS_CREATE_BUFFER_OP_ID)
     );
     assert_eq!(
         create_buffer.directives["wes_stack_witness"]["helperKind"],
         serde_json::json!("EINT")
+    );
+    assert_eq!(
+        create_buffer.directives["wes_stack_witness"]["canonicalVarsEncoding"],
+        vectors["canonicalVarsEncoding"]
     );
     assert_eq!(
         create_buffer_vector["helperShape"]["entrypoint"],
@@ -359,6 +374,22 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
         create_buffer.directives["wes_footprint"]["creates"],
         create_buffer_vector["declaredFootprint"]["creates"]
     );
+    assert_declared_footprint_matches_vector(create_buffer, create_buffer_vector);
+    assert_helper_shape(
+        create_buffer_vector,
+        "EINT",
+        "dispatch_intent",
+        &[
+            "contract_artifact_id",
+            "operation_id",
+            "canonical_vars_bytes",
+            "declared_footprint",
+        ],
+    );
+    assert_eq!(
+        create_buffer.directives["wes_stack_witness"]["fixtureVector"],
+        serde_json::json!("stack-witness-0001-vectors.json#createBuffer")
+    );
 
     let replace_range = operations
         .iter()
@@ -371,9 +402,15 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
         replace_range.directives["wes_stack_witness"]["opId"],
         replace_range_vector["opIdHex"]
     );
+    assert_artifact_identity_matches_vector(replace_range, &vectors);
+    assert_op_id_forms_agree(replace_range_vector, STACK_WITNESS_REPLACE_RANGE_OP_ID);
     assert_eq!(
         replace_range_vector["opIdDecimal"],
-        serde_json::json!(1398210562)
+        serde_json::json!(STACK_WITNESS_REPLACE_RANGE_OP_ID)
+    );
+    assert_eq!(
+        replace_range.directives["wes_stack_witness"]["canonicalVarsEncoding"],
+        vectors["canonicalVarsEncoding"]
     );
     assert_eq!(
         replace_range.directives["wes_stack_witness"]["canonicalVarsBytes"],
@@ -382,7 +419,7 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
     assert_eq!(
         replace_range.directives["wes_stack_witness"]["canonicalVarsBytes"],
         serde_json::json!(
-            "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
+            "stack-witness-0001/replaceRange;bufferId=demo.txt;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
         )
     );
     assert_eq!(
@@ -392,6 +429,22 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
     assert_eq!(
         replace_range.directives["wes_footprint"]["writes"],
         replace_range_vector["declaredFootprint"]["writes"]
+    );
+    assert_declared_footprint_matches_vector(replace_range, replace_range_vector);
+    assert_helper_shape(
+        replace_range_vector,
+        "EINT",
+        "dispatch_intent",
+        &[
+            "contract_artifact_id",
+            "operation_id",
+            "canonical_vars_bytes",
+            "declared_footprint",
+        ],
+    );
+    assert_eq!(
+        replace_range.directives["wes_stack_witness"]["fixtureVector"],
+        serde_json::json!("stack-witness-0001-vectors.json#replaceRange")
     );
 
     let text_window = operations
@@ -406,13 +459,19 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
         text_window.directives["wes_stack_witness"]["opId"],
         text_window_vector["opIdHex"]
     );
+    assert_artifact_identity_matches_vector(text_window, &vectors);
+    assert_op_id_forms_agree(text_window_vector, STACK_WITNESS_TEXT_WINDOW_QUERY_ID);
     assert_eq!(
         text_window_vector["opIdDecimal"],
-        serde_json::json!(1398214657)
+        serde_json::json!(STACK_WITNESS_TEXT_WINDOW_QUERY_ID)
     );
     assert_eq!(
         text_window.directives["wes_stack_witness"]["helperKind"],
         serde_json::json!("QueryView")
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["canonicalVarsEncoding"],
+        vectors["canonicalVarsEncoding"]
     );
     assert_eq!(
         text_window_vector["helperShape"]["entrypoint"],
@@ -421,7 +480,7 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
     assert_eq!(
         text_window.directives["wes_stack_witness"]["canonicalVarsBytes"],
         serde_json::json!(
-            "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
+            "stack-witness-0001/textWindow;bufferId=demo.txt;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
         )
     );
     assert_eq!(
@@ -435,6 +494,27 @@ fn lists_stack_witness_0001_fixture_artifact_shape() {
     assert_eq!(
         text_window.directives["wes_footprint"]["reads"],
         text_window_vector["declaredFootprint"]["reads"]
+    );
+    assert_declared_footprint_matches_vector(text_window, text_window_vector);
+    assert_helper_shape(
+        text_window_vector,
+        "QueryView",
+        "observe",
+        &[
+            "contract_artifact_id",
+            "query_id",
+            "canonical_vars_bytes",
+            "reading_envelope",
+            "query_bytes",
+        ],
+    );
+    assert_eq!(
+        text_window.directives["wes_stack_witness"]["fixtureVector"],
+        serde_json::json!("stack-witness-0001-vectors.json#textWindow")
+    );
+    assert_eq!(
+        text_window_vector["expectedQueryBytesHex"],
+        serde_json::json!("68656c6c6f")
     );
 }
 
@@ -624,4 +704,63 @@ fn vector_for<'a>(vectors: &'a serde_json::Value, name: &str) -> &'a serde_json:
         .iter()
         .find(|operation| operation["name"].as_str() == Some(name))
         .expect("fixture operation vector should exist")
+}
+
+const STACK_WITNESS_CREATE_BUFFER_OP_ID: u32 = 0x5357_0001;
+const STACK_WITNESS_REPLACE_RANGE_OP_ID: u32 = 0x5357_0002;
+const STACK_WITNESS_TEXT_WINDOW_QUERY_ID: u32 = 0x5357_1001;
+
+fn assert_artifact_identity_matches_vector(
+    operation: &wesley_core::SchemaOperation,
+    vectors: &serde_json::Value,
+) {
+    let artifact = &operation.directives["wes_artifact"];
+    assert_eq!(artifact["familyId"], vectors["artifact"]["familyId"]);
+    assert_eq!(artifact["schemaId"], vectors["artifact"]["schemaId"]);
+    assert_eq!(artifact["artifactId"], vectors["artifact"]["artifactId"]);
+    assert_eq!(artifact["version"], vectors["artifact"]["version"]);
+}
+
+fn assert_declared_footprint_matches_vector(
+    operation: &wesley_core::SchemaOperation,
+    vector: &serde_json::Value,
+) {
+    let footprint = &operation.directives["wes_footprint"];
+    assert_eq!(footprint["reads"], vector["declaredFootprint"]["reads"]);
+    assert_eq!(footprint["writes"], vector["declaredFootprint"]["writes"]);
+    assert_eq!(footprint["creates"], vector["declaredFootprint"]["creates"]);
+    assert_eq!(footprint["forbids"], vector["declaredFootprint"]["forbids"]);
+}
+
+fn assert_helper_shape(
+    vector: &serde_json::Value,
+    frame: &str,
+    entrypoint: &str,
+    fields: &[&str],
+) {
+    assert_eq!(vector["helperShape"]["frame"], serde_json::json!(frame));
+    assert_eq!(
+        vector["helperShape"]["entrypoint"],
+        serde_json::json!(entrypoint)
+    );
+    assert_eq!(
+        vector["helperShape"]["fields"],
+        serde_json::Value::Array(
+            fields
+                .iter()
+                .map(|field| serde_json::json!(field))
+                .collect()
+        )
+    );
+}
+
+fn assert_op_id_forms_agree(vector: &serde_json::Value, expected: u32) {
+    let hex = vector["opIdHex"]
+        .as_str()
+        .expect("opIdHex should be a string")
+        .strip_prefix("0x")
+        .expect("opIdHex should use 0x prefix");
+    let parsed = u32::from_str_radix(hex, 16).expect("opIdHex should parse as u32");
+    assert_eq!(parsed, expected);
+    assert_eq!(vector["opIdDecimal"], serde_json::json!(parsed));
 }

--- a/crates/wesley-emit-rust/src/lib.rs
+++ b/crates/wesley-emit-rust/src/lib.rs
@@ -736,6 +736,41 @@ pub struct UserFilter {
     }
 
     #[test]
+    fn emits_stack_witness_0001_fixture_operation_bindings() {
+        let sdl = include_str!(
+            "../../../test/fixtures/consumer-models/stack-witness-0001-file-history.graphql"
+        );
+        let ir = lower_schema_sdl(sdl).expect("stack witness fixture should lower");
+        let operations =
+            list_schema_operations_sdl(sdl).expect("stack witness operations should resolve");
+
+        let actual = emit_rust_with_operations(&ir, &operations);
+
+        syn::parse_file(&actual).expect("generated Rust should parse");
+        assert!(actual.contains("pub struct MutationCreateBufferRequest {"));
+        assert!(actual.contains("pub input: CreateBufferInput,"));
+        assert!(actual.contains("pub type MutationCreateBufferResponse = MutationReceipt;"));
+        assert!(actual.contains("pub struct MutationReplaceRangeRequest {"));
+        assert!(actual.contains("pub type MutationReplaceRangeResponse = MutationReceipt;"));
+        assert!(actual.contains("pub struct QueryTextWindowRequest {"));
+        assert!(actual.contains("pub type QueryTextWindowResponse = TextWindowReading;"));
+        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"createBuffer\";"));
+        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"replaceRange\";"));
+        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"textWindow\";"));
+        assert!(actual.contains("\\\"artifactId\\\":\\\"fixture-file-history-v0\\\""));
+        assert!(actual.contains("\\\"opId\\\":\\\"0x53570001\\\""));
+        assert!(actual.contains("\\\"opId\\\":\\\"0x53570002\\\""));
+        assert!(actual.contains("\\\"opId\\\":\\\"0x53571001\\\""));
+        assert!(actual.contains("\\\"helperKind\\\":\\\"EINT\\\""));
+        assert!(actual.contains("\\\"helperKind\\\":\\\"QueryView\\\""));
+        assert!(actual.contains(
+            "\\\"canonicalVarsBytes\\\":\\\"stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\\\""
+        ));
+        assert!(actual.contains("\\\"payloadCodec\\\":\\\"QueryBytes\\\""));
+        assert!(actual.contains("\\\"envelope\\\":\\\"ReadingEnvelope\\\""));
+    }
+
+    #[test]
     fn operation_bindings_include_operation_scope_in_type_names() {
         let sdl = r#"
             type Query {

--- a/crates/wesley-emit-rust/src/lib.rs
+++ b/crates/wesley-emit-rust/src/lib.rs
@@ -754,20 +754,38 @@ pub struct UserFilter {
         assert!(actual.contains("pub type MutationReplaceRangeResponse = MutationReceipt;"));
         assert!(actual.contains("pub struct QueryTextWindowRequest {"));
         assert!(actual.contains("pub type QueryTextWindowResponse = TextWindowReading;"));
-        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"createBuffer\";"));
-        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"replaceRange\";"));
-        assert!(actual.contains("pub const FIELD_NAME: &'static str = \"textWindow\";"));
-        assert!(actual.contains("\\\"artifactId\\\":\\\"fixture-file-history-v0\\\""));
-        assert!(actual.contains("\\\"opId\\\":\\\"0x53570001\\\""));
-        assert!(actual.contains("\\\"opId\\\":\\\"0x53570002\\\""));
-        assert!(actual.contains("\\\"opId\\\":\\\"0x53571001\\\""));
-        assert!(actual.contains("\\\"helperKind\\\":\\\"EINT\\\""));
-        assert!(actual.contains("\\\"helperKind\\\":\\\"QueryView\\\""));
-        assert!(actual.contains(
-            "\\\"canonicalVarsBytes\\\":\\\"stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\\\""
+        assert!(actual.contains("pub data_base64: String,"));
+
+        let create_buffer =
+            rust_operation_impl_block(&actual, "MutationCreateBufferRequest");
+        assert!(create_buffer.contains("pub const FIELD_NAME: &'static str = \"createBuffer\";"));
+        assert!(create_buffer.contains("\\\"artifactId\\\":\\\"fixture-file-history-v0\\\""));
+        assert!(create_buffer.contains("\\\"opId\\\":\\\"0x53570001\\\""));
+        assert!(create_buffer.contains("\\\"helperKind\\\":\\\"EINT\\\""));
+        assert!(create_buffer.contains(
+            "\\\"canonicalVarsBytes\\\":\\\"stack-witness-0001/createBuffer;name=demo.txt;artifact=fixture-file-history-v0\\\""
         ));
-        assert!(actual.contains("\\\"payloadCodec\\\":\\\"QueryBytes\\\""));
-        assert!(actual.contains("\\\"envelope\\\":\\\"ReadingEnvelope\\\""));
+
+        let replace_range =
+            rust_operation_impl_block(&actual, "MutationReplaceRangeRequest");
+        assert!(replace_range.contains("pub const FIELD_NAME: &'static str = \"replaceRange\";"));
+        assert!(replace_range.contains("\\\"artifactId\\\":\\\"fixture-file-history-v0\\\""));
+        assert!(replace_range.contains("\\\"opId\\\":\\\"0x53570002\\\""));
+        assert!(replace_range.contains("\\\"helperKind\\\":\\\"EINT\\\""));
+        assert!(replace_range.contains(
+            "\\\"canonicalVarsBytes\\\":\\\"stack-witness-0001/replaceRange;bufferId=demo.txt;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0\\\""
+        ));
+
+        let text_window = rust_operation_impl_block(&actual, "QueryTextWindowRequest");
+        assert!(text_window.contains("pub const FIELD_NAME: &'static str = \"textWindow\";"));
+        assert!(text_window.contains("\\\"artifactId\\\":\\\"fixture-file-history-v0\\\""));
+        assert!(text_window.contains("\\\"opId\\\":\\\"0x53571001\\\""));
+        assert!(text_window.contains("\\\"helperKind\\\":\\\"QueryView\\\""));
+        assert!(text_window.contains(
+            "\\\"canonicalVarsBytes\\\":\\\"stack-witness-0001/textWindow;bufferId=demo.txt;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\\\""
+        ));
+        assert!(text_window.contains("\\\"payloadCodec\\\":\\\"QueryBytes\\\""));
+        assert!(text_window.contains("\\\"envelope\\\":\\\"ReadingEnvelope\\\""));
     }
 
     #[test]
@@ -826,5 +844,18 @@ pub struct UserFilter {
         assert!(actual.contains(
             "#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]\npub enum SearchResult"
         ));
+    }
+
+    fn rust_operation_impl_block<'a>(actual: &'a str, request_name: &str) -> &'a str {
+        let marker = format!("impl {request_name} {{");
+        let start = actual
+            .find(&marker)
+            .expect("operation impl block should exist");
+        let tail = &actual[start..];
+        let end = tail
+            .find("\n}\n")
+            .expect("operation impl block should close")
+            + "\n}\n".len();
+        &tail[..end]
     }
 }

--- a/crates/wesley-emit-typescript/src/lib.rs
+++ b/crates/wesley-emit-typescript/src/lib.rs
@@ -753,6 +753,45 @@ export interface UserFilter {
     }
 
     #[test]
+    fn emits_stack_witness_0001_fixture_operation_bindings() {
+        let sdl = include_str!(
+            "../../../test/fixtures/consumer-models/stack-witness-0001-file-history.graphql"
+        );
+        let ir = lower_schema_sdl(sdl).expect("stack witness fixture should lower");
+        let operations =
+            list_schema_operations_sdl(sdl).expect("stack witness operations should resolve");
+
+        let actual = emit_typescript_with_operations(&ir, &operations);
+
+        assert!(actual.contains("export interface MutationCreateBufferRequest {"));
+        assert!(actual.contains("  input: CreateBufferInput;"));
+        assert!(actual.contains("export type MutationCreateBufferResponse = MutationReceipt;"));
+        assert!(actual.contains("export const mutationCreateBufferOperation = {"));
+        assert!(actual.contains("export interface MutationReplaceRangeRequest {"));
+        assert!(actual.contains("export type MutationReplaceRangeResponse = MutationReceipt;"));
+        assert!(actual.contains("export const mutationReplaceRangeOperation = {"));
+        assert!(actual.contains("export interface QueryTextWindowRequest {"));
+        assert!(actual.contains("export type QueryTextWindowResponse = TextWindowReading;"));
+        assert!(actual.contains("export const queryTextWindowOperation = {"));
+        assert!(actual.contains("  fieldName: \"createBuffer\","));
+        assert!(actual.contains("  fieldName: \"replaceRange\","));
+        assert!(actual.contains("  fieldName: \"textWindow\","));
+        assert!(actual.contains("\"artifactId\":\"fixture-file-history-v0\""));
+        assert!(actual.contains("\"opId\":\"0x53570001\""));
+        assert!(actual.contains("\"opId\":\"0x53570002\""));
+        assert!(actual.contains("\"opId\":\"0x53571001\""));
+        assert!(actual.contains("\"helperKind\":\"EINT\""));
+        assert!(actual.contains("\"helperKind\":\"QueryView\""));
+        assert!(actual.contains(
+            "\"canonicalVarsBytes\":\"stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\""
+        ));
+        assert!(actual.contains("\"payloadCodec\":\"QueryBytes\""));
+        assert!(actual.contains("\"envelope\":\"ReadingEnvelope\""));
+        assert!(actual.contains("export type QueryTextWindowOperation = {\n"));
+        assert!(actual.contains("  metadata: typeof queryTextWindowOperation;"));
+    }
+
+    #[test]
     fn operation_bindings_include_operation_scope_in_symbol_names() {
         let sdl = r#"
             type Query {

--- a/crates/wesley-emit-typescript/src/lib.rs
+++ b/crates/wesley-emit-typescript/src/lib.rs
@@ -773,20 +773,38 @@ export interface UserFilter {
         assert!(actual.contains("export interface QueryTextWindowRequest {"));
         assert!(actual.contains("export type QueryTextWindowResponse = TextWindowReading;"));
         assert!(actual.contains("export const queryTextWindowOperation = {"));
-        assert!(actual.contains("  fieldName: \"createBuffer\","));
-        assert!(actual.contains("  fieldName: \"replaceRange\","));
-        assert!(actual.contains("  fieldName: \"textWindow\","));
-        assert!(actual.contains("\"artifactId\":\"fixture-file-history-v0\""));
-        assert!(actual.contains("\"opId\":\"0x53570001\""));
-        assert!(actual.contains("\"opId\":\"0x53570002\""));
-        assert!(actual.contains("\"opId\":\"0x53571001\""));
-        assert!(actual.contains("\"helperKind\":\"EINT\""));
-        assert!(actual.contains("\"helperKind\":\"QueryView\""));
-        assert!(actual.contains(
-            "\"canonicalVarsBytes\":\"stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\""
+        assert!(actual.contains("dataBase64: string;"));
+
+        let create_buffer =
+            ts_operation_metadata_block(&actual, "mutationCreateBufferOperation");
+        assert!(create_buffer.contains("  fieldName: \"createBuffer\","));
+        assert!(create_buffer.contains("\"artifactId\":\"fixture-file-history-v0\""));
+        assert!(create_buffer.contains("\"opId\":\"0x53570001\""));
+        assert!(create_buffer.contains("\"helperKind\":\"EINT\""));
+        assert!(create_buffer.contains(
+            "\"canonicalVarsBytes\":\"stack-witness-0001/createBuffer;name=demo.txt;artifact=fixture-file-history-v0\""
         ));
-        assert!(actual.contains("\"payloadCodec\":\"QueryBytes\""));
-        assert!(actual.contains("\"envelope\":\"ReadingEnvelope\""));
+
+        let replace_range =
+            ts_operation_metadata_block(&actual, "mutationReplaceRangeOperation");
+        assert!(replace_range.contains("  fieldName: \"replaceRange\","));
+        assert!(replace_range.contains("\"artifactId\":\"fixture-file-history-v0\""));
+        assert!(replace_range.contains("\"opId\":\"0x53570002\""));
+        assert!(replace_range.contains("\"helperKind\":\"EINT\""));
+        assert!(replace_range.contains(
+            "\"canonicalVarsBytes\":\"stack-witness-0001/replaceRange;bufferId=demo.txt;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0\""
+        ));
+
+        let text_window = ts_operation_metadata_block(&actual, "queryTextWindowOperation");
+        assert!(text_window.contains("  fieldName: \"textWindow\","));
+        assert!(text_window.contains("\"artifactId\":\"fixture-file-history-v0\""));
+        assert!(text_window.contains("\"opId\":\"0x53571001\""));
+        assert!(text_window.contains("\"helperKind\":\"QueryView\""));
+        assert!(text_window.contains(
+            "\"canonicalVarsBytes\":\"stack-witness-0001/textWindow;bufferId=demo.txt;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0\""
+        ));
+        assert!(text_window.contains("\"payloadCodec\":\"QueryBytes\""));
+        assert!(text_window.contains("\"envelope\":\"ReadingEnvelope\""));
         assert!(actual.contains("export type QueryTextWindowOperation = {\n"));
         assert!(actual.contains("  metadata: typeof queryTextWindowOperation;"));
     }
@@ -825,5 +843,18 @@ export interface UserFilter {
         assert!(actual.contains("export const mutationStatusOperation = {"));
         assert!(actual.contains("export type MutationStatusOperation = {\n"));
         assert!(actual.contains("  metadata: typeof mutationStatusOperation;"));
+    }
+
+    fn ts_operation_metadata_block<'a>(actual: &'a str, const_name: &str) -> &'a str {
+        let marker = format!("export const {const_name} = {{");
+        let start = actual
+            .find(&marker)
+            .expect("operation metadata block should exist");
+        let tail = &actual[start..];
+        let end = tail
+            .find("} as const;")
+            .expect("operation metadata block should close")
+            + "} as const;".len();
+        &tail[..end]
     }
 }

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -7,6 +7,7 @@ Fixtures live here so tests, docs, and demos all reference the same canonical in
 | Directory | Purpose | Consumed By |
 | --- | --- | --- |
 | `examples/` | Canonical GraphQL schemas plus generated outputs for docs and HOLMES tests. | CLI bats (`holmes-e2e.bats`), documentation snippets. |
+| `consumer-models/` | Hermetic consumer-shaped GraphQL fixtures for jedit and Stack Witness 0001 contract-boundary tests. | Wesley core operation catalog tests, Rust emitter tests, TypeScript emitter tests. |
 | `blade/` | Daywalker Deploys demo assets (schemas, run script, signing key instructions). | Docs walkthrough, manual CLI demos. |
 | `reference/` | Comprehensive SDL showcasing most directives; useful for experiments. | Manual runs, future regression suites. |
 | `rls-schema.graphql` | Focused schema exercising RLS directives. | `cli-e2e.bats`, `cli-e2e-real.bats`. |

--- a/test/fixtures/consumer-models/stack-witness-0001-file-history.graphql
+++ b/test/fixtures/consumer-models/stack-witness-0001-file-history.graphql
@@ -46,7 +46,7 @@ type ReadingEnvelope {
 }
 
 type QueryBytes {
-  data: String!
+  dataBase64: String!
 }
 
 type TextWindowReading {
@@ -113,7 +113,7 @@ type Mutation {
       opId: "0x53570002"
       helperKind: "EINT"
       canonicalVarsEncoding: "utf8-semicolon-kv/v0"
-      canonicalVarsBytes: "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
+      canonicalVarsBytes: "stack-witness-0001/replaceRange;bufferId=demo.txt;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
       fixtureVector: "stack-witness-0001-vectors.json#replaceRange"
     )
     @wes_footprint(
@@ -150,7 +150,7 @@ type Query {
       opId: "0x53571001"
       helperKind: "QueryView"
       canonicalVarsEncoding: "utf8-semicolon-kv/v0"
-      canonicalVarsBytes: "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
+      canonicalVarsBytes: "stack-witness-0001/textWindow;bufferId=demo.txt;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
       payloadCodec: "QueryBytes"
       envelope: "ReadingEnvelope"
       fixtureVector: "stack-witness-0001-vectors.json#textWindow"

--- a/test/fixtures/consumer-models/stack-witness-0001-file-history.graphql
+++ b/test/fixtures/consumer-models/stack-witness-0001-file-history.graphql
@@ -1,0 +1,173 @@
+"""
+Stack Witness 0001 fixture artifact for the jedit-through-Echo file history
+walking skeleton.
+
+This fixture is intentionally small. It gives Wesley a hermetic contract shape
+that can replace Echo's hand-authored Stack Witness fixture constants without
+turning Wesley core into an Echo runtime or text editor host.
+"""
+enum TextCoordinateSystem {
+  UTF8_BYTES
+}
+
+type Buffer {
+  bufferId: ID!
+  name: String!
+  createdAtBasis: ID!
+}
+
+type MutationReceipt {
+  receiptId: ID!
+  basisRef: ID!
+  contractArtifactId: ID!
+  operationId: String!
+  canonicalVarsDigest: String!
+}
+
+type TextAperture {
+  coordinateSystem: TextCoordinateSystem!
+  start: Int!
+  length: Int!
+}
+
+type ReadingEnvelope {
+  readIdentity: ID!
+  basisRef: ID!
+  observerPlanId: ID!
+  contractArtifactId: ID!
+  canonicalVarsDigest: String!
+  aperture: TextAperture!
+  payloadDigest: String!
+  payloadCodec: String!
+  witnessPosture: String!
+  budgetPosture: String!
+  rightsPosture: String!
+  residualPosture: String!
+}
+
+type QueryBytes {
+  data: String!
+}
+
+type TextWindowReading {
+  envelope: ReadingEnvelope!
+  payload: QueryBytes!
+}
+
+input CreateBufferInput {
+  name: String!
+}
+
+input ReplaceRangeInput {
+  bufferId: ID!
+  basisRef: ID!
+  coordinateSystem: TextCoordinateSystem!
+  start: Int!
+  end: Int!
+  text: String!
+}
+
+input TextWindowInput {
+  bufferId: ID!
+  basisRef: ID!
+  coordinateSystem: TextCoordinateSystem!
+  start: Int!
+  length: Int!
+}
+
+type Mutation {
+  createBuffer(input: CreateBufferInput!): MutationReceipt!
+    @wes_op(name: "createBuffer")
+    @wes_artifact(
+      familyId: "stack-witness-0001.file-history"
+      schemaId: "stack-witness-0001.file-history.v0"
+      artifactId: "fixture-file-history-v0"
+      version: "0"
+    )
+    @wes_stack_witness(
+      opId: "0x53570001"
+      helperKind: "EINT"
+      canonicalVarsEncoding: "utf8-semicolon-kv/v0"
+      canonicalVarsBytes: "stack-witness-0001/createBuffer;name=demo.txt;artifact=fixture-file-history-v0"
+      fixtureVector: "stack-witness-0001-vectors.json#createBuffer"
+    )
+    @wes_footprint(
+      reads: []
+      writes: []
+      creates: ["Buffer"]
+      slots: []
+      createSlots: [{ slot: "buffer", kind: "Buffer" }]
+      updates: []
+      forbids: ["AstState", "Diagnostics", "GitWitness", "UiState"]
+    )
+
+  replaceRange(input: ReplaceRangeInput!): MutationReceipt!
+    @wes_op(name: "replaceRange")
+    @wes_artifact(
+      familyId: "stack-witness-0001.file-history"
+      schemaId: "stack-witness-0001.file-history.v0"
+      artifactId: "fixture-file-history-v0"
+      version: "0"
+    )
+    @wes_stack_witness(
+      opId: "0x53570002"
+      helperKind: "EINT"
+      canonicalVarsEncoding: "utf8-semicolon-kv/v0"
+      canonicalVarsBytes: "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0"
+      fixtureVector: "stack-witness-0001-vectors.json#replaceRange"
+    )
+    @wes_footprint(
+      reads: ["Buffer"]
+      writes: ["Buffer"]
+      creates: ["Tick", "Receipt"]
+      slots: [
+        {
+          slot: "buffer"
+          kind: "Buffer"
+          bindFromArg: "input.bufferId"
+          access: [READ, WRITE]
+        }
+      ]
+      createSlots: [
+        { slot: "tick", kind: "Tick" }
+        { slot: "receipt", kind: "Receipt" }
+      ]
+      updates: [{ slot: "buffer", fields: ["history"] }]
+      forbids: ["AstState", "Diagnostics", "GitWitness", "UiState"]
+    )
+}
+
+type Query {
+  textWindow(input: TextWindowInput!): TextWindowReading!
+    @wes_op(name: "textWindow")
+    @wes_artifact(
+      familyId: "stack-witness-0001.file-history"
+      schemaId: "stack-witness-0001.file-history.v0"
+      artifactId: "fixture-file-history-v0"
+      version: "0"
+    )
+    @wes_stack_witness(
+      opId: "0x53571001"
+      helperKind: "QueryView"
+      canonicalVarsEncoding: "utf8-semicolon-kv/v0"
+      canonicalVarsBytes: "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0"
+      payloadCodec: "QueryBytes"
+      envelope: "ReadingEnvelope"
+      fixtureVector: "stack-witness-0001-vectors.json#textWindow"
+    )
+    @wes_footprint(
+      reads: ["Buffer", "Tick", "Receipt"]
+      writes: []
+      creates: []
+      slots: [
+        {
+          slot: "buffer"
+          kind: "Buffer"
+          bindFromArg: "input.bufferId"
+          access: [READ]
+        }
+      ]
+      updates: []
+      forbids: ["AstState", "Diagnostics", "GitWitness", "UiState"]
+    )
+}

--- a/test/fixtures/consumer-models/stack-witness-0001-vectors.json
+++ b/test/fixtures/consumer-models/stack-witness-0001-vectors.json
@@ -37,7 +37,7 @@
       "opIdHex": "0x53570002",
       "opIdDecimal": 1398210562,
       "helperKind": "EINT",
-      "canonicalVarsBytes": "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0",
+      "canonicalVarsBytes": "stack-witness-0001/replaceRange;bufferId=demo.txt;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0",
       "declaredFootprint": {
         "reads": ["Buffer"],
         "writes": ["Buffer"],
@@ -61,9 +61,10 @@
       "opIdHex": "0x53571001",
       "opIdDecimal": 1398214657,
       "helperKind": "QueryView",
-      "canonicalVarsBytes": "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0",
+      "canonicalVarsBytes": "stack-witness-0001/textWindow;bufferId=demo.txt;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0",
       "payloadCodec": "QueryBytes",
       "envelope": "ReadingEnvelope",
+      "expectedQueryBytesHex": "68656c6c6f",
       "declaredFootprint": {
         "reads": ["Buffer", "Tick", "Receipt"],
         "writes": [],

--- a/test/fixtures/consumer-models/stack-witness-0001-vectors.json
+++ b/test/fixtures/consumer-models/stack-witness-0001-vectors.json
@@ -1,0 +1,86 @@
+{
+  "artifact": {
+    "familyId": "stack-witness-0001.file-history",
+    "schemaId": "stack-witness-0001.file-history.v0",
+    "artifactId": "fixture-file-history-v0",
+    "version": "0"
+  },
+  "canonicalVarsEncoding": "utf8-semicolon-kv/v0",
+  "operations": [
+    {
+      "name": "createBuffer",
+      "operationType": "MUTATION",
+      "opIdHex": "0x53570001",
+      "opIdDecimal": 1398210561,
+      "helperKind": "EINT",
+      "canonicalVarsBytes": "stack-witness-0001/createBuffer;name=demo.txt;artifact=fixture-file-history-v0",
+      "declaredFootprint": {
+        "reads": [],
+        "writes": [],
+        "creates": ["Buffer"],
+        "forbids": ["AstState", "Diagnostics", "GitWitness", "UiState"]
+      },
+      "helperShape": {
+        "frame": "EINT",
+        "entrypoint": "dispatch_intent",
+        "fields": [
+          "contract_artifact_id",
+          "operation_id",
+          "canonical_vars_bytes",
+          "declared_footprint"
+        ]
+      }
+    },
+    {
+      "name": "replaceRange",
+      "operationType": "MUTATION",
+      "opIdHex": "0x53570002",
+      "opIdDecimal": 1398210562,
+      "helperKind": "EINT",
+      "canonicalVarsBytes": "stack-witness-0001/replaceRange;basis=B0;coord=utf8-bytes;start=0;end=0;text=hello;artifact=fixture-file-history-v0",
+      "declaredFootprint": {
+        "reads": ["Buffer"],
+        "writes": ["Buffer"],
+        "creates": ["Tick", "Receipt"],
+        "forbids": ["AstState", "Diagnostics", "GitWitness", "UiState"]
+      },
+      "helperShape": {
+        "frame": "EINT",
+        "entrypoint": "dispatch_intent",
+        "fields": [
+          "contract_artifact_id",
+          "operation_id",
+          "canonical_vars_bytes",
+          "declared_footprint"
+        ]
+      }
+    },
+    {
+      "name": "textWindow",
+      "operationType": "QUERY",
+      "opIdHex": "0x53571001",
+      "opIdDecimal": 1398214657,
+      "helperKind": "QueryView",
+      "canonicalVarsBytes": "stack-witness-0001/textWindow;basis=B1;coord=utf8-bytes;start=0;length=5;artifact=fixture-file-history-v0",
+      "payloadCodec": "QueryBytes",
+      "envelope": "ReadingEnvelope",
+      "declaredFootprint": {
+        "reads": ["Buffer", "Tick", "Receipt"],
+        "writes": [],
+        "creates": [],
+        "forbids": ["AstState", "Diagnostics", "GitWitness", "UiState"]
+      },
+      "helperShape": {
+        "frame": "QueryView",
+        "entrypoint": "observe",
+        "fields": [
+          "contract_artifact_id",
+          "query_id",
+          "canonical_vars_bytes",
+          "reading_envelope",
+          "query_bytes"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the Stack Witness 0001 fixture artifact shape for the jedit-through-Echo walking skeleton.

This PR publishes a hermetic Wesley fixture that Echo can mirror without making Wesley depend on Echo runtime internals.

## Why

Echo now has a tiny jedit-through-Echo walking skeleton. Wesley needs to publish the corresponding fixture artifact shape so the stack can detect drift before real generated integration begins.

The specific boundary being proven is:

```text
createBuffer
-> replaceRange("hello")
-> textWindow(0..5)
-> ReadingEnvelope + QueryBytes
```

The fixture is intentionally narrow. It does not redesign Wesley, generalize contract hosting, touch Continuum, or publish a new Wesley release.

## Changes

- Added `test/fixtures/consumer-models/stack-witness-0001-file-history.graphql` with the Stack Witness 0001 GraphQL operation surface.
- Added `test/fixtures/consumer-models/stack-witness-0001-vectors.json` with operation ids, canonical vars encoding, helper shape, declared footprints, and expected query payload bytes.
- Hardened canonical vars for `replaceRange` and `textWindow` so target buffer identity is part of operation meaning.
- Modeled `QueryBytes` with base64-shaped byte payload semantics instead of pretending arbitrary bytes are plain text.
- Added Wesley core fixture-vector validation for SDL/vector drift, artifact identity, op-id consistency, footprint coverage, helper shape fields, and expected payload bytes.
- Added Rust and TypeScript emitter coverage that checks operation-local metadata blocks instead of broad global substrings.
- Documented `consumer-models/` fixture ownership in `test/fixtures/README.md`.
- Added an Unreleased changelog entry.

## Evidence

| Claim | Evidence |
| :--- | :--- |
| Fixture schema defines buffer-targeted mutation/read inputs and byte-safe query payload slots. | `test/fixtures/consumer-models/stack-witness-0001-file-history.graphql`: lines 48-75 |
| `createBuffer`, `replaceRange`, and `textWindow` publish artifact identity, op ids, helper kind, canonical vars encoding, canonical vars bytes, fixture-vector anchors, and footprints. | `test/fixtures/consumer-models/stack-witness-0001-file-history.graphql`: lines 78-173 |
| Vector fixture carries operation ids, canonical vars, declared footprints, helper shapes, and expected `hello` query bytes as hex. | `test/fixtures/consumer-models/stack-witness-0001-vectors.json`: lines 1-87 |
| Wesley core validates the fixture operation catalog and SDL/vector drift lock. | `crates/wesley-core/tests/operation_analysis.rs`: lines 305-519 |
| Rust operation emission keeps Stack Witness metadata attached to the correct generated operation blocks. | `crates/wesley-emit-rust/src/lib.rs`: lines 738-789 |
| TypeScript operation emission keeps Stack Witness metadata attached to the correct generated operation blocks. | `crates/wesley-emit-typescript/src/lib.rs`: lines 755-809 |

## Risk

Low runtime risk. This PR adds fixture data, tests, docs, and changelog coverage only.

Main integration risk is fixture drift between Wesley and Echo. That is intentional: Echo now mirrors this vector and has a separate drift-lock regression. If this Wesley vector changes, Echo must update its mirror in the dependent PR.

No Wesley release is included. Publishing should wait for reuse pressure after the seam lands.

## Backout

Revert this PR. It only adds fixture artifacts and tests; reverting removes the Stack Witness 0001 fixture surface without touching released Wesley runtime behavior.

If Echo has already landed its mirror, revert or update the Echo drift-lock PR/commit at the same time so Echo does not point at a removed Wesley fixture.

## Testing

```sh
cargo test -p wesley-core lists_stack_witness_0001_fixture_artifact_shape
cargo test -p wesley-emit-rust emits_stack_witness_0001_fixture_operation_bindings
cargo test -p wesley-emit-typescript emits_stack_witness_0001_fixture_operation_bindings
```

Additional push-time validation:

```text
Repo Bats smoke suite passed
```

CI on PR head `1b8cdaa2de57031fe91c29d8820f8c4f04885d7e` is green.

## Checklist

- [x] Stack Witness 0001 fixture schema added.
- [x] Stack Witness 0001 fixture vectors added.
- [x] Operation ids recorded for `createBuffer`, `replaceRange`, and `textWindow`.
- [x] Canonical vars include target buffer identity where operation meaning requires it.
- [x] Declared footprints are covered by regression tests.
- [x] EINT helper shape is covered by regression tests.
- [x] QueryView helper shape and expected query bytes are covered by regression tests.
- [x] Rust operation binding emission is covered.
- [x] TypeScript operation binding emission is covered.
- [x] Docs/changelog updated.
- [x] No Continuum changes.
- [x] No Wesley release/publish step.
