### PR TITLE
feat: add rust-native doctor command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **Rust-native doctor command**: Added `wesley doctor` with text and JSON
+  output for narrow Rust-native health checks covering the native CLI, Rust
+  lowerer, normalized SDL hash evidence, and Rust emitter crates without
+  inspecting legacy Node config, plugins, or package state.
 - **Native emit metadata**: `wesley emit rust` and `wesley emit typescript` now
   accept `--metadata-out <path>` to write deterministic JSON sidecars with the
   schema hash, generator identity, generator version, and `rust-native`

--- a/README.md
+++ b/README.md
@@ -181,12 +181,13 @@ cargo xtask preflight
 cargo wesley --help
 ```
 
-The native command can lower schema SDL to L1 IR, compute schema hashes, diff
-schema structure, list schema root operations, emit Rust models and TypeScript
-declarations with root operation bindings, resolve operation selections, and
-extract operation directive arguments.
+The native command can run Rust-native health checks, lower schema SDL to L1
+IR, compute schema hashes, diff schema structure, list schema root operations,
+emit Rust models and TypeScript declarations with root operation bindings,
+resolve operation selections, and extract operation directive arguments.
 
 ```bash
+cargo wesley doctor
 cargo wesley schema lower --schema test/fixtures/ir-parity/small-schema.graphql --json
 cargo wesley schema hash --schema test/fixtures/ir-parity/small-schema.graphql
 cargo wesley schema operations --schema test/fixtures/consumer-models/jedit-hot-text-runtime.graphql --json

--- a/crates/wesley-cli/README.md
+++ b/crates/wesley-cli/README.md
@@ -4,6 +4,10 @@
 Rust compiler kernel, schema inspection commands, schema diffing, and Rust or
 TypeScript emitter commands.
 
+Use `wesley doctor` to run narrow Rust-native health checks for the native CLI,
+Rust lowerer, normalized SDL hash evidence, and Rust emitter crates. It does
+not inspect legacy Node config, plugins, or package state.
+
 Use `wesley normalize-sdl --schema <path>` to print the deterministic,
 extension-folded SDL view produced from Rust compiler facts, or
 `wesley normalize-sdl --schema <path> --hash` to print its SHA-256 evidence

--- a/crates/wesley-cli/src/main.rs
+++ b/crates/wesley-cli/src/main.rs
@@ -47,6 +47,11 @@ fn run(args: Vec<String>) -> Result<u8, CliError> {
             Ok(EXIT_OK)
         }
         Some("normalize-sdl") => run_normalize_sdl_command(&args[1..]),
+        Some("doctor") if wants_help(&args[1..]) => {
+            print_doctor_help();
+            Ok(EXIT_OK)
+        }
+        Some("doctor") => run_doctor_command(&args[1..]),
         Some("schema") => run_schema_command(&args[1..]),
         Some("emit") => run_emit_command(&args[1..]),
         Some("operation") => run_operation_command(&args[1..]),
@@ -71,6 +76,22 @@ fn run_normalize_sdl_command(args: &[String]) -> Result<u8, CliError> {
     }
 
     Ok(EXIT_OK)
