### PR TITLE
docs(release): refresh v0.1.0 signposts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 No unreleased changes.
 
-## [0.1.0] - 2026-06-23
+## [0.1.0] - 2026-06-24
 
 ### Added
 
@@ -64,6 +64,12 @@ No unreleased changes.
   tracker. Former filesystem backlog cards were migrated to GitHub Issues with
   Method lane/legend labels, and the local backlog tree now points to the
   archived migration evidence under `docs/method/graveyard/`.
+- **Release signpost accuracy**: Refreshed README, GUIDE, ENTRYPOINTS,
+  ARCHITECTURE, TECHNICAL_TEARDOWN, release packet signposts, release runbooks,
+  and xtask help so `0.1.0` describes the current LE-binary codec-plan release,
+  names the shared `wesley-emit-codec` crate, distinguishes pre-tag source
+  checkout usage from published crates.io installs, and marks the superseded
+  `v0.0.6` planning packet as historical context.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ decode API cleanup needed to keep Rust and TypeScript codec emitters aligned:
   required shape at the generated boundary.
 
 This release also carries the accumulated Rust-native compiler hardening,
-strict preflight, and Holmes law-assurance foundation work that had been staged
-under `[Unreleased]`.
+strict preflight, and Holmes law-assurance foundation work that was staged
+before the `0.1.0` release packet was finalized.
 
 For the complete release history, read [CHANGELOG.md](./CHANGELOG.md).
 
@@ -94,19 +94,19 @@ flowchart LR
   IR --> EA[Emitted Artifacts]
 ```
 
-One schema can now drive many outputs simultaneously:
+One schema can now drive multiple outputs without making those outputs peer
+authorities. The current Wesley core ships:
 
-- TypeScript contracts
-- Rust bindings
-- SQL schemas and migrations
-- pgTAP test suites
-- Runtime manifests
-- Codecs
-- Validators
-- Observer plans
-- Transport bindings
+- TypeScript declarations and operation bindings
+- Rust models and operation bindings
+- TypeScript and Rust LE-binary codecs
+- Schema hashes, schema diffs, and operation facts
+- `weslaw/v1` Law IR, hashes, coverage, and bundle metadata
 
-This alignment happens automatically, eliminating hand-maintained drift.
+Target-owned modules can consume the same compiler facts to produce SQL
+schemas, migrations, validators, observer plans, runtime manifests, transport
+bindings, or other domain artifacts. That alignment eliminates hand-maintained
+drift without moving domain ownership into Wesley core.
 
 ---
 
@@ -269,7 +269,7 @@ contract and module seam they consume.
 | :------------ | :-------------------------------- | ----------------------------------------------------- |
 | Postgres      | `wesley-postgres`                 | SQL schemas, migrations, indexes, pgTAP, CRUD helpers |
 | Validation    | external target/module            | Runtime and static validation rules                   |
-| Codec         | external target/module            | Binary and runtime codecs                             |
+| Codec         | Wesley emitter or external target | Binary and runtime codecs                             |
 | TypeScript    | Wesley emitter or external target | Type contracts and client bindings                    |
 | Observer      | external target/module            | Observation plans and projections                     |
 | Echo          | Echo-owned integration            | Runtime law, footprints, observation semantics        |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,11 +32,12 @@ The repo is now split into three practical layers:
    structure, lists schema root operations, and exposes generic operation facts.
 2. **Native CLI / body**: `crates/wesley-cli` is the Rust product command. It
    exposes schema lowering, schema hashing, schema operation listing, schema
-   diffing, Rust/TypeScript emission, operation selection analysis, and
+   diffing, Rust/TypeScript emission, LE-binary codec emission, `weslaw`
+   validation/diff/coverage commands, operation selection analysis, and
    directive argument extraction from Rust crates.
 3. **Rust Holmes assurance foundation**: `crates/wesley-holmes` is the new
    law-assurance foundation for Holmes evidence, versioning, ports, and future
-   reports. It consumes Wesley-published artifacts and does not expose product
+   reports. It consumes Wesley compiler artifacts and does not expose product
    CLI commands yet.
 4. **Non-compiler JavaScript surfaces**: `packages/` now contains Holmes
    assurance tooling and browser/Bun/Deno host smoke experiments only. These
@@ -58,6 +59,7 @@ flowchart LR
     subgraph WesleyRepo["Wesley repository"]
         subgraph Rust["Rust workspace"]
             Core[wesley-core]
+            CodecPlan[wesley-emit-codec]
             RustEmitter[wesley-emit-rust]
             TsEmitter[wesley-emit-typescript]
             RustHolmes[wesley-holmes]
@@ -88,10 +90,13 @@ flowchart LR
     SDL --> Core
     OP --> Core
     NativeCli --> Core
+    NativeCli --> CodecPlan
     NativeCli --> RustEmitter
     NativeCli --> TsEmitter
     RustEmitter --> Core
+    RustEmitter --> CodecPlan
     TsEmitter --> Core
+    TsEmitter --> CodecPlan
     RustHolmes --> Fixtures
     Xtask --> NativeCli
     Xtask --> Core
@@ -118,6 +123,7 @@ semantics.
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `crates/wesley-core/`                                                    | Rust compiler kernel. Parses/lower SDL to domain-empty L1 IR, diffs L1 schema structure, lists schema root operations, and analyzes operation documents.                 |
 | `crates/wesley-cli/`                                                     | Native Rust `wesley` binary for schema deltas, schema hashes, Rust/TypeScript artifacts, and operation facts.                                                            |
+| `crates/wesley-emit-codec/`                                               | Shared LE-binary codec planning crate consumed by Rust and TypeScript codec emitters.                                                                                    |
 | `crates/wesley-emit-rust/`                                               | Rust projection crate. Builds a Rust item/type AST from L1 IR and `SchemaOperation` data, then prints deterministic model and operation declarations.                    |
 | `crates/wesley-emit-typescript/`                                         | Rust TypeScript projection crate. Builds a TypeScript declaration AST from L1 IR and `SchemaOperation` data, then prints deterministic model and operation declarations. |
 | `crates/wesley-holmes/`                                                  | Rust Holmes law-assurance foundation. Defines pure domain models, deterministic ports/fakes, evidence bundle validation, artifact path resolution, and version diagnostics without exposing public CLI commands yet. |
@@ -201,7 +207,9 @@ deployments, or runtime policy.
 projection crates. They do not parse or rewrite existing source files. They take
 `WesleyIR` for models and, when available, `SchemaOperation` data for root
 operation bindings. Each crate builds structured language-specific ASTs and
-prints deterministic artifacts.
+prints deterministic artifacts. LE-binary codec emission now shares the
+language-neutral plan from `crates/wesley-emit-codec` before each emitter
+renders language-specific syntax.
 
 This generation path does not need tree-sitter. Tree-sitter, SWC, oxc, or a
 similar parser becomes relevant when Wesley needs to inspect or edit existing
@@ -595,6 +603,9 @@ Wesley currently does these things in this repo:
 - Resolves operation selection paths in schema-coordinate mode.
 - Extracts operation directive arguments by directive name.
 - Provides a native Rust workspace preflight and release check.
+- Emits Rust and TypeScript models, operation bindings, and LE-binary codecs.
+- Validates, lints, diffs, explains, rebinds, and reports coverage for
+  `weslaw/v1` documents.
 - Maintains non-compiler JavaScript tooling only where it has an explicit owner.
 - Maintains docs, schemas, fixtures, CI scripts, and design packets around the
   broader compiler-and-assurance system.

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -159,11 +159,14 @@ Wesley crates when paired with an exact matching `version`.
 ### Phase 3: Documentation
 
 1. Locate `[Unreleased]` in `CHANGELOG.md`.
-2. `ABORT` if `[Unreleased]` is missing or empty.
-3. Rename it to `[X.Y.Z] - YYYY-MM-DD` using the target version and UTC date.
+2. If the release has not been shaped yet, `ABORT` when `[Unreleased]` is
+   missing or empty.
+3. If the release has already been shaped, verify the exact
+   `[X.Y.Z] - YYYY-MM-DD` section exists and `[Unreleased]` contains no changes
+   that should be pulled into the tag.
 4. Preserve the existing changelog style, anchors, and compare links.
 5. Find or create `## What's New in vX.Y.Z` in `README.md`.
