### PR TITLE
docs(boundary): define domain-empty core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **Domain-empty core boundary packet**: Pulled the boundary card into design
+  packet `0014`, defining what generic Wesley owns, what external modules or
+  sibling repos own, and the first docs/dispatch audit that keeps product and
+  database semantics outside the base compiler surface.
 - **Rust IR parity sentinel packet**: Pulled the parity sentinel backlog item
   into design packet `0013`, defining comparator inputs, normalization, hash
   behavior, and failure output for the next JS/Rust parity check.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ extension modules.
 
 For the bounded-autonomy direction, read
 [Wesley North Star](./docs/NORTHSTAR.md). For the SDL boundary, read
-[SDL, Shape, And Law](./docs/SDL.md).
+[SDL, Shape, And Law](./docs/SDL.md). For the active ownership boundary, read
+[Domain-Empty Core Boundary](./docs/design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md).
 
 ---
 
@@ -224,23 +225,23 @@ developer-level operator guide, read [GUIDE.md](./docs/GUIDE.md).
 
 ---
 
-## Extension modules
+## External module examples
 
 A single schema can be compiled by many extensions simultaneously. Each
 extension walks the semantic graph independently and emits its own artifacts.
 Extensions do not need to know about one another.
-These are external owning module families; Wesley preserves the neutral IR
-contract they consume.
+These are externally owned module families; Wesley preserves the neutral IR
+contract and module seam they consume.
 
-| Extension | Responsibility |
+| Module family | External owner | Responsibility |
 | :--- | :--- |
-| Postgres | SQL schemas, migrations, indexes, pgTAP, CRUD helpers |
-| Validation | Runtime and static validation rules |
-| Codec | Binary and runtime codecs |
-| TypeScript | Type contracts and client bindings |
-| Observer | Observation plans and projections |
-| Echo | Runtime law, footprints, observation semantics |
-| Continuum | Deferred protocol generation |
+| Postgres | `wesley-postgres` | SQL schemas, migrations, indexes, pgTAP, CRUD helpers |
+| Validation | loaded module | Runtime and static validation rules |
+| Codec | loaded module | Binary and runtime codecs |
+| TypeScript | Wesley emitter or loaded module | Type contracts and client bindings |
+| Observer | loaded module | Observation plans and projections |
+| Echo | Echo-owned integration | Runtime law, footprints, observation semantics |
+| Continuum | Continuum-owned module/repo | Deferred protocol generation |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,8 @@ authored GraphQL -> Wesley core facts -> module-owned targets / evidence / hosts
 
 Wesley owns compiler truth. External modules and sibling repos own target
 semantics, runtime policy, database behavior, Echo behavior, and deployment.
+The active ownership doctrine is
+[Domain-Empty Core Boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md).
 
 If you are trying to figure out where to start, read
 [ENTRYPOINTS.md](./ENTRYPOINTS.md) first. This document is the deeper structural

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -112,10 +112,11 @@ table-compatible sentinel corpus.
 
 The next pulls are:
 
-1. Broaden parity sentinel coverage only after naming fair projections for
+1. Land domain-empty core boundary enforcement so product and database behavior
+   stays outside generic Wesley. The active packet is
+   [0014-domain-empty-core-boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md).
+2. Broaden parity sentinel coverage only after naming fair projections for
    non-table extension semantics and scale/performance fixtures.
-2. Pull the domain-empty core boundary card into enforcement work so product
-   and database behavior stays outside generic Wesley.
 3. Continue the IR contract fixture lane for stable invalid-SDL diagnostics,
    including codes and spans where available.
 4. Keep `wesley-postgres` visible as the database extraction home and avoid

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -50,6 +50,8 @@ Bring the `whatever` side of `GraphQL -> whatever` through explicit modules.
 
 External modules own target semantics, generators, witness scopes, release
 profiles, and runtime conventions. Wesley core does not own those meanings.
+For the active ownership rule, see
+[design/0014-domain-empty-core-boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md).
 
 The current repository still contains historical Continuum, WARPspace,
 PostgreSQL, and Supabase command/package residue. Treat those paths as

