### PR TITLE
docs(release): record v0.1.0 publication evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
-No unreleased changes.
+### Changed
+
+- **v0.1.0 release evidence**: Recorded the signed tag, GitHub Release,
+  Release Crates workflow, and crates.io publication evidence for the published
+  `v0.1.0` release.
 
 ## [0.1.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - **v0.1.0 release evidence**: Recorded the signed tag, GitHub Release,
   Release Crates workflow, and crates.io publication evidence for the published
-  `v0.1.0` release.
+  `v0.1.0` release, and tightened the release doctrine so future releases treat
+  the signed tag on synced `main` as the repo release boundary instead of
+  relying on manual post-release evidence backfills.
 
 ## [0.1.0] - 2026-06-24
 

--- a/docs/CRATES_IO_RELEASE.md
+++ b/docs/CRATES_IO_RELEASE.md
@@ -10,8 +10,8 @@ Humans prepare commits and tags; GitHub Actions performs the publish.
 ## Non-Negotiable Policy
 
 1. Releases must only be performed by GitHub Actions.
-2. Releases must only be performed from a versioned `v*` tag whose commit is
-   reachable from `origin/main`.
+2. Releases must only be performed from a versioned `v*` tag created on a
+   synced `main` commit where local `HEAD` equals `origin/main`.
 3. The publish job must only run after the full release gauntlet succeeds.
 4. The publish job must perform its own sanity checks before uploading crates.
 5. A local `cargo publish` is never an official Wesley release.
@@ -19,6 +19,8 @@ Humans prepare commits and tags; GitHub Actions performs the publish.
    GitHub Actions tag workflow whose ref matches the requested release tag.
 7. The legacy `cargo xtask publish-alpha` command remains a dry-run planning
    helper for the first alpha package set; it is not the project release path.
+8. The tagged `main` commit is the repo release boundary. Do not merge manual
+   release-truth or publication-evidence backfills to `main` after publishing.
 
 A valid release tag looks like one of these:
 