-6. Write a concise user-facing summary.
+6. Write or verify a concise user-facing summary.
 7. Ensure `README.md` visibly links to `CHANGELOG.md`.
 8. Extract the final changelog section for GitHub Release notes.
 
@@ -174,13 +177,9 @@ Wesley crates when paired with an exact matching `version`.
 The Rust gauntlet for Wesley is:
 
 ```bash
-cargo xtask docs-check
-cargo check --workspace --all-targets
-cargo test --workspace --all-features
-cargo clippy --workspace --all-targets -- -D warnings
-cargo xtask release-check
-cargo audit
 cargo xtask release-prep-guard --version X.Y.Z
+cargo xtask preflight
+cargo xtask release-check
 cargo xtask package-crates --version X.Y.Z
 ```
 

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -39,6 +39,7 @@ For example, tag `v0.1.0-alpha.1` requires every published Wesley crate to have
 | Crate                    | Publishes      | Purpose                                                                                              |
 | ------------------------ | -------------- | ---------------------------------------------------------------------------------------------------- |
 | `wesley-core`            | library        | GraphQL lowering, schema hashing, schema diffing, operation analysis, and directive data extraction. |
+| `wesley-emit-codec`      | library        | Shared LE-binary codec planning consumed by the Rust and TypeScript codec emitters.                  |
 | `wesley-emit-rust`       | library        | Rust model and operation-binding projection from Wesley IR.                                          |
 | `wesley-emit-typescript` | library        | TypeScript declaration and operation-binding projection from Wesley IR.                              |
 | `wesley-cli`             | binary package | Installs the `wesley` command.                                                                       |

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -181,6 +181,7 @@ The Rust gauntlet for Wesley is:
 cargo xtask release-prep-guard --version X.Y.Z
 cargo xtask preflight
 cargo xtask release-check
