### PR TITLE
Revise README.md for clarity and additional information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,229 +1,251 @@
-<!-- docs-truth: status=experimental owner=@flyingrobots -->
+> “Things are only impossible until they’re not.”  
+> — Jean-Luc Picard
+
 <div align="center">
 <img src="https://github.com/user-attachments/assets/0c03a527-dc36-466f-a212-a3a24731acf8" />
 </div>
 
-A schema-first compiler kernel for trustworthy change. Wesley turns authored
-GraphQL into derived artifacts through explicit target modules, while keeping
-source identity, lowering, artifact emission, and evidence separate.
+## What is Wesley?
 
-Wesley itself is the core `GraphQL -> whatever` compiler and assurance
-toolchain. The `whatever` is brought by modules outside the core repo. Domain
-systems such as Continuum and PostgreSQL are not Wesley product surfaces; their
-generators, policies, witnesses, and runtime conventions belong in external
-module repos such as Continuum itself or `wesley-postgres`.
+**Wesley is a semantic contract compiler.**
 
-## Entry Point
+It takes GraphQL Schema Definition Language (SDL) as its single source of truth, constructs a semantic graph, and compiles that graph into domain-specific outputs through a system of extensions.
 
-Start with the Rust-native surface:
+Wesley is deliberately domain-empty. It claims no ownership over runtime law, scheduler semantics, persistence models, replication behavior, storage engines, transport protocols, or substrate truth. Those concerns belong entirely to extension modules.
 