--- a/docs/WARP_DRIFT.md
+++ b/docs/WARP_DRIFT.md
@@ -125,7 +125,7 @@ The highest-value next notes are now:
 - [Module Contract](./design/wesley-module-contract.md)
 - [Module Capability Contract](./design/wesley-module-capability-contract.md)
 - [Extraction Map](./design/wesley-extraction-map.md)
-- [SOURCE_domain-empty-wesley-core-boundary](./method/backlog/asap/SOURCE_domain-empty-wesley-core-boundary.md)
+- [Domain-Empty Core Boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md)
 - Continuum repo:
   `docs/method/backlog/asap/SOURCE_minimum-runtime-boundary-contract-family.md`
 

--- a/docs/design/0014-domain-empty-core-boundary/SOURCE_domain-empty-wesley-core-boundary.md
+++ b/docs/design/0014-domain-empty-core-boundary/SOURCE_domain-empty-wesley-core-boundary.md
@@ -1,8 +1,9 @@
 # Domain-empty Wesley core boundary
 
-- Lane: `asap`
+- Lane: `design/0014-domain-empty-core-boundary`
 - Legend: `SOURCE`
 - Rank: `1`
+- Pulled from: `docs/method/backlog/asap/`
 
 ## Why now
 
@@ -48,6 +49,7 @@ generic toolchain, generic module contracts, and hermetic fixture modules only.
 - `docs/GUIDE.md`
 - `docs/ARCHITECTURE.md`
 - `docs/BEARING.md`
+- `docs/design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md`
 - `docs/design/wesley-module-contract.md`
 - `docs/design/wesley-module-capability-contract.md`
 - `docs/design/wesley-extraction-map.md`