+cargo audit
 cargo xtask package-crates --version X.Y.Z
 ```
 

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -205,11 +205,11 @@ Packaging sanity must fail on:
 - unresolved workspace references
 - registry-incompatible dependencies
 
-### Phase 5: Commit And Tagging
+### Phase 5: Commit And Main Sync
 
 1. Summarize the final diff.
 2. Stage all release-prep changes.
-3. Create exactly one release commit:
+3. Create exactly one release-prep commit on a release branch:
 
 ```bash
 git commit -m "chore(release): vX.Y.Z"
@@ -221,7 +221,16 @@ For prereleases:
 git commit -m "chore(release): vX.Y.Z-alpha.1"
 ```
 
-4. Create exactly one signed tag:
+4. Land the release-prep change through the protected `main` branch.
+5. Fetch `origin/main` and tags.
+6. Check out local `main` at `origin/main`.
+7. Verify `HEAD` equals `origin/main`.
+8. Verify the release commit is already reachable from origin/main before
+   creating the tag.
+
+### Phase 6: Tag, Delivery, Release, And Monitoring
+
+1. Create exactly one signed tag on the synced `main` commit:
 
 ```bash
 git tag -s vX.Y.Z -m "release: vX.Y.Z"
@@ -233,19 +242,16 @@ For prereleases:
 git tag -s vX.Y.Z-alpha.1 -m "release: vX.Y.Z-alpha.1"
 ```
 
-5. Verify the tag points at the release commit.
-6. Verify the tag signature.
-7. `ABORT` if verification fails.
-
-### Phase 6: Delivery, Release, And Monitoring
-
-1. Push `main`.
-2. Push the exact release tag.
-3. Let GitHub Actions run the tag-triggered release workflow.
-4. Create or verify the GitHub Release from the versioned changelog notes.
-5. Monitor every workflow triggered by the release commit and tag.
-6. Do not infer success from queued or in-progress jobs.
-7. Verify crates.io directly for every published crate.
+2. Verify the tag points at the synced `main` commit.
+3. Verify the tag signature.
+4. `ABORT` if verification fails.
+5. Run `cargo xtask release-guard --tag vX.Y.Z`.
+6. Push the exact release tag only.
+7. Let GitHub Actions run the tag-triggered release workflow.
+8. Create or verify the GitHub Release from the versioned changelog notes.
+9. Monitor every workflow triggered by the release tag.
+10. Do not infer success from queued or in-progress jobs.
+11. Verify crates.io directly for every published crate.
 
 `ABORT LOUDLY` if any of these fail:
 

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -8,8 +8,9 @@ Wesley has one intended front door:
 cargo wesley --help
 ```
 