-```bash
-cargo xtask preflight
-cargo wesley --help
-```
-
-Wesley currently has legacy Node packages and a newer Rust kernel in the same
-repository. They are not equal product fronts.
-
-- `crates/wesley-core/` is the compiler truth for new work.
-- `crates/wesley-cli/` is the native `wesley` command for Rust-backed compiler
-  facts.
-- `xtask/` is repository automation.
-- `packages/` is the historical Node toolchain: old commands, generators,
-  hosts, module loading, evidence tooling, package tests, and docs support.
-- `package.json` keeps that old Node workspace installable; it is not the
-  product entry point.
-
-For the full map, read [ENTRYPOINTS.md](./docs/ENTRYPOINTS.md).
-
-## Why Wesley?
-
-Unlike traditional code-generators that treat schemas as suggestions, Wesley treats the schema as the sovereign system of record.
-
-- **Contract Sovereignty**: Authored GraphQL SDL is the single source of truth. Generated artifacts are derived surfaces that are never allowed to become peer authorities.
-- **Admission Discipline**: Authored source, lowered IR, realization shells, and witness output are kept distinct so Wesley can certify explicit properties without overstating runtime truth.
-- **Module-Brought Targets**: Wesley owns parsing, lowering, dispatch, artifact bookkeeping, and assurance plumbing. Modules own target semantics, generators, policy, witness scopes, and release conventions.
-- **Evidence-Backed Change**: Toolchain surfaces can produce machine-readable evidence that a proposed artifact bundle is coherent with the authored source and selected modules.
-- **Cross-Language Inevitability**: By generating bit-exact codecs and IR envelopes, Wesley prevents the "adapter spaghetti" that typically causes multi-repo platforms to rot.
-- **Local-First Operation**: The compiler and witness suite run entirely on the local developer workstation, ensuring that contract verification is part of the fast inner-loop.
-
-## Quick Start
-
-### 1. Verify The Rust Workspace
-```bash
-cargo xtask preflight
-```
-
-### 2. Inspect The Native Command
-```bash
-cargo wesley --help
-```
-
-The native command can lower schema SDL to L1 IR, compute schema hashes, diff
-schema structure, list schema root operations, emit Rust models and TypeScript
-declarations with root operation bindings, resolve operation selections, and
-extract operation directive arguments.
-
-```bash
-cargo wesley schema lower --schema test/fixtures/ir-parity/small-schema.graphql --json
-cargo wesley schema hash --schema test/fixtures/ir-parity/small-schema.graphql
-cargo wesley schema operations --schema test/fixtures/consumer-models/jedit-hot-text-runtime.graphql --json
-cargo wesley schema diff --old old.graphql --new new.graphql --format summary --exit-code
-cargo wesley schema diff --schema schema.graphql --against HEAD --format summary
-cargo wesley emit rust --schema test/fixtures/consumer-models/jedit-hot-text-runtime.graphql --out generated/model.rs
-cargo wesley emit typescript --schema test/fixtures/consumer-models/jedit-hot-text-runtime.graphql --out generated/types.ts
-```
-
-Echo-owned tooling owns Echo-specific footprint honesty checks.
-
-## What's New in v0.0.2
-
-Wesley's `0.0.2` alpha hardens the Rust-native crates.io release path. The
-GitHub Actions release workflow now keeps temporary GitHub Release notes and
-draft-state files outside the repository checkout, so the real-publish
-clean-worktree guard can run immediately before registry mutation.
-
-The native alpha line still centers the Rust front door: it lowers GraphQL SDL
-to domain-empty L1 IR, hashes schemas, diffs schema structure, lists schema root
-operations, emits Rust and TypeScript model/operation bindings, resolves
-operation selection paths, and extracts operation directive arguments without
-requiring an npm entry point. See [CHANGELOG.md](./CHANGELOG.md) for the full
-release notes.
-
-## Rust-Native Front Door
-
-Wesley core work now starts from Cargo.
-
-- `cargo wesley ...` runs the native Rust `wesley` binary from
-  `crates/wesley-cli`.
-- `cargo xtask ...` runs repository automation from `xtask`.
-- `cargo xtask docs-check` runs Rust-native documentation hygiene checks.
-- `cargo xtask preflight` is the normal Rust-native health check: docs checks,
-  Rust tests, and native CLI help.
-- `cargo xtask release-check` builds the optimized native binary and packages
-  the Rust library crate without publishing anything.
-- `cargo xtask legacy-preflight` runs the historical npm/package preflight
-  while the old package surfaces are being retired.
-
-The distinction matters: `wesley` is the user-facing compiler command, while
-`xtask` is for maintaining this repository. Avoid adding new core workflows to
-`pnpm wesley`; new compiler behavior should land in Rust first.
-
-### Extending Wesley
-
-Extend Wesley at the narrowest boundary that owns the meaning:
-
-- Add generic GraphQL compiler facts in `crates/wesley-core`.
-- Add user-facing Rust commands in `crates/wesley-cli`.
-- Add generic Rust or TypeScript projections in the existing Rust emitter crates
-  when the projection is domain-empty and broadly reusable.
-- Put domain targets, policies, witnesses, and runtime conventions in external
-  modules or crates owned by that domain.
-
-The practical extension guide is [docs/guides/extending.md](./docs/guides/extending.md).
-
-### Native Install And Release
-
-Install the published alpha native binary from crates.io.
-```bash
-cargo install wesley-cli --version 0.0.2
-wesley --help
-```
-
-Install the local native binary directly from the Rust workspace when working
-inside this checkout.
-```bash
-cargo install --locked --path crates/wesley-cli
-wesley --help
-```
-
-Before cutting or attaching a native release artifact, run the Rust release
-check.
-```bash
-cargo xtask release-check
-./target/release/wesley --help
-```
-
-This path does not require an npm entry point. The native CLI is distributed as
-the `wesley-cli` crate on crates.io, which installs a `wesley` binary. The
-historical Node packages remain available only for legacy package projections
-and surrounding tooling until those surfaces are extracted, retired, or
-reimplemented in Rust.
-
-### Legacy Repository Tooling Preflight
-The repo still carries historical Node package tooling while the Rust-native
-front door takes over. Use preflight when changing docs, package boundaries, or
-legacy package surfaces.
-```bash
-pnpm install
-cargo xtask legacy-preflight
-```
-
-### Legacy Package Projection
-Generate TypeScript from an authored GraphQL schema.
-```bash
-pnpm wesley typescript \
-  --schema ./schema.graphql \
-  --out-file ./generated/types.generated.ts
-```
-
-### Legacy Target Module Loading
-Select target behavior explicitly from project config or `WESLEY_MODULES`.
-```bash
-WESLEY_MODULES=/path/to/my-wesley-module.mjs pnpm wesley --help
-```
-Modules are trusted Node code. Use `WESLEY_DISABLE_MODULES=1` for a no-module
-diagnostic run, or set `WESLEY_MODULE_ALLOWLIST` to path-delimited config/module
-paths in CI environments that must refuse unapproved module imports.
-
-The current repo still carries historical Continuum and PostgreSQL surfaces.
-They are extraction debt, not Wesley identity. New target semantics should land
-in external modules rather than in this repository.
-
-## Overall Status
-
-<!-- BEGIN:OVERALL_STATUS -->
-Stage: MVP  \
-Progress: 61% → Alpha
-<!-- END:OVERALL_STATUS -->
-
-## Package Matrix
-
-<!-- BEGIN:PACKAGE_MATRIX -->
-| Package | Status | Stage | Progress | CI | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `@wesley/core` | Active | MVP | 45% → Alpha | — | Pure domain logic, no Node builtins |
-| `@wesley/cli` | Active | Alpha | 50% → Beta | — | CLI + Bats suites |
-| `@wesley/host-node` | Active | MVP | 50% → Alpha | — | Node adapters + binary |
-| `@wesley/host-browser` | Experimental | MVP | 40% → Alpha | — | Pure ESM; in-memory FS; minimal parser; smoke-level only |
-| `@wesley/generator-js` | Active | MVP | 50% → Alpha | — | TS/Zod emitters |
-| `@wesley/generator-vue` | Experimental | MVP | 0% → Alpha | — | Vue-facing TS/composable emitters |
-| `@wesley/holmes` | Active | Alpha | 50% → Beta | — | Evidence scoring |
-| `@wesley/runtime-node` | Active | MVP | 0% → Alpha | — | Shared Node runtime adapters |
-| `@wesley/tasks` | Active | MVP | 50% → Alpha | — | Planner utilities |
-| `@wesley/host-deno` | Experimental | Alpha | 50% → Beta | — | Deno host runtime (demo) |
-| `@wesley/host-bun` | Experimental | Alpha | 50% → Beta | — | Bun host runtime (demo) |
-| `@wesley/scaffold-multitenant` | Too soon | Prototype | 50% → MVP | — | Early scaffold, no CI yet |
-| `@wesley/test-fixtures` | Active | MVP | 20% → Alpha | — | Private shared fixtures + schema builders |
-<!-- END:PACKAGE_MATRIX -->
-
-## Documentation
-
-- **[Guide](./docs/GUIDE.md)**: Orientation, the fast path, and compiler usage.
-- **[Crates.io Release](./docs/CRATES_IO_RELEASE.md)**: Native Rust alpha
-  package set and publish order.
-- **[Wesley Glossary](./docs/WESLEY_GLOSSARY.md)**: The main nouns, layers, and boundary terms for Wesley and its surrounding toolchain.
-- **[Advanced Guide](./docs/ADVANCED_GUIDE.md)**: Deep dives into the IR model, custom directives, and the "Holmes" policy engine.
-- **[Architecture](./docs/ARCHITECTURE.md)**: The authoritative system map (Base Platform, Modules, Workspace, and bundle pipeline).
-- **[Extending Wesley](./docs/guides/extending.md)**: How to add Rust compiler
-  behavior, native CLI surfaces, emitter projections, or external modules
-  without breaking the core boundary.
-- **[Realization Admission and Witness](./docs/design/0004-realization-admission-and-witness/realization-admission-and-witness.md)**: The release-line doctrine for authored source, IR, realization shells, and bounded witness claims.
-- **[Module Contract](./docs/design/wesley-module-contract.md)**: The boundary between the Wesley compiler kernel and external target modules.
-- **[Module Capability Contract](./docs/design/wesley-module-capability-contract.md)**: The capability surfaces external modules bring to Wesley.
-- **[Extraction Map](./docs/design/wesley-extraction-map.md)**: The currently known wrong-repo domain residue and its intended external homes.
-- **[Vision](./docs/VISION.md)**: Core tenets and the "Trustworthy Change" mission.
-- **[Method](./docs/METHOD.md)**: Repo work doctrine and the cycle loop.
+**Wesley owns semantic compilation. Domains own law.**
 
 ---
