### PR TITLE
Release v0.0.5 finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-05-21
+
 ### Fixed
 
 - **Object extension folding validation**: JS GraphQL lowering now rejects
@@ -20,6 +22,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   active README/progress metadata and architecture-boundary required package
   checks, and replaced the generated overall status hard break with a Markdown
   table.
+- **Release dependency audit**: Added pnpm overrides for patched `fast-uri`,
+  `brace-expansion`, and `ws` transitive versions so `pnpm audit --prod=false`
+  reports no known vulnerabilities during release prep.
 
 ## [0.0.4] - 2026-05-15
 
@@ -931,7 +936,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.1.0] - 2025-09-01
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/flyingrobots/wesley/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/flyingrobots/wesley/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/flyingrobots/wesley/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/flyingrobots/wesley/compare/v0.0.1...v0.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "pretty_assertions",
  "serde_json",

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.4" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.4" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.4" }
+wesley-core = { path = "../wesley-core", version = "0.0.5" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.0.5" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.0.5" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "AST-based Rust emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.4" }
+wesley-core = { path = "../wesley-core", version = "0.0.5" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "AST-based TypeScript emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.0.4" }
+wesley-core = { path = "../wesley-core", version = "0.0.5" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md
+++ b/docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md
@@ -2,7 +2,7 @@
 title: Product Leftover Cleanup
 legend: OWN
 packet: 0012-product-leftover-cleanup
-status: active
+status: shipped
 release: v0.0.5
 ---
 
@@ -167,6 +167,32 @@ This slice:
 - exits nonzero if any fixture fails, so stale or partial parity fixtures do
   not pass silently
 - updates the IR truth manifest with the current stable L1 hashes
+
+## Playback
+
+1. Active backlog lanes no longer keep Echo, jedit, Continuum, `warp-ttd`,
+   `git-warp`, PostgreSQL, or Supabase product work in Wesley's release center.
+2. The old `docs/method/backlog/v0.1.0/` lane is graveyard context, not an
+   active release lane.
+3. Product-era docs that presented SQL/RLS/PostgreSQL behavior as generic
+   Wesley behavior were retired to historical context.
+4. The README/progress surface now excludes extracted product scaffolding and
+   keeps `@wesley/runtime-node` framed as shared module-loading and parsing
+   infrastructure.
+5. Rust L1 fixture regeneration now uses the native Wesley CLI. The future
+   JS/Rust parity comparator remains explicit follow-up work rather than an
+   implied property of `pnpm fixtures:ir`.
+
+## Retrospective
+
+This release cleaned the queue and front door before attempting deeper Rust
+parity work. That was the right order: the repository now says where product
+and database concerns belong, and the remaining near-term work is compiler
+truth, module-boundary enforcement, and compatibility evidence.
+
+Do not use this packet as justification for new product behavior in Wesley.
+The next work should either strengthen the domain-empty compiler boundary or
+move external behavior to its owning module or sibling repository.
 
 ## Non-Goals
 

--- a/docs/method/backlog/README.md
+++ b/docs/method/backlog/README.md
@@ -11,8 +11,8 @@ Lanes:
 - `bad-code/` for tech debt that is worth naming
 
 The old `v0.1.0/` release lane was retired to
-`docs/method/graveyard/v0.1.0/` during the v0.0.5 clean-house release. Treat it
-as historical/extraction context, not an active queue.
+`docs/method/graveyard/v0.1.0/` during the clean-house release. Treat it as
+historical/extraction context, not an active queue.
 
 When an item is pulled into `docs/design/<cycle>/`, the backlog file is removed.
 Work should not live in two places at once.

--- a/docs/method/releases/README.md
+++ b/docs/method/releases/README.md
@@ -4,6 +4,7 @@ Store internal release artifacts here.
 
 ## Available Releases
 
+- [Wesley v0.0.5](./v0.0.5/release.md)
 - [Wesley v0.0.4](./v0.0.4/release.md)
 
 Each shaped release should have a versioned directory such as

--- a/docs/method/releases/v0.0.5/release.md
+++ b/docs/method/releases/v0.0.5/release.md
@@ -1,0 +1,67 @@
+# Wesley v0.0.5 Release Packet
+
+## Summary
+
+Wesley `0.0.5` is a clean-house release for the domain-empty compiler
+direction. It closes the product-leftover cleanup packet, stabilizes obvious
+IR truth drift, and prepares the repo for explicit Rust parity and module
+boundary work.
+
+## Included Scope
+
+- Backlog cleanup for old Echo, jedit, Continuum, PostgreSQL, Supabase, and
+  `v0.1.0` release-lane residue.
+- Root governance docs that frame Wesley as a module-first semantic contract
+  compiler and assurance toolchain.
+- Product-era docs moved to historical graveyard context.
+- README/progress metadata cleanup for extracted product scaffolding.
+- Stable JS IR metadata for parity-sensitive bytes.
+- JS object type extension folding and validation in the GraphQL adapter.
+- Native Rust L1 fixture regeneration through `pnpm fixtures:ir`.
+- pnpm dependency override updates that clear the release dependency audit.
+- Release notes, internal release packet, and Rust crate version bump to
+  `0.0.5`.
+
+## Sponsored Users
+
+- Wesley maintainers can pull active work without rediscovering which repo owns
+  product or database concerns.
+- Rust-core maintainers get a cleaner fixture and metadata base for parity
+  work.
+- Echo, jedit, Continuum, `warp-ttd`, `git-warp`, and `wesley-postgres`
+  maintainers can treat Wesley as compatibility evidence and compiler truth,
+  not as a hidden owner of their product behavior.
+
+## Version Justification
+
+This is a patch release because it tightens repository truth, Rust fixture
+generation, and JS lowering compatibility behavior without introducing a new
+public runtime feature or intentionally breaking current Rust crate APIs.
+
+The release does change maintainer-facing behavior: `pnpm fixtures:ir` now
+regenerates Rust L1 fixture outputs through the native CLI. That is compatible
+with the direction of the Rust crates and appropriate for the next `0.0.x`
+patch tag.
+
+## Non-Goals
+
+- No Echo, jedit, Continuum, `warp-ttd`, or `git-warp` product changes.
+- No PostgreSQL/Supabase feature implementation in Wesley.
+- No JS/Rust parity sentinel implementation in this release.
+- No module capability runtime implementation in this release.
+- No npm package version bump; the release tag is for the Rust/repo release
+  line.
+
+## Acceptance
+
+- Rust crate manifests and lockfile use version `0.0.5` for the release set.
+- `CHANGELOG.md` has a `0.0.5` section and compare link.
+- `docs/releases/v0.0.5.md` exists and includes migration guidance.
+- `docs/method/releases/v0.0.5/verification.md` records guard and validation
+  evidence.
+- `docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md` is
+  marked shipped with playback and retrospective notes.
+- Release prep guard passes for `0.0.5`.
+- Package sanity passes for `0.0.5`.
+- Cargo and pnpm dependency audits pass.
+- Full preflight passes before opening the release finalization PR.

--- a/docs/method/releases/v0.0.5/verification.md
+++ b/docs/method/releases/v0.0.5/verification.md
@@ -1,0 +1,48 @@
+# Wesley v0.0.5 Verification
+
+## Discovery
+
+- Repository type: mixed Rust and Node workspace.
+- Rust publishable units: `wesley-core`, `wesley-emit-rust`,
+  `wesley-emit-typescript`, and `wesley-cli`.
+- Node workspace version line: existing `0.1.0` package metadata, not changed
+  by this Rust/repo release.
+- Package managers: Cargo for Rust crates, pnpm for legacy/tooling workspace.
+- Latest reachable release tag before prep: `v0.0.4`.
+- Target version: `0.0.5`.
+- Target tag: `v0.0.5`.
+- Release authority: GitHub Actions tag workflow.
+- Prep branch: `release/v0.0.5-finalize`.
+- Release scope source: PR #511 merged into `main` as
+  `fc826f630a9bede90f330961f8b0c97d71b91936`.
+
+## Guard Evidence
+
+| Command | Result |
+| --- | --- |
+| `git status --porcelain=v1 --branch` | Passed; worktree was clean before release prep. |
+| `git checkout main` | Passed. |
+| `git pull origin main` | Passed; fast-forwarded local `main` to `fc826f63`. |
+| `git checkout -b release/v0.0.5-finalize` | Passed. |
+| `git tag --list 'v0.0.5'` | Passed; no local tag collision. |
+| `git ls-remote --tags origin 'refs/tags/v0.0.5'` | Passed; no remote tag collision. Initial sandboxed run failed on DNS; escalated network run returned no tag. |
+
+## Local Release Prep Evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo xtask docs-check` | Passed. |
+| `cargo clippy --workspace --all-targets -- -D warnings` | Passed. |
+| `cargo xtask release-check` | Passed outside the sandbox. Initial sandboxed run failed because git-backed CLI tests could not access GPG agent state for signed fixture commits. |
+| `cargo xtask release-prep-guard --version 0.0.5` | Passed after removing version-specific release wording from the active backlog README. |
+| `cargo xtask package-crates --version 0.0.5` | Passed. |
+| `cargo audit` | Passed. Initial sandboxed run could not lock the RustSec advisory database under `~/.cargo`; escalated run loaded 1096 advisories and found no vulnerabilities. |
+| `pnpm install` | Passed after adding pnpm overrides for patched transitive dependency versions. Existing peer/deprecation warnings were non-blocking. |
+| `pnpm audit --prod=false` | Passed after dependency overrides; no known vulnerabilities found. Initial run reported `fast-uri`, `brace-expansion`, and `ws` advisories. |
+| `pnpm run preflight` | Passed. |
+| `git diff --check` | Passed. |
+
+## Publication Evidence
+
+Publication is pending merge of the release finalization branch, creation of
+tag `v0.0.5`, and the tag-triggered GitHub Actions release workflow.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ Store user-facing release notes here.
 
 ## Release Notes
 
+- [Wesley v0.0.5](./v0.0.5.md)
 - [Wesley v0.0.4](./v0.0.4.md)
 
 Each release note should live at `docs/releases/vX.Y.Z.md` and include these

--- a/docs/releases/v0.0.5.md
+++ b/docs/releases/v0.0.5.md
@@ -1,0 +1,66 @@
+# Wesley v0.0.5
+
+## Summary
+
+Wesley `0.0.5` is the clean-house release. It makes the repository's active
+docs, backlog, release surface, and fixture tooling match the domain-empty
+compiler direction: Wesley owns compiler truth and generic module/evidence
+plumbing, while product, runtime, and database behavior belongs in owning
+modules or sibling repositories.
+
+## What Changed
+
+- Active backlog and design signposts now treat old Echo, jedit, Continuum,
+  PostgreSQL, and Supabase lanes as historical or external ownership context.
+- The old `docs/method/backlog/v0.1.0/` lane moved to graveyard context.
+- Product-era public docs that presented SQL/RLS/PostgreSQL behavior as
+  generic Wesley behavior were retired.
+- Root governance docs now describe trusted modules, generated artifact review,
+  evidence integrity, and external ownership for product/database policy.
+- README progress metadata no longer presents extracted product scaffolding as
+  active Wesley release progress.
+- JS GraphQL lowering now emits stable metadata for parity-sensitive IR bytes.
+- JS object type extensions are folded into base object definitions before IR
+  construction, with duplicate field and directive validation.
+- `pnpm fixtures:ir` now regenerates tracked Rust L1 `*.l1.json` and
+  `*.l1.hash` files through the native Wesley CLI.
+- Release dependency overrides now force patched transitive `fast-uri`,
+  `brace-expansion`, and `ws` versions so the pnpm audit gate is clean.
+
+## Why It Matters
+
+v0.0.5 gives maintainers a cleaner base for Rust-native compiler work. The
+repository now distinguishes generic Wesley responsibilities from external
+consumer responsibilities, so future IR, module, and compatibility work can
+land without reopening old product-lane confusion.
+
+The fixture generator also now updates the files Rust tests actually consume.
+That makes IR fixture churn easier to review and keeps the future JS/Rust
+parity sentinel separate from Rust L1 golden regeneration.
+
+## Breaking Changes
+
+No runtime API breaking changes are expected for current Rust crate consumers.
+
+Repository automation and documentation consumers should note that historical
+product/database docs moved to graveyard context and that `pnpm fixtures:ir`
+now writes Rust L1 fixture files instead of legacy JS side outputs.
+
+Tooling dependency resolution changed through pnpm overrides. Maintainers
+should run `pnpm install` after pulling this release finalization commit.
+
+## Migration
+
+No migration required for current Rust crate users.
+
+Maintainers who regenerate IR fixtures should review the tracked
+`test/fixtures/ir-parity/*.l1.json` and `*.l1.hash` outputs and should not
+treat `pnpm fixtures:ir` as JS/Rust parity proof. The parity comparator remains
+separate follow-up work.
+
+## Links to deeper docs
+
+- [CHANGELOG](../../CHANGELOG.md)
+- [BEARING](../BEARING.md)
+- [Product Leftover Cleanup](../design/0012-product-leftover-cleanup/product-leftover-cleanup.md)
+- [IR Truth Manifest](../design/0009-rust-core-and-wasm-capability-abi/phase-0-ir-truth-manifest.md)

--- a/package.json
+++ b/package.json
@@ -62,10 +62,13 @@
       "markdown-it@>=13.0.0": ">=14.1.1",
       "brace-expansion@1.1.12": "1.1.14",
       "brace-expansion@2.0.2": "2.0.3",
-      "brace-expansion@5.0.4": "5.0.5",
+      "brace-expansion@5.0.4": "5.0.6",
+      "brace-expansion@5.0.5": "5.0.6",
+      "fast-uri": "3.1.2",
       "picomatch@2.3.1": "2.3.2",
       "picomatch@4.0.3": "4.0.4",
-      "postcss@8.5.6": "8.5.14"
+      "postcss@8.5.6": "8.5.14",
+      "ws@8.18.3": "8.20.1"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,13 @@ overrides:
   markdown-it@>=13.0.0: '>=14.1.1'
   brace-expansion@1.1.12: 1.1.14
   brace-expansion@2.0.2: 2.0.3
-  brace-expansion@5.0.4: 5.0.5
+  brace-expansion@5.0.4: 5.0.6
+  brace-expansion@5.0.5: 5.0.6
+  fast-uri: 3.1.2
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   postcss@8.5.6: 8.5.14
+  ws@8.18.3: 8.20.1
 
 importers:
 
@@ -1460,8 +1463,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1829,8 +1832,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3258,8 +3261,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4295,7 +4298,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4419,7 +4422,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4932,7 +4935,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -5281,7 +5284,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -5434,7 +5437,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -6423,7 +6426,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Finalize the Wesley v0.0.5 clean-house release after PR #511 landed on `main`.

This PR:

- bumps the Rust release crate set from `0.0.4` to `0.0.5`
- moves `CHANGELOG.md` entries into a `0.0.5` section and updates compare links
- adds internal METHOD release artifacts under `docs/method/releases/v0.0.5/`
- adds user-facing release notes at `docs/releases/v0.0.5.md`
- marks design packet `0012-product-leftover-cleanup` as shipped with playback and retrospective notes
- records release verification evidence
- adds pnpm overrides for patched `fast-uri`, `brace-expansion`, and `ws` transitive versions so release dependency audit is clean

## Verification

- `cargo xtask docs-check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo xtask release-check` *(passed outside sandbox; sandboxed run could not access GPG agent state for git-backed fixture commits)*
- `cargo xtask release-prep-guard --version 0.0.5`
- `cargo xtask package-crates --version 0.0.5`
- `cargo audit`
- `pnpm install`
- `pnpm audit --prod=false`
- `pnpm run preflight`
- `git diff --check`
- targeted `markdownlint-cli` over new release docs with repo-local MD013/MD024 exclusions
- pre-push Repository preflight

## After Merge

- create tag `v0.0.5` on the merge commit
- push the tag and monitor the tag-triggered release workflow
- update publication evidence once the workflow and registry visibility are verified