-For installed alpha builds, the crates.io package is `wesley-cli` and the
-installed command is `wesley`:
+For published alpha builds, the crates.io package is `wesley-cli` and the
+installed command is `wesley`. The `0.1.0` install command is valid after the
+tag-driven release workflow publishes that version:
 
 ```bash
 cargo install wesley-cli --version 0.1.0
@@ -32,6 +33,7 @@ smoke experiments outside compiler authority. The migration map lives in
 | ----------------------- | ------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Rust compiler kernel    | `crates/wesley-core/`                 | Canonical for new compiler work     | Lowers GraphQL SDL into domain-empty L1 IR; diffs L1 schema structure; lists schema root operations; resolves operation selections; extracts directive arguments.                                                                             |
 | Native Wesley command   | `crates/wesley-cli/`                  | Rust product CLI                    | Provides Rust-native health checks, SDL normalization, schema lowering, schema hashing, schema operation listing, schema diffing, Rust/TypeScript emission, operation selection analysis, and directive argument extraction from Rust crates. |
+| Shared codec planner    | `crates/wesley-emit-codec/`           | Rust projection support crate       | Lowers L1 IR and selected schema operations into a language-neutral LE-binary codec plan consumed by Rust and TypeScript codec emitters.                                                                                                      |
 | Rust model emitter      | `crates/wesley-emit-rust/`            | Rust projection crate               | Emits Rust data models and root operation request/response bindings from Wesley L1 IR plus `SchemaOperation` data through a structured Rust item/type AST and printer.                                                                        |
 | Rust TypeScript emitter | `crates/wesley-emit-typescript/`      | Rust projection crate               | Emits TypeScript declarations, root operation request/response bindings, and operation metadata constants from Wesley L1 IR plus `SchemaOperation` data through a structured TypeScript declaration AST and printer.                          |
 | Repo automation         | `xtask/`                              | Current Rust maintenance front door | Runs docs checks, Rust tests, native preflight, release checks, and the JavaScript package preflight bridge.                                                                                                                                  |
@@ -54,7 +56,7 @@ It can:
 - list schema root operations with arguments, result types, and directives
 - emit Rust data models and operation bindings through a Rust AST/printer path
 - emit TypeScript declarations and operation bindings through a Rust AST/printer path
-- emit TypeScript little-endian operation-variable codec helpers
+- emit Rust and TypeScript little-endian codec helpers from a shared codec plan
 - write deterministic emit metadata sidecars with schema hash, generator
   identity, generator version, execution mode, and optional law bundle hashes
 - run narrow Rust-native health checks without inspecting legacy Node config,
@@ -135,9 +137,10 @@ compiler work should not depend on them.
 
 ## Crates.io Alpha Packages
 
-The first crates.io alpha is intentionally small:
+The crates.io alpha package set is intentionally small:
 
 - `wesley-core`: compiler kernel library
+- `wesley-emit-codec`: shared LE-binary codec planning crate
 - `wesley-emit-rust`: Rust projection crate
 - `wesley-emit-typescript`: TypeScript projection crate
 - `wesley-cli`: installable CLI package that provides the `wesley` binary

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -89,6 +89,7 @@ wesley law capabilities --law <law.weslaw.yaml> [--json]
 wesley law coverage --schema <path> --law <law.weslaw.yaml> [--profile release|ci-release|local] [--json]
 wesley emit rust --schema <path> --out <path> [--law <path>] [--metadata-out <path>]
 wesley emit typescript --schema <path> --out <path> [--law <path>] [--metadata-out <path>]
+wesley emit le-binary-rust --schema <path> --out <path> [--law <path>] [--metadata-out <path>] [--codec-import <path>]
 wesley emit le-binary-typescript --schema <path> --out <path> [--law <path>] [--metadata-out <path>] [--codec-import <path>]
 wesley operation selections --operation <path> [--schema <path>] [--json]
 wesley operation directive-args --operation <path> --directive <name> --json

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -15,7 +15,7 @@ artifacts.
 
 - **Inspect native CLI**: `cargo wesley --help`
 - **Doctor native CLI**: `cargo wesley doctor`
-- **Install alpha from crates.io**: `cargo install wesley-cli --version 0.1.0`
+- **Install published alpha**: `cargo install wesley-cli --version 0.1.0`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Strict preflight**: `cargo xtask preflight`
 - **Explicit alias**: `cargo xtask strict-preflight`
@@ -34,10 +34,10 @@ native CLI, Rust lowerer, normalized SDL hashing, and Rust emitter crates. It
 does not inspect legacy Node config, plugins, or package state.
 
 Use `cargo install wesley-cli --version 0.1.0` when you want the published
-alpha `wesley` binary on your PATH. Use
-`cargo install --locked --path crates/wesley-cli` when working from this
-checkout. Use `cargo xtask preflight` before opening a PR. This is the strict
-quality gate: it runs `cargo fmt --check`,
+`0.1.0` alpha `wesley` binary on your PATH. Before the release workflow has
+published that version, use `cargo install --locked --path crates/wesley-cli`
+when working from this checkout. Use `cargo xtask preflight` before opening a
+PR. This is the strict quality gate: it runs `cargo fmt --check`,
 `cargo clippy --workspace --all-targets -- -D warnings`,
 `pnpm audit --prod=false --json`, docs checks, workspace tests, and a native
 CLI smoke test. Use `cargo xtask release-check` before cutting native release
@@ -60,6 +60,8 @@ The historical package CLI is retired. Use the native commands:
 
 - **Rust**: `wesley emit rust --schema <path> --out <path> [--law <path>]`
 - **TypeScript**: `wesley emit typescript --schema <path> --out <path> [--law <path>]`
+- **LE Binary Rust**: `wesley emit le-binary-rust --schema <path> --out <path> [--law <path>] [--codec-import <path>]`
+- **LE Binary TypeScript**: `wesley emit le-binary-typescript --schema <path> --out <path> [--law <path>] [--codec-import <path>]`
 - **Emit metadata**: add `--metadata-out <path>` to record schema hash,
   generator identity, generator version, and `rust-native` execution mode. When
   `--law <path>` is supplied, metadata also records `schemaHashQualified`,

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -3,7 +3,8 @@
 # Wesley Technical Teardown
 
 This document is an end-to-end technical explanation of the Wesley repository
-as it exists on the `main` branch on June 15, 2026 (post-PR #604).
+as it exists on the `main` branch on June 24, 2026 (post-PR #619, before the
+`v0.1.0` release tag is cut).
 
 It assumes no prior knowledge of Wesley, its domain, or its implementation.
 The explanation starts with the business and domain concepts, then follows the
@@ -56,9 +57,15 @@ The Rust crates in this checkout declare version `0.1.0`, and the public README
 now carries the matching "What's New in v0.1.0" release note. The changelog's
 dated `0.1.0` section carries the accumulated Rust-native compiler hardening,
 Holmes law evidence gates, release-governance work, and the LE-binary codec-plan
-breaking change. The skipped `v0.0.6` packet remains planning context; the
+breaking change. The skipped `v0.0.6` packet is superseded planning context; the
 public decode-signature change makes this a pre-1.0 minor release instead of a
 patch release.
+
+As of this teardown refresh, `cargo xtask preflight`, `cargo xtask
+release-check`, `cargo xtask package-crates --version 0.1.0`, and
+`cargo xtask release-prep-guard --version 0.1.0` pass locally. The obsolete
+2025 `#60` v0.1.0 umbrella issue has been closed as not planned because it no
+longer represents the current release scope.
 
 The active project direction is to finish the Rust-native compiler spine,
 preserve the domain-empty boundary, and grow Holmes law-assurance ingestion