+}
+
+fn run_doctor_command(args: &[String]) -> Result<u8, CliError> {
+    let output_format = parse_doctor_options(args)?;
+    let report = build_doctor_report();
+
+    match output_format {
+        DoctorOutputFormat::Text => print_doctor_text(&report),
+        DoctorOutputFormat::Json => print_json(&report)?,
+    }
+
+    if report.ok {
+        Ok(EXIT_OK)
+    } else {
+        Ok(EXIT_FAILURE)
+    }
 }
 
 fn run_schema_command(args: &[String]) -> Result<u8, CliError> {
@@ -249,6 +270,178 @@ fn run_operation_command(args: &[String]) -> Result<u8, CliError> {
         Some(command) => Err(CliError::usage(format!(
             "unknown operation command '{command}'"
         ))),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DoctorOutputFormat {
+    Text,
+    Json,
+}
+
+fn parse_doctor_options(args: &[String]) -> Result<DoctorOutputFormat, CliError> {
+    let mut output_format = DoctorOutputFormat::Text;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => output_format = DoctorOutputFormat::Json,
+            "--format" => {
+                index += 1;
+                let format = required_value(args, index, "--format")?;
+                output_format = match format.as_str() {
+                    "text" => DoctorOutputFormat::Text,
+                    "json" => DoctorOutputFormat::Json,
+                    format => {
+                        return Err(CliError::usage(format!(
+                            "unknown output format '{format}'; expected text or json"
+                        )));
+                    }
+                };
+            }
+            "--help" | "-h" => {
+                return Err(CliError::usage(
+                    "`doctor` help should be handled before option parsing",
+                ));
+            }
+            value if value.starts_with('-') => {
+                return Err(CliError::usage(format!(
+                    "unknown option '{value}' for `doctor`"
+                )));
+            }
+            value => {
+                return Err(CliError::usage(format!(
+                    "unexpected argument '{value}' for `doctor`"
+                )));
+            }
+        }
+
+        index += 1;
+    }
+
+    Ok(output_format)
+}
+
+const DOCTOR_MINIMAL_SDL: &str = "type Query { health: Boolean }\n";
+
+fn build_doctor_report() -> DoctorReport {
+    let checks = vec![
+        DoctorCheck::pass(
+            "native-cli",
+            format!(
+                "wesley-cli {} ({RUST_NATIVE_EXECUTION_MODE})",
+                env!("CARGO_PKG_VERSION")
+            ),
+        ),
+        doctor_lowering_check(),
+        doctor_normalized_sdl_hash_check(),
+        doctor_rust_emitter_check(),
+        doctor_typescript_emitter_check(),
+    ];
+    let ok = checks
+        .iter()
+        .all(|check| check.status == DoctorStatus::Pass);
+
+    DoctorReport {
+        ok,
+        execution_mode: RUST_NATIVE_EXECUTION_MODE,
+        checks,
+    }
+}
+
+fn doctor_lowering_check() -> DoctorCheck {
+    match lower_schema_sdl(DOCTOR_MINIMAL_SDL) {
+        Ok(ir) if !ir.types.is_empty() => DoctorCheck::pass(
+            "rust-core-lowering",
+            "wesley-core lowerer accepts minimal SDL",
+        ),
+        Ok(_) => DoctorCheck::fail(
+            "rust-core-lowering",
+            "wesley-core lowerer returned no types",
+        ),
+        Err(error) => DoctorCheck::fail(
+            "rust-core-lowering",
+            format!("wesley-core lowerer rejected minimal SDL: {error}"),
+        ),
+    }
+}
+
+fn doctor_normalized_sdl_hash_check() -> DoctorCheck {
+    match normalize_schema_sdl(DOCTOR_MINIMAL_SDL) {
+        Ok(normalized) => {
+            let hash = compute_content_hash(&normalized);
+            if hash.len() == 64 && hash.chars().all(|character| character.is_ascii_hexdigit()) {
+                DoctorCheck::pass(
+                    "normalized-sdl-hash",
+                    "normalized SDL hash evidence is available",
+                )
+            } else {
+                DoctorCheck::fail(
+                    "normalized-sdl-hash",
+                    format!("normalized SDL hash had unexpected shape: {hash}"),
+                )
+            }
+        }
+        Err(error) => DoctorCheck::fail(
+            "normalized-sdl-hash",
+            format!("normalized SDL hash evidence failed: {error}"),
+        ),
+    }
+}
+
+fn doctor_rust_emitter_check() -> DoctorCheck {
+    match doctor_emitter_inputs() {
+        Ok((ir, operations)) => {
+            let output = emit_rust_with_operations(&ir, &operations);
+            if output.trim().is_empty() {
+                DoctorCheck::fail("rust-emitter", "wesley-emit-rust returned empty output")
+            } else {
+                DoctorCheck::pass(
+                    "rust-emitter",
+                    format!("wesley-emit-rust {RUST_GENERATOR_VERSION} available"),
+                )
+            }
+        }
+        Err(error) => DoctorCheck::fail(
+            "rust-emitter",
+            format!("wesley-emit-rust input preparation failed: {error}"),
+        ),
+    }
+}
+
+fn doctor_typescript_emitter_check() -> DoctorCheck {
+    match doctor_emitter_inputs() {
+        Ok((ir, operations)) => {
+            let output = emit_typescript_with_operations(&ir, &operations);
+            if output.trim().is_empty() {
+                DoctorCheck::fail(
+                    "typescript-emitter",
+                    "wesley-emit-typescript returned empty output",
+                )
+            } else {
+                DoctorCheck::pass(
+                    "typescript-emitter",
+                    format!("wesley-emit-typescript {TYPESCRIPT_GENERATOR_VERSION} available"),
+                )
+            }
+        }
+        Err(error) => DoctorCheck::fail(
+            "typescript-emitter",
+            format!("wesley-emit-typescript input preparation failed: {error}"),
+        ),
+    }
+}
+
+fn doctor_emitter_inputs() -> Result<(WesleyIR, Vec<wesley_core::SchemaOperation>), WesleyError> {
+    let ir = lower_schema_sdl(DOCTOR_MINIMAL_SDL)?;
+    let operations = list_schema_operations_sdl(DOCTOR_MINIMAL_SDL)?;
+
+    Ok((ir, operations))
+}
+
+fn print_doctor_text(report: &DoctorReport) {
+    for check in &report.checks {
+        println!("[{}] {}", check.status, check.message);
     }
 }
 