--- a/docs/design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md
+++ b/docs/design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md
@@ -1,0 +1,125 @@
+---
+title: Domain-Empty Core Boundary
+legend: SOURCE
+packet: 0014-domain-empty-core-boundary
+status: active
+release: v0.0.6
+---
+
+# Domain-Empty Core Boundary
+
+## Sponsors
+
+- Human: I can add compiler truth without accidentally turning Wesley back into
+  a product, database, scheduler, or runtime policy repository.
+- Agent: I can decide whether a proposed change belongs in generic Wesley,
+  an external module, `wesley-postgres`, or a product repo before editing code.
+
+## Hill
+
+Wesley has one enforced core boundary: it owns generic GraphQL semantic
+compilation, generic module contracts, and evidence plumbing. The `whatever`
+side of `GraphQL -> whatever` is module-owned.
+
+Product, runtime, database, scheduler, replication, transport, deployment, and
+substrate truth semantics are not Wesley core features.
+
+## Why This Cycle Exists
+
+v0.0.5 cleaned up historical product gravity. v0.0.6 is now deepening Rust IR
+truth and compatibility evidence. That work only stays coherent if the repo
+also blocks new product and database semantics from entering the base platform.
+
+The first Rust IR parity sentinel already gives Wesley a real compatibility
+check. The next risk is not missing another product feature. The risk is
+growing the compiler around old product assumptions while the Rust kernel and
+module surfaces are still settling.
+
+## Boundary Contract
+
+### Wesley Owns
+
+- GraphQL SDL parsing and semantic normalization.
+- Domain-empty L1 IR bytes, hashes, fixture truth, and diagnostics.
+- Generic schema diff, operation selection, directive argument extraction, and
+  emitter primitives.
+- Module discovery, module capability contracts, and module-owned target
+  dispatch.
+- Evidence plumbing for artifacts, realization shells, witness reports, and
+  release checks.
+- Hermetic fixtures that prove compiler behavior without making the fixture's
+  product domain a Wesley responsibility.
+
+### External Owners Own
+
+- Echo law, handles, footprints, runtime admission, and observation semantics.
+- jedit editing behavior and product workflows.
+- Continuum product protocol families and release policy.
+- WARPspace, `warp-ttd`, and `git-warp` runtime or substrate behavior.
+- PostgreSQL and Supabase generation, execution, safety primitives, migrations,
+  row-level security, and pgTAP behavior in `wesley-postgres`.
+- Application deployment, scheduler, transport, replication, and storage
+  semantics.
+
+### Module Seam
+
+External behavior enters Wesley through explicit module capability surfaces.
+The generic compile command must discover targets from registered
+`wesley.targets`; it must not carry built-in product or database target names.
+
+That keeps the base platform auditable:
+
+- no module loaded means no target-specific compile semantics are available
+- a target name means a module registered it
+- target collisions are module capability errors
+- historical package residue does not define current Wesley ownership
+
+## First Slice
+
+This first slice is a boundary-definition and front-door enforcement slice.
+
+It:
+
+- pulls the domain-empty boundary card out of `docs/method/backlog/asap/`
+- creates this packet as the active v0.0.6 boundary doctrine
+- updates front-door docs to point at the packet
+- reframes README extension examples as externally owned module families
+- adds a repo-level Bats check for the packet link, backlog move, and
+  module-owned compile target dispatch
+
+It does not move behavior into `wesley-postgres`, Echo, jedit, Continuum, or
+other sibling repos. Those moves need their own repo-local cycles.
+
+## Playback Questions
+
+1. Does the active design map define what Wesley core owns and what external
+   owners own?
+2. Does the front door link to the boundary packet instead of relying on
+   scattered doctrine?
+3. Does the ASAP queue stop carrying the pulled boundary card?
+4. Does `compile` still discover targets from module capabilities rather than
+   built-in product or database names?
+5. Does PostgreSQL/Supabase behavior point at `wesley-postgres` as the owning
+   home?
+6. Does this slice avoid changing sibling repositories?
+
+## Next Enforcement Slices
+
+- Turn product/database front-door wording into a stronger docs or metadata
+  audit if new residue appears.
+- Add module capability fixture coverage for target dispatch, alias conflicts,
+  and no-module diagnostics.
+- Decide which historical Node package command surfaces are legacy support
+  only, extraction debt, or still generic Wesley toolchain behavior.
+- Keep `wesley-postgres` visible as the database extraction home while leaving
+  its implementation work in that repository.
+
+## Non-Goals
+
+- Do not delete historical design packets that remain useful extraction
+  context.
+- Do not add product, database, runtime, or scheduler semantics while defining
+  the boundary.
+- Do not edit `~/git/wesley-postgres`, Echo, jedit, Continuum, `warp-ttd`, or
+  `git-warp` from this Wesley branch.
+- Do not retire legacy Node lowering in this packet.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,7 @@ Current packets:
 - [`0011`](./0011-causal-suffix-bundle-family-and-runtime-sync/causal-suffix-bundle-family-and-runtime-sync.md): Causal suffix bundle family and runtime sync
 - [`0012`](./0012-product-leftover-cleanup/product-leftover-cleanup.md): Product leftover cleanup for the v0.0.5 clean-house release
 - [`0013`](./0013-rust-ir-parity-sentinel/rust-ir-parity-sentinel.md): Rust IR parity sentinel for the v0.0.6 compiler-truth release
+- [`0014`](./0014-domain-empty-core-boundary/domain-empty-core-boundary.md): Domain-empty Wesley core boundary for the v0.0.6 compiler-truth release
 - [Module Contract](./wesley-module-contract.md): Generic core boundary versus external module-owned domain surfaces
 - [Module Capability Contract](./wesley-module-capability-contract.md): The capability surfaces external modules should implement
 - [Contract / Artifact / Runtime Boundary](./wesley-contract-family-artifact-runtime-value.md): GraphQL-authored families, Wesley-emitted artifacts, and later runtime values

--- a/docs/method/backlog/asap/README.md
+++ b/docs/method/backlog/asap/README.md
@@ -13,6 +13,5 @@ database lanes as Wesley features.
 
 Current near-term pulls:
 