@@ -123,8 +130,10 @@ mindmap
         emit commands
         operation commands
       Emitters
+        Shared codec plan
         Rust models
         TypeScript declarations
+        Rust LE binary codec
         TypeScript LE binary codec
       xtask
         preflight
@@ -229,19 +238,25 @@ layers are Rust core, native CLI, Rust emitters, Rust Holmes foundation,
 retained non-compiler JavaScript packages, fixtures, schemas, docs, scripts,
 and xtask automation.
 
-PR #600 (merged June 5, 2026) added the Holmes law assurance policy substrate
-and suppression abuse-prevention layer through `HIMP-036`. The campaign stands
-at 36 of 90 implementation slices closed. Concrete adapters, public CLI
-commands, and reporting surfaces are not yet wired (planned in `HIMP-041+` and
-`HIMP-061+`).
+PR #619 merged the `0.1.0` codec-plan release preparation. It added the shared
+`wesley-emit-codec` planning crate, moved Rust and TypeScript LE-binary codec
+emitters onto the same language-neutral plan, made TypeScript public decoders
+return `Result<T>`, and updated the release notes, changelog, and package
+metadata for the pre-1.0 minor release.
+
+The Holmes law assurance foundation remains an unpublished Rust crate. It has
+evidence, ingest, policy, gate, and suppression foundations, but concrete
+public Holmes adapters, public CLI commands, and reporting surfaces are not yet
+wired.
 
 ### Notable Achievements
 
 The project now has native Rust support for schema lowering, normalized SDL,
 schema hashing, structural diffs, root operation catalogs, operation selection
 analysis, directive argument extraction, Rust emission, TypeScript emission,
-little-endian TypeScript codec emission, `weslaw` validation, `weslaw` semantic
-diffs, law coverage, law capabilities, and emit metadata sidecars.
+little-endian Rust and TypeScript codec emission from a shared codec plan,
+`weslaw` validation, `weslaw` semantic diffs, law coverage, law capabilities,
+and emit metadata sidecars.
 
 The assurance side has an unpublished `wesley-holmes` Rust crate with domain
 models, deterministic ports, evidence bundle validation, law diff ingest, law
@@ -258,19 +273,22 @@ intentionally not yet exposed as a public Holmes CLI from Rust.
 
 The README now describes `v0.1.0`, aligned with the `Cargo.toml` crate version
 declared across the workspace. The changelog's dated `0.1.0` section carries
-the Holmes law assurance substrate work (`HIMP-001–036`) plus the LE-binary
-codec-plan and decode-result contract changes.
+the Holmes law assurance substrate work plus the LE-binary codec-plan and
+decode-result contract changes. Release preparation is no longer blocked by
+the stale 2025 `#60` umbrella issue; the current pre-tag guard passes for
+`0.1.0`.
 
 ## Package(s) Overview
 
 ### Rust Workspace As Product Center
 
-The root `Cargo.toml` contains six workspace members:
+The root `Cargo.toml` contains seven workspace members:
 
 ```toml
 [workspace]
 members = [
     "crates/wesley-core",
+    "crates/wesley-emit-codec",
     "crates/wesley-emit-typescript",
     "crates/wesley-emit-rust",
     "crates/wesley-holmes",
@@ -289,9 +307,14 @@ resolver = "2"
 subcommands, writes output files, and converts domain errors into process exit
 codes.
 
+`wesley-emit-codec` is the shared LE-binary codec planner. It consumes L1 IR
+and selected operation facts, then produces language-neutral codec definitions
+used by both LE-binary emitters.
+
 `wesley-emit-rust` and `wesley-emit-typescript` are structured printers. They
 consume L1 IR and root operation facts, build language-specific internal ASTs,
-and then print deterministic source text.
+and then print deterministic source text. Their LE-binary codec paths now share
+the `wesley-emit-codec` plan before rendering Rust or TypeScript syntax.
 
 `wesley-holmes` is the law-assurance foundation. It is not published and has no
 public CLI yet. Its design is hexagonal: pure domain, application services,
@@ -1468,20 +1491,21 @@ for assurance, but they are not compiler semantics.
 
 `xtask` has release-specific guards. Real crates.io publish requires GitHub
 Actions, a tag ref, a clean worktree, matching manifest versions, release
-backlog checks, package file checks, Rust tests, clippy, and release packaging
-checks. It also has a Git identity guard that rejects known fixture identities
-from local config or HEAD metadata.
+issue-tracker checks, package file checks, Rust tests, clippy, and release
+packaging checks. It also has a Git identity guard that rejects known fixture
+identities from local config or HEAD metadata.
 
 ## Test Coverage
 
 ### Rust Workspace Coverage
 
-The Rust workspace registers 279 tests under `cargo test --workspace -- --list`
-as of commit `ca2755ff` (PR #600). The full Rust workspace test run passes:
+The Rust workspace registers 306 tests under `cargo test --workspace -- --list`
+as of the June 24, 2026 `0.1.0` release-candidate state. The full Rust
+workspace test run passes:
 
 ```text
 cargo test --workspace