@@ -51,6 +53,21 @@ installable package is `wesley-cli`:
 cargo install wesley-cli --version X.Y.Z
 wesley --help
 ```
+
+## Tagged Main Boundary
+
+The signed tag on synced `main` is the source of truth for a release. Every
+repo-resident fact humans intend to ship with the release must already be on
+`origin/main` before the tag is created: version bumps, changelog entries,
+README copy, release notes, release packets, runbook changes, and any
+verification plan.
+
+After the release tag is pushed, publication facts should be verified from the
+tag workflow, GitHub Release, and crates.io registry. Do not merge a manual
+post-release PR solely to backfill release evidence for the version that just
+published. If repo-resident evidence is missing at tag time, treat that as a
+process defect, file follow-up work, and fix the release preparation process
+before the next tag.
 
 ## GitHub Actions Release Shape
 
@@ -170,6 +187,8 @@ Wesley crates when paired with an exact matching `version`.
 6. Write or verify a concise user-facing summary.
 7. Ensure `README.md` visibly links to `CHANGELOG.md`.
 8. Extract the final changelog section for GitHub Release notes.
+9. Verify repo-resident release packets and verification docs do not require a
+   manual post-release merge to become accurate.
 
 ### Phase 4: The Gauntlet
 
@@ -254,6 +273,8 @@ git tag -s vX.Y.Z-alpha.1 -m "release: vX.Y.Z-alpha.1"
 9. Monitor every workflow triggered by the release tag.
 10. Do not infer success from queued or in-progress jobs.
 11. Verify crates.io directly for every published crate.
+12. Do not merge manual release-evidence backfills to `main` for the release
+    that just published.
 
 `ABORT LOUDLY` if any of these fail:
 

--- a/docs/governance/RELEASE_CHECKLIST.md
+++ b/docs/governance/RELEASE_CHECKLIST.md
@@ -47,6 +47,12 @@ and rationale.
       already marked as release issues. Anything knowingly deferred is acknowledged
       in the CHANGELOG or a documented follow-on issue.
 
+- [ ] **Tagged `main` is the release boundary**
+      I confirmed every repo-resident release fact that must ship with this
+      version is already on synced `main` before tagging. The release does not
+      depend on a manual post-publish merge to make README, changelog, release
+      notes, runbooks, or verification docs accurate.
+
 ### Notes
 
 _Add any relevant context, known deferred issues, or reviewer observations._

--- a/docs/governance/RELEASE_POLICY.md
+++ b/docs/governance/RELEASE_POLICY.md
@@ -44,7 +44,7 @@ lacks the human sign-off is not a valid release, and vice versa.
 | 15  | `cargo audit` reports zero vulnerabilities           | shell          |          |
 | 16  | No WIP or `fixup!` commits in release range          | git log        |          |
 | 17  | Working tree is clean                                | git status     |          |
-| 18  | Tag commits to `main`                                | git branch     |          |
+| 18  | Tag is the synced `main` release boundary            | git branch     | reviewer |
 | 19  | CI is green on HEAD at tag time                      | `gh` API       |          |
 | 20  | `BREAKING CHANGE` commits → major/minor version bump | git log        |          |
 | 21  | `cargo doc --workspace` builds with zero warnings    | cargo doc      |          |
@@ -144,11 +144,15 @@ history that was not cleaned up before tagging.
 `git status --porcelain` must return no output. Uncommitted changes at tag
 time indicate the tag does not represent a clean, reproducible state.
 
-### Check 18: Tag on main
+### Check 18: Tagged main release boundary
 
-The tag's commit must be reachable from `origin/main`
-(`git merge-base --is-ancestor`). Releases from feature branches are not
-permitted.
+The release tag must be created from local `main` after fetching `origin/main`
+and verifying local `HEAD` equals `origin/main`. The tag's commit must remain
+reachable from `origin/main` in CI (`git merge-base --is-ancestor`), but
+reachability alone is not enough for human release preparation. Releases from
+feature branches are not permitted, and humans must not merge manual
+release-truth or publication-evidence backfills to `main` after the version has
+published.
 
 ### Check 19: CI Green
 
@@ -199,6 +203,11 @@ are being knowingly shipped without acknowledgment in the CHANGELOG or a
 documented follow-on issue. Automated issue-tracker checks surface issues by
 version label and milestone; they cannot detect an issue that was never labeled
 but is nonetheless blocking.
+
+The reviewer must also confirm that repo-resident release evidence is complete
+enough before tagging. Post-publish facts may live in the GitHub Release,
+workflow logs, and crates.io registry; they should not require a manual
+post-release merge to make the released commit truthful.
 
 ## Policy Violations
 

--- a/docs/method/releases/v0.1.0/verification.md
+++ b/docs/method/releases/v0.1.0/verification.md
@@ -1,8 +1,6 @@
 # Wesley v0.1.0 Verification
 
-This packet records pre-release evidence for `v0.1.0`. Publish evidence must be
-appended after the signed tag, GitHub release, CI run, and crates.io
-publication complete.
+This packet records pre-release and publication evidence for `v0.1.0`.
 
 ## Release Inputs
 
@@ -79,14 +77,26 @@ Validation after that refresh:
 
 ## Publish Evidence
 
-Publication has not been performed in this branch. Append evidence here when
-the release is cut:
+Publication was performed from the signed `v0.1.0` tag after PR #620 merged to
+`main`. The tag-triggered Release Crates workflow completed successfully on
+attempt 2. Attempt 1 stopped before publishing because a legacy shell guard
+matched stale open issue comments; no crates were published before the retry.
 
 | Item | Evidence |
 | --- | --- |
-| Release tag | Pending. |
-| Tag signature | Pending. |
-| GitHub Release | Pending. |
-| CI workflow | Pending. |
-| Crates workflow | Pending. |
-| Crates.io visibility | Pending. |
+| Release tag | `v0.1.0` tag object `94449806ab0b08c2023afe1721c9bcca83174188`; tag commit `214d27a94e4aa46614f32d18daf9827e5dfbd058`. |
+| Tag signature | `git tag -v v0.1.0` reported a good signature from `James Ross <james@flyingrobots.dev>` using RSA key `01A63D8E9DBEEDE32918AF9C39560E0406CA9135`. |
+| GitHub Release | `https://github.com/flyingrobots/wesley/releases/tag/v0.1.0`; published `2026-06-24T15:40:30Z`; not draft; not prerelease. |
+| CI workflow | Tag CI run for `v0.1.0` completed successfully before the release rerun. |
+| Crates workflow | `https://github.com/flyingrobots/wesley/actions/runs/28109147150`, attempt 2, completed successfully at `2026-06-24T15:40:35Z`. |
+| Crates.io visibility | `cargo info` from outside the repository downloaded `wesley-core@0.1.0`, `wesley-emit-codec@0.1.0`, `wesley-emit-rust@0.1.0`, `wesley-emit-typescript@0.1.0`, and `wesley-cli@0.1.0` from crates.io. |
+
+The crates.io API reported the following published versions, all not yanked:
+
+| Crate | Version | Created at |
+| --- | --- | --- |
+| `wesley-core` | `0.1.0` | `2026-06-24T15:39:07.393094Z` |
+| `wesley-emit-codec` | `0.1.0` | `2026-06-24T15:39:15.992300Z` |
+| `wesley-emit-rust` | `0.1.0` | `2026-06-24T15:39:20.464557Z` |
+| `wesley-emit-typescript` | `0.1.0` | `2026-06-24T15:39:23.559832Z` |
+| `wesley-cli` | `0.1.0` | `2026-06-24T15:40:27.522439Z` |


### PR DESCRIPTION
## Summary
- record the signed v0.1.0 tag, GitHub Release, Release Crates run, and crates.io publication evidence
- replace pending v0.1.0 verification rows with concrete release witness data
- add an Unreleased changelog note for the post-release documentation update

## Validation
- git diff --check
- cargo xtask docs-check
- pnpm run preflight
- pre-push Rust product preflight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release rules so the signed tag on synced `main` is treated as the release boundary.
  * Added guidance that release details must already be complete before tagging, and should not depend on post-publish backfills.
  * Updated the release checklist and policy with stricter tag, verification, and no-backfill requirements.
  * Recorded completed `v0.1.0` release evidence, including tag, GitHub Release, workflow runs, and crates.io publication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->