@@ -614,6 +807,56 @@ struct EmitMetadata {
     execution_mode: &'static str,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DoctorReport {
+    ok: bool,
+    execution_mode: &'static str,
+    checks: Vec<DoctorCheck>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DoctorCheck {
+    id: &'static str,
+    status: DoctorStatus,
+    message: String,
+}
+
+impl DoctorCheck {
+    fn pass(id: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            status: DoctorStatus::Pass,
+            message: message.into(),
+        }
+    }
+
+    fn fail(id: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            status: DoctorStatus::Fail,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DoctorStatus {
+    Pass,
+    Fail,
+}
+
+impl std::fmt::Display for DoctorStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => write!(formatter, "pass"),
+            Self::Fail => write!(formatter, "fail"),
+        }
+    }
+}
+
 fn print_schema_delta(
     delta: &SchemaDelta,
     output_format: OutputFormat,
@@ -730,6 +973,7 @@ Usage:
 
 Commands:
   normalize-sdl            Print the Rust-core normalized SDL view
+  doctor                   Run Rust-native health checks
   schema lower              Lower GraphQL SDL to Wesley L1 IR JSON
   schema hash               Print the Wesley L1 registry hash for GraphQL SDL
   schema operations         List Query/Mutation/Subscription root operations
@@ -743,6 +987,24 @@ Commands:
 Options:
   -h, --help     Show help
   -V, --version  Show version"
+    );
+}
+
+fn print_doctor_help() {
+    println!(
+        "\
+Wesley native doctor
+
+Rust-native health checks only. This command does not inspect legacy Node,
+pnpm, config modules, or plugin packages.
+
+Usage:
+  wesley doctor [--json]
+  wesley doctor [--format text|json]
+
+Options:
+  --json                 Emit JSON output
+  --format text|json     Output format"
     );
 }
 