-279 tests passed
+306 tests passed
 0 failed
 0 ignored
 0 doc tests
@@ -1489,12 +1513,13 @@ cargo test --workspace
 
 The suite covers CLI commands, schema lowering, parser diagnostics, schema
 diffs, operation analysis, resilience policy, runtime optic artifacts, module
-capability registry behavior, Rust emission, TypeScript emission, LE binary
-codec emission, Law IR loading and binding, law diffing, Holmes architecture,
-Holmes evidence validation, law artifact ingest ports, semantic findings, law
-coverage gates, xtask repository guards, law assurance policy parsing and
-normalization, suppression rule matching, and suppression abuse prevention
-(invalid-evidence guard, non-overridable gate guard, expiry guard).
+capability registry behavior, Rust emission, TypeScript emission, shared
+LE-binary codec planning, Rust and TypeScript LE-binary codec emission, Law IR
+loading and binding, law diffing, Holmes architecture, Holmes evidence
+validation, law artifact ingest ports, semantic findings, law coverage gates,
+xtask repository guards, law assurance policy parsing and normalization,
+suppression rule matching, and suppression abuse prevention (invalid-evidence
+guard, non-overridable gate guard, expiry guard).
 
 ### JavaScript Package Coverage
 
@@ -1665,7 +1690,7 @@ Wesley issue runtime authority.
 - Domain-empty L1 IR with deterministic JSON and hashes.
 - Schema diffing with explicit file mode and Git revision mode.
 - Structured Rust and TypeScript emitters.
-- TypeScript little-endian binary codec emission for operation variables.
+- Rust and TypeScript little-endian binary codec emission from a shared plan.
 - `weslaw/v1` loading, binding, hashing, diffing, coverage, and capabilities.
 - Rust Holmes law evidence foundation with deterministic ports and gates.
 - Xtask preflight, docs check, release guard, and package publication guards.
@@ -1708,10 +1733,10 @@ for Rust and JavaScript, then attach those reports to Holmes or CI artifacts.
 
 ### Next Release Narrative
 
-The next crates.io release should decide which remaining Rust-native front-door,
-`weslaw`, Holmes foundation, and release-governance work belongs in a patch
-release versus a later pre-1.0 milestone. Every path must keep README,
-CHANGELOG, tags, and publishable crate manifests aligned.
+After `0.1.0`, the next crates.io release should decide which remaining
+Rust-native front-door, `weslaw`, Holmes foundation, and release-governance work
+belongs in a patch release versus a later pre-1.0 milestone. Every path must
+keep README, CHANGELOG, tags, and publishable crate manifests aligned.
 
 ### Host Package Fate
 

--- a/docs/method/release-runbook.md
+++ b/docs/method/release-runbook.md
@@ -89,17 +89,18 @@ CI state.
 
 1. Review the final diff.
 2. Stage the release changes.
-3. Create the release commit.
-4. Create the release tag.
-5. Verify the tag points at the release commit and satisfies signing
+3. Create the release commit on a release branch.
+4. Land the release commit through the protected `main` branch.
+5. Sync local main to origin/main after the release commit has landed.
+6. Create the release tag on the synced `main` commit.
+7. Verify the tag points at the release commit and satisfies signing
    requirements where applicable.
-6. Run `cargo xtask release-guard --tag vX.Y.Z` after the tag exists locally.
-7. Push `main` and the exact release tag together, for example:
-   `git push origin main vX.Y.Z`.
-8. Create the GitHub Release or equivalent forge release using the versioned
+8. Run `cargo xtask release-guard --tag vX.Y.Z` after the tag exists locally.
+9. Push the exact release tag only, for example: `git push origin vX.Y.Z`.
+10. Create the GitHub Release or equivalent forge release using the versioned
    release notes.
-9. Monitor triggered workflows to completion.
-10. Verify registries directly before claiming publication succeeded.
+11. Monitor triggered workflows to completion.
+12. Verify registries directly before claiming publication succeeded.
 
 ## Evidence
 

--- a/docs/method/release-runbook.md
+++ b/docs/method/release-runbook.md
@@ -64,9 +64,10 @@ per-version release log by default.
 Run validation strictly in order, using repo-native commands where available:
 
 - release pre-flight script, if the repo already has one
+- `cargo xtask release-prep-guard --version X.Y.Z`, before the tag exists
 - `cargo xtask preflight`
 - `cargo xtask release-check`