-Built with bit-exact ambition by [FLYING ROBOTS](https://github.com/flyingrobots)
+
+## Core doctrine
+
+Product pressure determines architectural truth.
+
+The stack evolves in this order:
+
+```mermaid
+flowchart TD
+  PP[Product Pressure] --> WE[Witnessed Execution]
+  WE --> SB[Stabilized Boundary]
+  SB --> SC[Semantic Contract]
+  SC --> GA[Generated Artifacts]
+  GA --> RP[Reusable Protocol]
+
+  classDef default fill:#f8fafc,stroke:#334155,stroke-width:2px,rx:6,ry:6
+  classDef final fill:#fef3c7,stroke:#d97706,stroke-width:2px,rx:6,ry:6
+
+  class RP final
+```
+
+Wesley lives at the contract and boundary layers. It exists to stabilize truths that product pressure and real-world execution have already forced into existence — never before.
+
+## The inversion
+
+The industry generates GraphQL schemas from runtime models or application code. Wesley inverts this relationship:
+
+```mermaid
+flowchart LR
+  SDL[GraphQL SDL] --> SG[Semantic Graph]
+  SG --> DLI[Domain Law Interpretation]
+  DLI --> IR[IR Lowering]
+  IR --> EA[Emitted Artifacts]
+```
+
+One schema can now drive many outputs simultaneously:
+
+* TypeScript contracts
+* Rust bindings
+* SQL schemas and migrations
+* pgTAP test suites
+* Runtime manifests
+* Codecs
+* Validators
+* Observer plans
+* Transport bindings
+
+This alignment happens automatically, eliminating hand-maintained drift.
+
+---
+
+## Why GraphQL?
+
+GraphQL was chosen for several deep, structural reasons.
+
+**Additive evolution.** Schemas can grow safely without breaking existing consumers. SDL has proven to be an exceptionally stable, long-lived contract substrate.
+
+**Ontology over layout.** GraphQL describes entities, operations, and relationships rather than dictating storage or implementation details. It is a semantic schema language first, and an API layer second.
+
+**Behavioral extension through directives.** Directives allow additional meaning to be attached to schema elements without altering their fundamental shape. This distinction is foundational:
+
+* Types define **shape**.
+* Directives define **law**.
+* Extensions define **interpretation**.
+
+Because directives attach semantics structurally to schema locations, law becomes statically inspectable instead of being hidden inside arbitrary runtime code.
+
+**Strong contract boundaries.** Schema-first GraphQL already treats the SDL as the single source of truth. Wesley generalizes this principle: one SDL becomes the common root for many different technical systems simultaneously.
+
+---
+
+## Compilation model
+
+Wesley follows a clear, deterministic pipeline:
+
+```mermaid
+flowchart LR
+  SDL[SDL] --> P[Parser]
+  P --> SG[Semantic Graph]
+  SG --> DLI[Domain Law Interpretation]
+  DLI --> IR[IR Lowering]
+  IR --> EA[Emitted Artifacts]
+```
+
+* **L1 — Semantic graph:** Normalizes types, fields, directives, and relationships.
+* **L2 — Domain law:** Validates operational footprints, admissibility rules, capabilities, constraints, and interpreted semantics.
+* **L3 — Emitted outputs:** Generates runtime plans, witnesses, materializations, bindings, and artifacts.
+
+Most extensions operate entirely at L1 and L2. They remain completely unaware of L3. L3 exists strictly for runtimes with deeper execution requirements.
+
+---
+
+## Extension modules
+
+A single schema can be compiled by many extensions simultaneously. Each extension walks the semantic graph independently and emits its own artifacts. Extensions do not need to know about one another.
+
+| Extension | Responsibility |
+| :--- | :--- |
+| Postgres | SQL schemas, migrations, indexes, pgTAP, CRUD helpers |
+| Validation | Runtime and static validation rules |
+| Codec | Binary and runtime codecs |
+| TypeScript | Type contracts and client bindings |
+| Observer | Observation plans and projections |
+| Echo | Runtime law, footprints, observation semantics |
+| Continuum | Deferred protocol generation |
+
+---
+
+## Shape vs Law
+
+### Shape
+
+Shape answers: *What exists?*
+
+It defines the structural reality of the system, covering fields, entities, relationships, arguments, and payloads. GraphQL types define shape.
+
+```graphql
+type User {
+  id: ID!
+  email: String!
+  createdAt: String!
+}
+```
+
+A Postgres extension can safely observe this shape and emit tables, migrations, indexes, and tests without any knowledge of runtime footprints or causal execution.
+
+### Law
+
+Law answers: *What is permitted, required, or forbidden?*
+
+It governs execution, covering reads, writes, capabilities, footprints, admissibility rules, and operational constraints. Directives carry this law when interpreted by extensions.
+
+```graphql
+@wes_op(name: "replaceRangeAsTick")
+@wes_footprint(
+  reads: ["BufferWorldline", "RopeHead"]
+  writes: ["BufferWorldline"]
+)
+```
+
+The Postgres extension ignores these directives completely. The Echo extension interprets them as runtime law. Neither extension needs to understand the other. Wesley sees both but assigns no meaning itself — that responsibility belongs solely to the extensions.
+
+---
+
+## The deep end
+
+For most use cases, Wesley is a powerful drift-eliminating code generator with a clean extension model. That alone justifies the investment.
+
+But GraphQL has a deeper property that matters enormously here: **GraphQL operation structure is statically analyzable.**
+
+Selections, mutations, arguments, and directives together form a fully declarative operational surface. That means the complete intent and footprint of an operation can be inspected before execution begins.
+
+This enables extensions to:
+
+* Declare precise operational footprints
+* Validate read/write honesty
+* Detect forbidden dependencies
+* Compile deterministic runtime plans
+* Define bounded observation apertures
+* Reject dishonest operations at compile time
+
+Arbitrary application code can lie about what it reads or writes. A GraphQL mutation structurally cannot — its footprint is an immutable part of the contract.
+
+**If your footprint is dishonest, Wesley becomes a compile-time error.**
+
+This is not merely code generation. It is semantic law enforcement through compilation.
+
+The Echo extension currently pushes this capability the furthest, but it is not required for all uses of Wesley. Most Wesley users may never touch causal runtimes at all.
+
+---
+
+## Layer separation
+
+| Layer | Responsibility |
+| :--- | :--- |
+| Product | Product pressure and user semantics |
+| Runtime | Execution and substrate truth |
+| Wesley | Semantic compilation |
+| Extensions | Domain law |
+| Protocols | Deferred publication of proven seams |
+
+The compiler must not silently become a runtime.  
+The runtime must not silently become product policy.  
+The product must not manufacture substrate coordinates.
+
+If any layer requires forbidden knowledge from another to progress, either the boundary is wrong or the witness is not ready. **That is the trap detector.**
+
+---
+
+## Anti-goals
+
+Wesley is **not**:
+
+* A runtime
+* A scheduler
+* A database
+* A replication engine
+* A GraphQL server replacement
+* A universal protocol
+* A transport framework
+* A “one true architecture”
+
+It is not a venue for premature abstractions to look impressive before reality demands them. Keeping Wesley narrow and focused is what allows extensions to own rich semantics without the compiler collapsing into hidden platform ideology or architectural sludge.
+
+---
+
+## Current grounding
+
+The current witness:
+
+```mermaid
+flowchart TD
+  A[createBuffer] --> B["replaceRange('hello')"]
+  B --> C["textWindow(0..5)"]
+  C --> D["ReadingEnvelope + QueryBytes('hello')"]
+  D --> E[TextWindowReading]
+
+  classDef default fill:#f8fafc,stroke:#334155,stroke-width:2px,rx:6,ry:6
+```
+
+This sequence proves a real product/runtime seam. Wesley’s job is to stabilize that seam. It did not invent it.
+
+---
+
+## Final doctrine
+
+Wesley does not exist to invent universal semantics. It exists to make proven semantics reproducible, inspectable, and drift-resistant.
+
+1. GraphQL SDL provides the semantic source contract.
+2. Directives carry domain-owned law.
+3. Extensions interpret that law.
+
+The compiler stabilizes truths that product pressure has already forced into existence. **Not before.**


### PR DESCRIPTION
Updated README.md to include new sections and clarify existing content.

## Summary
- What problem does this PR solve? Link issues/PRs.

## Why
- Rationale for this approach. Mention alternatives considered and trade‑offs.

## Changes
- Bulleted list of focused changes (keep it surgical).

## Risk
- User‑facing or CI risk and mitigations. Rollout/enablement notes if any.

## Backout
- How to revert safely; follow‑up cleanup if rollback happens.

## Testing
- Rust core/CLI: `cargo xtask preflight`
- Core fixtures: `cargo test --manifest-path crates/wesley-core/Cargo.toml`
- Legacy package surfaces: `cargo xtask legacy-preflight` (when touching `packages/`, docs checks, or JS tooling)
- JS package focus: `pnpm -w -F <package> test` (only for legacy package changes)

## EvidenceMap / SourceMap (if applicable)
- Confirm UIDs use `tbl:Table` and `col:Table.field`.
- If mapping SQL→SDL, verify `.wesley-cache/bundle.json` exists and SourceMap finds SDL.

## Screenshots / Logs (optional)

## Merge Strategy
- Merge commit only; no rebase.
- Delete branch after merge.

## Checklist
- [ ] One‑topic PR with tight diff
- [ ] Rust-native preflight passes (`cargo xtask preflight`)
- [ ] Legacy package preflight passes when relevant (`cargo xtask legacy-preflight`)
- [ ] No widened permissions/secrets in workflows
- [ ] Docs updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README to emphasize architectural principles and core compilation concepts, replacing usage-focused sections. Added guidance on module responsibilities, layer separation, and compile-time enforcement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/wesley/pull/503)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->