--- a/crates/wesley-cli/tests/cli.rs
+++ b/crates/wesley-cli/tests/cli.rs
@@ -12,6 +12,7 @@ fn help_exits_zero_without_footprint_command() {
     assert!(stdout.contains("schema lower"));
     assert!(stdout.contains("schema operations"));
     assert!(stdout.contains("schema diff"));
+    assert!(stdout.contains("doctor"));
     assert!(stdout.contains("emit rust"));
     assert!(stdout.contains("emit typescript"));
     assert!(stdout.contains("operation selections"));
@@ -42,6 +43,71 @@ fn nested_command_help_exits_zero() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     assert!(stdout.contains("wesley schema lower --schema <path>"));
+}
+
+#[test]
+fn doctor_help_exits_zero() {
+    let output = wesley()
+        .args(["doctor", "--help"])
+        .output()
+        .expect("wesley should run");
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+
+    assert!(stdout.contains("Wesley native doctor"));
+    assert!(stdout.contains("wesley doctor [--json]"));
+    assert!(stdout.contains("Rust-native health checks only"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn doctor_reports_rust_native_health_checks_as_text() {
+    let output = wesley().arg("doctor").output().expect("wesley should run");
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+
+    assert!(stdout.contains("[pass] wesley-cli "));
+    assert!(stdout.contains("[pass] wesley-core lowerer accepts minimal SDL"));
+    assert!(stdout.contains("[pass] normalized SDL hash evidence is available"));
+    assert!(stdout.contains("[pass] wesley-emit-rust "));
+    assert!(stdout.contains("[pass] wesley-emit-typescript "));
+    assert!(!stdout.contains("Node.js"));
+    assert!(!stdout.contains("wesley.config.mjs"));
+    assert!(!stdout.contains("Plugins"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn doctor_reports_rust_native_health_checks_as_json() {
+    let output = wesley()
+        .args(["doctor", "--json"])
+        .output()
+        .expect("wesley should run");
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be json");
+
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["executionMode"], "rust-native");
+    assert_eq!(
+        report["checks"]
+            .as_array()
+            .expect("checks should be array")
+            .len(),
+        5
+    );
+    assert_eq!(report["checks"][0]["id"], "native-cli");
+    assert_eq!(report["checks"][1]["id"], "rust-core-lowering");
+    assert_eq!(report["checks"][2]["id"], "normalized-sdl-hash");
+    assert_eq!(report["checks"][3]["id"], "rust-emitter");
+    assert_eq!(report["checks"][4]["id"], "typescript-emitter");
+    assert!(stderr.is_empty());
 }
 
 #[test]

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -178,7 +178,7 @@ exists.
   Echo, or jedit semantics leak into generic output.
 - [x] NR-029 Port or retire legacy `models` command behavior.
 - [x] NR-030 Port or retire legacy `init` command behavior.
-- [ ] NR-031 Port a narrow Rust `doctor` command only for Rust-native health
+- [x] NR-031 Port a narrow Rust `doctor` command only for Rust-native health
   checks.
 - [ ] NR-032 Extract certificate creation/signing/verification commands from the
   compiler front door.

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -32,7 +32,7 @@ or ported. Their migration map lives in
 | Surface                 | Path                                  | Status                              | What it does                                                                                                                                                                                                         |
 | ----------------------- | ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Rust compiler kernel    | `crates/wesley-core/`                 | Canonical for new compiler work     | Lowers GraphQL SDL into domain-empty L1 IR; diffs L1 schema structure; lists schema root operations; resolves operation selections; extracts directive arguments.                                                    |
-| Native Wesley command   | `crates/wesley-cli/`                  | Rust product CLI                    | Provides SDL normalization, schema lowering, schema hashing, schema operation listing, schema diffing, Rust/TypeScript emission, operation selection analysis, and directive argument extraction from Rust crates.    |
+| Native Wesley command   | `crates/wesley-cli/`                  | Rust product CLI                    | Provides Rust-native health checks, SDL normalization, schema lowering, schema hashing, schema operation listing, schema diffing, Rust/TypeScript emission, operation selection analysis, and directive argument extraction from Rust crates. |
 | Rust model emitter      | `crates/wesley-emit-rust/`            | Rust projection crate               | Emits Rust data models and root operation request/response bindings from Wesley L1 IR plus `SchemaOperation` data through a structured Rust item/type AST and printer.                                               |
 | Rust TypeScript emitter | `crates/wesley-emit-typescript/`      | Rust projection crate               | Emits TypeScript declarations, root operation request/response bindings, and operation metadata constants from Wesley L1 IR plus `SchemaOperation` data through a structured TypeScript declaration AST and printer. |
 | Repo automation         | `xtask/`                              | Current Rust maintenance front door | Runs docs checks, Rust tests, native preflight, release checks, and the legacy preflight bridge.                                                                                                                     |
@@ -60,6 +60,8 @@ It can:
 - emit TypeScript declarations and operation bindings through a Rust AST/printer path
 - write deterministic emit metadata sidecars with schema hash, generator
   identity, generator version, and execution mode
+- run narrow Rust-native health checks without inspecting legacy Node config,
+  plugins, or package state
 - resolve GraphQL operation selection paths
 - resolve schema-coordinate selections when schema SDL is available
 - extract arbitrary operation directive arguments as data
@@ -67,6 +69,8 @@ It can:
 The native CLI exposes those facts through:
 
 ```bash
+wesley doctor
+wesley doctor --json
 wesley normalize-sdl --schema <path>
 wesley normalize-sdl --schema <path> --hash
 wesley schema lower --schema <path> --json

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -14,6 +14,7 @@ Compile authored GraphQL into generic or explicitly selected generated
 artifacts.
 
 - **Inspect native CLI**: `cargo wesley --help`
+- **Doctor native CLI**: `cargo wesley doctor`
 - **Install alpha from crates.io**: `cargo install wesley-cli --version 0.0.4`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Rust preflight**: `cargo xtask preflight`
@@ -27,6 +28,9 @@ Echo-specific footprint honesty checks.
 Use `wesley normalize-sdl --schema <path>` when you need the consolidated,
 sorted SDL view that the Rust compiler sees before emission or diffing. Add
 `--hash` when you need stable evidence bytes for a normalized SDL snapshot.
+Use `wesley doctor` when you need a narrow Rust-native health check for the
+native CLI, Rust lowerer, normalized SDL hashing, and Rust emitter crates. It
+does not inspect legacy Node config, plugins, or package state.
 
 Use `cargo install wesley-cli --version 0.0.4` when you want the published
 alpha `wesley` binary on your PATH. Use

--- a/docs/design/0017-rust-native-front-door-and-node-retirement/LEGACY_COMMAND_DECISIONS.md
+++ b/docs/design/0017-rust-native-front-door-and-node-retirement/LEGACY_COMMAND_DECISIONS.md
@@ -18,10 +18,12 @@ belong in external modules or owning repos.
 | `zod` | Extract from core Wesley. | Zod is a JavaScript validation target, not compiler truth. It can be valuable as an external module or package, but it should not force a Rust Zod emitter crate into the core retirement path. |
 | `models` | Retire from core Wesley. | Model-class scaffolding is target/application ergonomics. The retained generic model facts now appear through Rust and TypeScript emitters; richer model classes need an owning target module. |
 | `init` | Retire legacy scaffolding. | The historical `init` shape can smuggle product conventions into generic Wesley. A future native `init` may create a tiny generic starter schema, but that is a new proposal, not a port of the Node command. |
+| `doctor` | Port a narrow Rust-native health check. | The retained native command checks only the Rust CLI, Rust lowerer, normalized SDL hash evidence, and Rust emitter crates. Node version, config, plugin, and package diagnostics remain legacy-only. |
 
 ## Current Native Replacement
 
 ```bash
+wesley doctor
 wesley emit rust --schema <path> --out <path> --metadata-out <path>
 wesley emit typescript --schema <path> --out <path> --metadata-out <path>
 ```

--- a/docs/design/0017-rust-native-front-door-and-node-retirement/NODE_RETIREMENT_LEDGER.md
+++ b/docs/design/0017-rust-native-front-door-and-node-retirement/NODE_RETIREMENT_LEDGER.md
@@ -45,7 +45,7 @@ The machine-readable CI/review export lives beside this document as
 | `models` | `packages/wesley-cli/src/commands/models.mjs` | Retire from core | Model-class scaffolding is not compiler truth; retained generic model facts live in Rust and TypeScript emitters. |
 | `diff` | `packages/wesley-cli/src/commands/diff.mjs` | Ported for L1 structure | `wesley schema diff` owns generic schema diff; operation-argument deltas remain separate. |
 | `init` | `packages/wesley-cli/src/commands/init.mjs` | Retire legacy scaffolding | Future native `init` may only create tiny generic starter schemas and must be designed as new work, not as a Node port. |
-| `doctor` | `packages/wesley-cli/src/commands/doctor.mjs` | Port narrow | Rust-native health checks only. |
+| `doctor` | `packages/wesley-cli/src/commands/doctor.mjs` | Narrow port complete | `wesley doctor` runs Rust-native health checks only; legacy Node config, plugin, and package diagnostics stay legacy-only. |
 | `validate-bundle` | `packages/wesley-cli/src/commands/validate-bundle.mjs` | Defer | Port only if Rust evidence bundles remain Wesley-owned. |
 | `runs` | `packages/wesley-cli/src/commands/runs.mjs` | Extract or defer | Runtime ledger inspection belongs with assurance/runtime evidence if not compiler-core. |
 | `cert-create` | `packages/wesley-cli/src/commands/cert-create.mjs` | Extract | Certificate workflow exits the compiler front door. |

--- a/docs/design/0017-rust-native-front-door-and-node-retirement/rust-native-front-door-and-node-retirement.md
+++ b/docs/design/0017-rust-native-front-door-and-node-retirement/rust-native-front-door-and-node-retirement.md
@@ -105,9 +105,15 @@ Native Wesley keeps explicit generic emit commands for retained model and
 operation-binding output:
 
 ```bash
+wesley doctor
 wesley emit rust --schema <path> --out <path> --metadata-out <path>
 wesley emit typescript --schema <path> --out <path> --metadata-out <path>
 ```
+
+The native `doctor` command is intentionally narrow: it checks only the Rust
+CLI, Rust lowerer, normalized SDL hash evidence, and Rust emitter crates. It
+does not recreate the legacy Node command's config, plugin, package, or Node
+runtime diagnostics.
 
 The legacy umbrella `generate` command is being replaced by these explicit
 native commands plus external modules for target-owned outputs. Legacy `zod`,


### PR DESCRIPTION
## Summary

Adds a narrow Rust-native `wesley doctor` command for Node retirement slice NR-031. The command checks the native CLI, Rust lowerer, normalized SDL hash evidence, and Rust emitter crates, with text and JSON output. It intentionally does not inspect legacy Node config, plugins, package state, or runtime diagnostics.

Updates the public command maps, CLI README, design packet 0017, the Node retirement ledger, CHANGELOG, and BEARING checklist progress.

## Why

The retirement campaign needs Rust-native health checks before the historical Node doctor can stop looking like a product front door. This keeps the native command useful without recreating the legacy Node diagnostic surface.

## Validation

- `cargo test -p wesley-cli doctor_ -- --nocapture`
- `cargo test -p wesley-cli --test cli -- --nocapture`
- `cargo wesley doctor --json`
- `cargo xtask docs-check`
- `cargo test -p wesley-cli -- --nocapture`
- `cargo xtask preflight`
- `pnpm run preflight`
- pre-push Repository preflight

## Retirement Progress

- Completes NR-031.
- Next slice: NR-032 extract certificate creation/signing/verification commands from the compiler front door.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wesley doctor` command for Rust-native health checks, supporting both text and JSON output formats

* **Documentation**
  * Updated README, user guides, CLI documentation, and design specifications to document the new `wesley doctor` command and mark the corresponding retirement task as complete

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/wesley/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->