-- `cargo xtask package-crates --tag vX.Y.Z`
+- `cargo xtask package-crates --version X.Y.Z`, before the tag exists
 - `cargo xtask legacy-preflight`, only when the release changes legacy
   packages, pnpm workspace files, or compatibility-only package metadata
 - build
@@ -92,12 +93,13 @@ CI state.
 4. Create the release tag.
 5. Verify the tag points at the release commit and satisfies signing
    requirements where applicable.
-6. Push `main` and the exact release tag together, for example:
+6. Run `cargo xtask release-guard --tag vX.Y.Z` after the tag exists locally.
+7. Push `main` and the exact release tag together, for example:
    `git push origin main vX.Y.Z`.
-7. Create the GitHub Release or equivalent forge release using the versioned
+8. Create the GitHub Release or equivalent forge release using the versioned
    release notes.
-8. Monitor triggered workflows to completion.
-9. Verify registries directly before claiming publication succeeded.
+9. Monitor triggered workflows to completion.
+10. Verify registries directly before claiming publication succeeded.
 
 ## Evidence
 

--- a/docs/method/releases/README.md
+++ b/docs/method/releases/README.md
@@ -5,7 +5,7 @@ Store internal release artifacts here.
 ## Available Releases
 
 - [Wesley v0.1.0](./v0.1.0/release.md)
-- [Wesley v0.0.6](./v0.0.6/release.md)
+- [Wesley v0.0.6 superseded planning packet](./v0.0.6/release.md)
 - [Wesley v0.0.5](./v0.0.5/release.md)
 - [Wesley v0.0.4](./v0.0.4/release.md)
 

--- a/docs/method/releases/v0.0.6/release.md
+++ b/docs/method/releases/v0.0.6/release.md
@@ -1,5 +1,12 @@
 # Wesley v0.0.6 Release Packet
 
+## Status
+
+Superseded by [Wesley v0.1.0](../v0.1.0/release.md). This packet is retained
+as planning context for the compiler-truth lane that was folded into the
+pre-1.0 minor release after the TypeScript decode API break became part of the
+ship scope.
+
 ## Summary
 
 Wesley `0.0.6` is the compiler-truth release. It turns the v0.0.5 clean-house

--- a/docs/method/releases/v0.0.6/verification.md
+++ b/docs/method/releases/v0.0.6/verification.md
@@ -2,11 +2,10 @@
 
 ## Status
 
-Pending release finalization.
+Superseded by [Wesley v0.1.0](../v0.1.0/release.md).
 
-This file is reserved for the final guard, versioning, tag, publish, and
-registry evidence gathered when v0.0.6 is actually cut. The release-proof PR
-must not fill this with guessed evidence.
+This file is retained as planning context. Do not use it as an active release
+gate, and do not fill it with guessed tag, publish, or registry evidence.
 
 ## Current Pre-Release Evidence
 

--- a/docs/method/releases/v0.1.0/verification.md
+++ b/docs/method/releases/v0.1.0/verification.md
@@ -30,7 +30,8 @@ publication complete.
 
 ## Release-Prep Checks
 
-These checks were run during release preparation on `feat/codec-plan`:
+These checks were run during release preparation on `feat/codec-plan` and
+refreshed on `main` before the release tag:
 
 | Check | Result |
 | --- | --- |
@@ -39,22 +40,42 @@ These checks were run during release preparation on `feat/codec-plan`:
 | `cargo xtask package-crates --version 0.1.0` | Passed after adding `wesley-emit-codec` to the publish set and adding its crate README. |
 | `cargo xtask preflight` | Passed. Includes workspace clippy, pnpm audit, docs checks, workspace tests, doctests, and native CLI smoke. |
 | `cargo xtask release-check` | Passed. Includes strict preflight, optimized CLI build/smoke, and `wesley-core` package check. |
-| `cargo xtask release-prep-guard --version 0.1.0` | Blocked only by the release umbrella #60 after issue-tracker triage; see tracker blocker below. |
+| `cargo xtask release-prep-guard --version 0.1.0` | Passed on `main` after closing the obsolete #60 umbrella issue. |
 
-## Tracker Blocker
+## Tracker Refresh
 
-`cargo xtask release-prep-guard --version 0.1.0` passes local manifest and docs
-checks, then fails the issue-tracker check only for the live release umbrella:
+The original release-prep run failed only on the live release umbrella:
 
 - #60 release: plan and ship v0.1.0
 
-The older noisy blocker set was triaged. Satisfied or obsolete items were
-closed; future Method backlog remains open but no longer counts as release-lane
-ownership unless the issue title/body, milestone, or label owns the exact tag or
-version. Third-party comments and automatic cross-reference chatter are ignored.
+That issue was a stale 2025 umbrella for an older meaning of `v0.1.0`. It was
+closed as not planned on June 24, 2026, because the current release is governed
+by this release packet, current release notes, the changelog, and the release
+guard.
 
