### PR TITLE
chore(release): v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-05-14
+
 ### Added
 
 - **Stack Witness 0001 fixture artifact shape**: Added a hermetic
@@ -903,6 +905,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.1.0] - 2025-09-01
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/flyingrobots/wesley/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/flyingrobots/wesley/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/flyingrobots/wesley/releases/tag/v0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "pretty_assertions",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ For the bounded-autonomy direction, read
 
 ---
 
+## What's New in v0.0.3
+
+Wesley `0.0.3` introduces the first runtime optic artifact compiler surface.
+`wesley-core` can compile supported GraphQL runtime optic operations into
+stable, content-addressed artifact claims with operation identity, variable and
+payload shapes, preserved directive records, admission requirements, law claim
+templates, artifact hashes, and registration descriptors for runtime import.
+
+The release also hardens the runtime optic executable subset before
+`shape.valid.v1` is emitted. Unsupported v0 features are rejected explicitly,
+footprints are root-field-only admission declarations, nested inputs and list
+wrappers are validated, response-name conflicts are rejected, authority and
+witness wire spellings are snapshotted, and causal suffix bundle design notes
+record the next runtime synchronization direction.
+
+For the complete release history, read [CHANGELOG.md](./CHANGELOG.md).
+
+---
+
 ## Core doctrine
 
 Product pressure determines architectural truth.

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.2" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.2" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.2" }
+wesley-core = { path = "../wesley-core", version = "0.0.3" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.3" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.3" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -2160,16 +2160,19 @@ fn selection_argument_bindings(
     variable_types: &BTreeMap<String, TypeReference>,
 ) -> Result<Vec<SelectionArgumentBinding>, WesleyError> {
     let mut bindings = Vec::new();
+    let context = SelectionArgumentBindingContext {
+        schema,
+        fragments,
+        variable_types,
+    };
 
     if let Some(selection_set) = root_field.selection_set() {
         collect_selection_argument_bindings(
             &selection_set,
             &result_type.base,
-            schema,
-            fragments,
+            &context,
             &mut Vec::new(),
             "",
-            variable_types,
             &mut bindings,
         )?;
     }
@@ -2177,14 +2180,18 @@ fn selection_argument_bindings(
     Ok(bindings)
 }
 
+struct SelectionArgumentBindingContext<'a> {
+    schema: &'a SchemaIndex<'a>,
+    fragments: &'a BTreeMap<String, cst::FragmentDefinition>,
+    variable_types: &'a BTreeMap<String, TypeReference>,
+}
+
 fn collect_selection_argument_bindings(
     selection_set: &cst::SelectionSet,
     parent_type: &str,
-    schema: &SchemaIndex<'_>,
-    fragments: &BTreeMap<String, cst::FragmentDefinition>,
+    context: &SelectionArgumentBindingContext<'_>,
     active_fragments: &mut Vec<String>,
     prefix: &str,
-    variable_types: &BTreeMap<String, TypeReference>,
     bindings: &mut Vec<SelectionArgumentBinding>,
 ) -> Result<(), WesleyError> {
     for selection in selection_set.selections() {
@@ -2192,7 +2199,7 @@ fn collect_selection_argument_bindings(
             cst::Selection::Field(field) => {
                 let field_name = required_name(field.name(), "Field selection missing name")?;
                 let response_name = response_field_name(&field)?;
-                let schema_field = schema.field(parent_type, &field_name)?;
+                let schema_field = context.schema.field(parent_type, &field_name)?;
                 let path = if prefix.is_empty() {
                     response_name
                 } else {
@@ -2203,22 +2210,20 @@ fn collect_selection_argument_bindings(
                     &field,
                     &path,
                     schema_field,
-                    variable_types,
-                    schema,
+                    context.variable_types,
+                    context.schema,
                     bindings,
                 )?;
 
                 if let Some(nested_selection_set) = field.selection_set() {
                     let nested_parent = schema_field.r#type.base.as_str();
-                    schema.require_type(nested_parent)?;
+                    context.schema.require_type(nested_parent)?;
                     collect_selection_argument_bindings(
                         &nested_selection_set,
                         nested_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         &path,
-                        variable_types,
                         bindings,
                     )?;
                 }
@@ -2238,22 +2243,25 @@ fn collect_selection_argument_bindings(
                     ));
                 }
 
-                let fragment = fragments.get(&name).ok_or_else(|| {
+                let fragment = context.fragments.get(&name).ok_or_else(|| {
                     operation_error_value(format!("Unknown fragment spread '{name}'"))
                 })?;
                 let fragment_parent = fragment_type_condition(fragment)?;
-                validate_fragment_type_condition(parent_type, &fragment_parent, schema, &name)?;
+                validate_fragment_type_condition(
+                    parent_type,
+                    &fragment_parent,
+                    context.schema,
+                    &name,
+                )?;
 
                 active_fragments.push(name);
                 if let Some(fragment_selection_set) = fragment.selection_set() {
                     collect_selection_argument_bindings(
                         &fragment_selection_set,
                         &fragment_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         prefix,
-                        variable_types,
                         bindings,
                     )?;
                 }
@@ -2265,17 +2273,20 @@ fn collect_selection_argument_bindings(
                 } else {
                     parent_type.to_string()
                 };
-                validate_fragment_type_condition(parent_type, &inline_parent, schema, "inline")?;
+                validate_fragment_type_condition(
+                    parent_type,
+                    &inline_parent,
+                    context.schema,
+                    "inline",
+                )?;
 
                 if let Some(inline_selection_set) = fragment.selection_set() {
                     collect_selection_argument_bindings(
                         &inline_selection_set,
                         &inline_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         prefix,
-                        variable_types,
                         bindings,
                     )?;
                 }
@@ -2730,13 +2741,13 @@ fn list_items_are_compatible(actual: &TypeReference, expected: &TypeReference) -
         return false;
     }
 
-    match (
-        actual.leaf_nullable.or(actual.list_item_nullable),
-        expected.leaf_nullable.or(expected.list_item_nullable),
-    ) {
-        (Some(true), Some(false)) => false,
-        _ => true,
-    }
+    !matches!(
+        (
+            actual.leaf_nullable.or(actual.list_item_nullable),
+            expected.leaf_nullable.or(expected.list_item_nullable),
+        ),
+        (Some(true), Some(false))
+    )
 }
 
 fn list_item_type_ref(type_ref: &TypeReference) -> TypeReference {
@@ -2882,13 +2893,13 @@ fn payload_codec_shape(
     fragments: &BTreeMap<String, cst::FragmentDefinition>,
 ) -> Result<CodecShape, WesleyError> {
     let mut fields = Vec::new();
+    let context = PayloadCodecContext { schema, fragments };
 
     if let Some(selection_set) = root_field.selection_set() {
         collect_payload_codec_fields(
             &selection_set,
             &result_type.base,
-            schema,
-            fragments,
+            &context,
             &mut Vec::new(),
             "",
             !result_type.nullable,
@@ -2902,11 +2913,15 @@ fn payload_codec_shape(
     })
 }
 
+struct PayloadCodecContext<'a> {
+    schema: &'a SchemaIndex<'a>,
+    fragments: &'a BTreeMap<String, cst::FragmentDefinition>,
+}
+
 fn collect_payload_codec_fields(
     selection_set: &cst::SelectionSet,
     parent_type: &str,
-    schema: &SchemaIndex<'_>,
-    fragments: &BTreeMap<String, cst::FragmentDefinition>,
+    context: &PayloadCodecContext<'_>,
     active_fragments: &mut Vec<String>,
     prefix: &str,
     parent_path_required: bool,
@@ -2917,7 +2932,7 @@ fn collect_payload_codec_fields(
             cst::Selection::Field(field) => {
                 let field_name = required_name(field.name(), "Field selection missing name")?;
                 let response_name = response_field_name(&field)?;
-                let schema_field = schema.field(parent_type, &field_name)?;
+                let schema_field = context.schema.field(parent_type, &field_name)?;
                 let path = if prefix.is_empty() {
                     response_name
                 } else {
@@ -2937,12 +2952,11 @@ fn collect_payload_codec_fields(
 
                 if let Some(nested_selection_set) = field.selection_set() {
                     let nested_parent = schema_field.r#type.base.as_str();
-                    schema.require_type(nested_parent)?;
+                    context.schema.require_type(nested_parent)?;
                     collect_payload_codec_fields(
                         &nested_selection_set,
                         nested_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         &path,
                         field_required,
@@ -2965,19 +2979,23 @@ fn collect_payload_codec_fields(
                     ));
                 }
 
-                let fragment = fragments.get(&name).ok_or_else(|| {
+                let fragment = context.fragments.get(&name).ok_or_else(|| {
                     operation_error_value(format!("Unknown fragment spread '{name}'"))
                 })?;
                 let fragment_parent = fragment_type_condition(fragment)?;
-                validate_fragment_type_condition(parent_type, &fragment_parent, schema, &name)?;
+                validate_fragment_type_condition(
+                    parent_type,
+                    &fragment_parent,
+                    context.schema,
+                    &name,
+                )?;
 
                 active_fragments.push(name);
                 if let Some(fragment_selection_set) = fragment.selection_set() {
                     collect_payload_codec_fields(
                         &fragment_selection_set,
                         &fragment_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         prefix,
                         parent_path_required,
@@ -2992,14 +3010,18 @@ fn collect_payload_codec_fields(
                 } else {
                     parent_type.to_string()
                 };
-                validate_fragment_type_condition(parent_type, &inline_parent, schema, "inline")?;
+                validate_fragment_type_condition(
+                    parent_type,
+                    &inline_parent,
+                    context.schema,
+                    "inline",
+                )?;
 
                 if let Some(inline_selection_set) = fragment.selection_set() {
                     collect_payload_codec_fields(
                         &inline_selection_set,
                         &inline_parent,
-                        schema,
-                        fragments,
+                        context,
                         active_fragments,
                         prefix,
                         parent_path_required,

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "AST-based Rust emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.2" }
+wesley-core = { path = "../wesley-core", version = "0.0.3" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "AST-based TypeScript emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.2" }
+wesley-core = { path = "../wesley-core", version = "0.0.3" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -52,7 +52,7 @@ timeline
   moving away from npm scripts. Native preflight now includes Rust docs checks,
   Rust tests, and native CLI help.
 - Keeping native install/release checks on the Cargo path with
-  `cargo install wesley-cli --version 0.0.2`,
+  `cargo install wesley-cli --version 0.0.3`,
   `cargo install --locked --path crates/wesley-cli`, and
   `cargo xtask release-check`.
 - Treating `pnpm wesley` as legacy package tooling until its remaining useful

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -11,7 +11,7 @@ For installed alpha builds, the crates.io package is `wesley-cli` and the
 installed command is `wesley`:
 
 ```bash
-cargo install wesley-cli --version 0.0.2
+cargo install wesley-cli --version 0.0.3
 wesley --help
 ```
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -12,7 +12,7 @@ If you need the main Wesley nouns and the layer split before reading anything el
 Compile authored GraphQL into generic or explicitly selected generated
 artifacts.
 - **Inspect native CLI**: `cargo wesley --help`
-- **Install alpha from crates.io**: `cargo install wesley-cli --version 0.0.2`
+- **Install alpha from crates.io**: `cargo install wesley-cli --version 0.0.3`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Rust preflight**: `cargo xtask preflight`
 - **Release check**: `cargo xtask release-check`
@@ -23,7 +23,7 @@ native binary stays small while core behavior moves into the Rust library.
 selection paths and extracting directive arguments; Echo-owned tooling owns
 Echo-specific footprint honesty checks.
 
-Use `cargo install wesley-cli --version 0.0.2` when you want the published
+Use `cargo install wesley-cli --version 0.0.3` when you want the published
 alpha `wesley` binary on your PATH. Use
 `cargo install --locked --path crates/wesley-cli` when working from this
 checkout. Use `cargo xtask release-check` before cutting native release


### PR DESCRIPTION
## Summary

- bump the published Wesley Rust crates to 0.0.3
- move runtime optic compiler work into the 0.0.3 changelog section
- add the README release summary and update install docs
- satisfy the release clippy gate for runtime optic traversal helpers

## Validation

- git diff --check
- cargo fmt --check
- cargo xtask docs-check
- cargo check --workspace --all-targets
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets -- -D warnings
- cargo xtask release-check
- cargo audit
- cargo xtask release-prep-guard --version 0.0.3
- cargo xtask package-crates --version 0.0.3
- cargo xtask preflight
- pnpm run preflight


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "What's New in v0.0.3" section to README with release highlights
  * Updated CHANGELOG with v0.0.3 release information
  * Updated installation instructions across documentation

* **Chores**
  * Bumped all package versions to 0.0.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/wesley/pull/506)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->