-1. `SOURCE_domain-empty-wesley-core-boundary.md`
-2. `SOURCE_wesley-core-rs-ir-contract-and-fixtures.md`
-3. `OWN_ninelives-resilience-integration.md`
+1. `SOURCE_wesley-core-rs-ir-contract-and-fixtures.md`
+2. `OWN_ninelives-resilience-integration.md`

--- a/scripts/smoke/repo-bats-prepush.sh
+++ b/scripts/smoke/repo-bats-prepush.sh
@@ -24,6 +24,7 @@ files=(
   test/serve-static-unit.bats
   test/serve-static-relative-unit.bats
   test/progress-dry-run.bats
+  test/domain-empty-boundary.bats
   test/ir-fixtures.bats
   test/ir-parity-sentinel.bats
   test/progress-safety.bats

--- a/test/README.md
+++ b/test/README.md
@@ -61,6 +61,7 @@ pnpm run setup:bats-plugins
 BATS_LIB_PATH=packages/wesley-cli/test \
   bats test/serve-static*.bats \
     test/progress-*.bats \
+    test/domain-empty-boundary.bats \
     test/ir-fixtures.bats \
     test/ir-parity-sentinel.bats \
     test/ci-*.bats \

--- a/test/domain-empty-boundary.bats
+++ b/test/domain-empty-boundary.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load 'bats-plugins/bats-support/load'
+load 'bats-plugins/bats-assert/load'
+
+@test "front-door docs point to the domain-empty boundary packet" {
+  run grep -F "[Domain-Empty Core Boundary](./docs/design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md)" README.md
+  assert_success
+
+  run grep -F "[design/0014-domain-empty-core-boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md)" docs/GUIDE.md
+  assert_success
+
+  run grep -F "[Domain-Empty Core Boundary](./design/0014-domain-empty-core-boundary/domain-empty-core-boundary.md)" docs/ARCHITECTURE.md
+  assert_success
+}
+
+@test "domain-empty boundary card is pulled from asap into design" {
+  run test -e docs/method/backlog/asap/SOURCE_domain-empty-wesley-core-boundary.md
+  assert_failure
+
+  run test -e docs/design/0014-domain-empty-core-boundary/SOURCE_domain-empty-wesley-core-boundary.md
+  assert_success
+
+  run grep -F "0014-domain-empty-core-boundary" docs/design/README.md
+  assert_success
+}
+
+@test "compile targets remain module-owned instead of built-in product targets" {
+  run grep -F "listModuleCapabilities(" packages/wesley-cli/src/commands/compile.mjs
+  assert_success
+
+  run grep -F "'wesley'," packages/wesley-cli/src/commands/compile.mjs
+  assert_success
+
+  run grep -F "'targets'" packages/wesley-cli/src/commands/compile.mjs
+  assert_success
+
+  run grep -F "No compile targets are available. Load a Wesley module that registers wesley.targets." packages/wesley-cli/src/commands/compile.mjs
+  assert_success
+
+  run grep -E "['\"](postgres|supabase|echo|continuum|jedit|warp-ttd|ttd)['\"]" packages/wesley-cli/src/commands/compile.mjs
+  assert_failure
+}


### PR DESCRIPTION
## Summary

- pull the domain-empty Wesley core boundary card from `asap/` into design packet `0014`
- define what generic Wesley owns versus what external modules, product repos, and `wesley-postgres` own
- point README, GUIDE, ARCHITECTURE, BEARING, WARP_DRIFT, and the design/backlog indexes at the new packet
- add a repo-level Bats guard for front-door packet links, the backlog move, and module-owned compile target dispatch

## Validation

- `BATS_LIB_PATH=packages/wesley-cli/test bats -t test/domain-empty-boundary.bats`
- `pnpm run lint:docs-whitespace`
- `pnpm run lint:docs-truth`
- `git diff --check`
- `pnpm run preflight`
- `bash scripts/smoke/repo-bats-prepush.sh`
- push hook reran repository preflight and repo Bats smoke suite successfully

## Notes

This slice does not edit `wesley-postgres`, Echo, jedit, Continuum, `warp-ttd`, or `git-warp`. It defines and guards the Wesley-side ownership boundary before deeper module-boundary enforcement work.