-Do not cut the `v0.1.0` tag until #60 is closed as part of the final release
-handoff.
+After #60 was closed, `cargo xtask release-prep-guard --version 0.1.0` passed
+on `main`. The older noisy blocker set was triaged earlier. Satisfied or
+obsolete items were closed; future Method backlog remains open but no longer
+counts as release-lane ownership unless the issue title/body, milestone, or
+label owns the exact tag or version. Third-party comments and automatic
+cross-reference chatter are ignored.
+
+## Final Signpost Refresh
+
+On June 24, 2026, the release-facing signposts were refreshed after #60 was
+closed so README, GUIDE, ENTRYPOINTS, ARCHITECTURE, TECHNICAL_TEARDOWN,
+CHANGELOG, release packets, release runbooks, and xtask help all describe the
+current `0.1.0` release scope.
+
+Validation after that refresh:
+
+| Check | Result |
+| --- | --- |
+| `cargo fmt --all -- --check` | Passed. |
+| `cargo xtask docs-check` | Passed. |
+| `cargo test -p xtask` | Passed. |
+| `cargo xtask release-prep-guard --version 0.1.0` | Passed. |
+| `cargo xtask release-check` | Passed. |
 
 ## Publish Evidence
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -83,4 +83,4 @@ migration for this release.
 - [CHANGELOG](../../CHANGELOG.md)
 - [Wesley v0.1.0 Release Packet](../method/releases/v0.1.0/release.md)
 - [Wesley v0.1.0 Verification](../method/releases/v0.1.0/verification.md)
-- [Wesley v0.0.6 Planning Packet](../method/releases/v0.0.6/release.md)
+- [Superseded v0.0.6 Planning Packet](../method/releases/v0.0.6/release.md)

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -31,3 +31,8 @@ load 'bats-plugins/bats-assert/load'
   run grep -F "Verify the release commit is already reachable from origin/main before" docs/CRATES_IO_RELEASE.md
   assert_success
 }
+
+@test "crates.io pre-tag gauntlet includes Rust dependency audit" {
+  run grep -F "cargo audit" docs/CRATES_IO_RELEASE.md
+  assert_success
+}

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -36,3 +36,8 @@ load 'bats-plugins/bats-assert/load'
   run grep -F "cargo audit" docs/CRATES_IO_RELEASE.md
   assert_success
 }
+
+@test "entrypoints command map lists Rust LE binary emitter" {
+  run grep -F "wesley emit le-binary-rust --schema <path> --out <path>" docs/ENTRYPOINTS.md
+  assert_success
+}

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -15,3 +15,11 @@ load 'bats-plugins/bats-assert/load'
   run grep -F "decodeMakeWidget(bytes)" docs/releases/v0.1.0.md
   assert_success
 }
+
+@test "method release runbook syncs protected main before tag guard" {
+  run grep -F "git push origin main vX.Y.Z" docs/method/release-runbook.md
+  assert_failure
+
+  run grep -F "Sync local main to origin/main after the release commit has landed" docs/method/release-runbook.md
+  assert_success
+}

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -23,3 +23,11 @@ load 'bats-plugins/bats-assert/load'
   run grep -F "Sync local main to origin/main after the release commit has landed" docs/method/release-runbook.md
   assert_success
 }
+
+@test "crates.io release procedure tags only synced origin main" {
+  run grep -F 'Push `main`.' docs/CRATES_IO_RELEASE.md
+  assert_failure
+
+  run grep -F "Verify the release commit is already reachable from origin/main before" docs/CRATES_IO_RELEASE.md
+  assert_success
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3587,6 +3587,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn release_procedure_lists_all_publish_crates() {
+        let doc = include_str!("../../docs/CRATES_IO_RELEASE.md");
+        for publish_crate in PUBLISH_CRATES {
+            let table_entry = format!("| `{}`", publish_crate.name);
+            assert!(
+                doc.contains(&table_entry),
+                "release procedure should list `{}` in Published Units",
+                publish_crate.name
+            );
+        }
+    }
+
     // --- looks_like_file_path ---
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2759,6 +2759,7 @@ Publish options:
   cargo xtask publish-alpha                    Print alpha plan and run safe dry-runs
   cargo xtask publish-alpha --execute          CI tag-only compatibility publish path
   cargo xtask package-crates --tag vX.Y.Z      Check release package file sets
+  cargo xtask package-crates --version X.Y.Z   Check pre-tag release package file sets
   cargo xtask publish-crates --tag vX.Y.Z      Print tag-derived plan and run safe dry-runs
   cargo xtask publish-crates --tag vX.Y.Z --execute  Publish in GitHub Actions only
   cargo xtask release-prep-guard --version X.Y.Z


### PR DESCRIPTION
## Summary

- refresh README, GUIDE, ENTRYPOINTS, ARCHITECTURE, TECHNICAL_TEARDOWN, release packets, release runbooks, and xtask help for the current v0.1.0 release scope
- document that v0.1.0 is the LE-binary codec-plan release and that v0.0.6 is superseded planning context
- record the #60 closure and final signpost validation in the v0.1.0 verification packet

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo xtask docs-check
- cargo test -p xtask
- cargo xtask release-prep-guard --version 0.1.0
- cargo xtask release-check
- pre-push Rust product preflight