### PR TITLE
docs(method): define release-lane triage flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ Do not audit the repository by recursively walking the filesystem. Follow the au
 
 - **`docs/BEARING.md`**: Current execution gravity and active tensions.
 - **`docs/design/README.md`**: Active design packets and structural doctrine.
-- **GitHub Issues**: The active source of truth for pending work. Use Method lane labels such as `lane:asap`, `lane:bad-code`, `lane:cool-ideas`, and `lane:inbox`.
+- **GitHub Issues**: The active source of truth for pending work. Use
+  `triage:*` labels for unscheduled intake and `lane:vX.Y.Z` labels for work
+  scheduled into a named future release. See
+  **`docs/topics/contributing/triage.md`**.
 - **`docs/method/graveyard/github-issue-migration/`**: Historical evidence for the former filesystem backlog migration.
 
 ### 4. The Proof
@@ -42,7 +45,8 @@ When starting a new session or recovering from context loss:
 
 1. **Read `docs/BEARING.md`** to find the current execution gravity.
 2. **Read `docs/METHOD.md`** to understand the work doctrine.
-3. **Check GitHub Issues with `lane:asap`** for imminent work.
+3. **Check scheduled release lanes and triage queues** using
+   `docs/topics/contributing/triage.md`.
 4. **Check `git log -n 5` and `git status`** to verify the current branch state.
 
 ## End of Turn Checklist
@@ -50,7 +54,8 @@ When starting a new session or recovering from context loss:
 After altering files:
 
 1. **Verify Truth**: Ensure documentation is updated if behavior or structure changed.
-2. **Log Debt**: Add follow-on work as GitHub Issues with the right Method lane labels.
+2. **Log Debt**: Add follow-on work as GitHub Issues with either a `triage:*`
+   intake label or a concrete `lane:vX.Y.Z` release label.
 3. **Commit**: Use focused, conventional commit messages. Propose a draft before executing.
 4. **Validate**: Run `pnpm run preflight`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   Project, and labels. Repo docs now define direction and evidence instead of
   tracking live backlog/progress state.
 
+### Fixed
+
+- **Release guard lane scheduling**: `cargo xtask release-prep-guard` and
+  `cargo xtask release-guard` now block on concrete `lane:vX.Y.Z` release-lane
+  issues for the release being cut, recognize older `lane:v*` labels as
+  prior-version blockers, and no longer depend on the retired `lane:asap` label.
+
 ## [0.1.0] - 2026-06-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Read these surfaces in order:
 - [docs/BEARING.md](docs/BEARING.md) for current direction and tensions
 - [docs/VISION.md](docs/VISION.md) for a bounded executive synthesis
 - [docs/design/README.md](docs/design/README.md) for active design packets and boundary doctrine
-- [docs/method/process.md](docs/method/process.md) for the workflow contract
-- [docs/method/guide.md](docs/method/guide.md) for practical repo guidance
+- [docs/METHOD.md](docs/METHOD.md) for the workflow contract
+- [docs/governance/labels.md](docs/governance/labels.md) for issue and PR label semantics
 - [AGENTS.md](AGENTS.md) for repository-specific automation rules
 
 ## Repository Doctrine
@@ -43,15 +43,16 @@ repos such as `wesley-postgres`.
 
 ## Repo Queue
 
-The queue is in the filesystem:
+GitHub owns live work state:
 
-- `docs/method/backlog/` for queued work
-- `docs/design/` for active cycle packets
-- `docs/method/retro/` for closed cycle packets
+- GitHub Issues hold slices and raw intake.
+- GitHub Milestones hold goalposts and release gates.
+- GitHub Projects provide roadmap board views.
+- GitHub labels carry lane, legend, work-shape, and ownership metadata.
 
-The backlog names what should happen next. Retros, witnesses, and updated repo
-surfaces record what was actually proved. The Chronicle files in the repo root
-are historical archive only.
+Repository files are the evidence ledger. Design packets, witnesses, retros,
+release notes, and signpost docs record stable truth and proof after work is
+done. The Chronicle files in the repo root are historical archive only.
 
 ## Design Requirements
 
@@ -102,24 +103,23 @@ See `docs/method/legends/` for the standing questions each legend owns.
 
 ## Default Loop
 
-1. Pull a backlog item into `docs/design/<cycle>/`, or add a new backlog item
-   first if the work emerged during the current cycle.
-2. Write the design packet with the required METHOD fields.
-3. Write failing tests from the playback questions.
-4. Implement.
-5. Produce a reproducible witness.
-6. Close the cycle with a retro in `docs/method/retro/<cycle>/`.
-7. Reconcile backlog lanes at cycle boundaries, not continuously.
+1. Pull a GitHub Issue with the right goalpost milestone and `lane:*` label.
+2. Add `work-in-progress` while the slice is active.
+3. Write or update the design packet when the work needs durable design context.
+4. Write failing tests from the playback questions or issue acceptance criteria.
+5. Implement.
+6. Produce a reproducible witness.
+7. File follow-up work as GitHub Issues with the right milestone and lane.
 8. Update ship surfaces such as `docs/BEARING.md`, `CHANGELOG.md`, and release
    notes only from merged `main` state.
 
-Review state still rides on branches and PRs. METHOD does not pretend GitHub is
-the queue.
+Review state rides on branches and PRs. GitHub Issues, Milestones, Projects, and
+labels are the live queue.
 
 ## Wesley-Specific Closeout Rules
 
-- Do not append new Chronicle entries. Close the loop in backlog, design,
-  retro, witness, and signpost files instead.
+- Do not append new Chronicle entries. Close the loop in GitHub Issues, design
+  packets, retros, witnesses, and signpost files instead.
 - If docs contradict runtime behavior, fix the docs.
 - If a claimed result cannot be reproduced from committed commands, tests,
   fixtures, or witness artifacts, it is not done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Read these surfaces in order:
 - [docs/VISION.md](docs/VISION.md) for a bounded executive synthesis
 - [docs/design/README.md](docs/design/README.md) for active design packets and boundary doctrine
 - [docs/METHOD.md](docs/METHOD.md) for the workflow contract
+- [docs/topics/contributing/triage.md](docs/topics/contributing/triage.md) for issue triage and release-lane scheduling
 - [docs/governance/labels.md](docs/governance/labels.md) for issue and PR label semantics
 - [AGENTS.md](AGENTS.md) for repository-specific automation rules
 
@@ -48,7 +49,8 @@ GitHub owns live work state:
 - GitHub Issues hold slices and raw intake.
 - GitHub Milestones hold goalposts and release gates.
 - GitHub Projects provide roadmap board views.
-- GitHub labels carry lane, legend, work-shape, and ownership metadata.
+- GitHub labels carry triage state, release scheduling, legend, work-shape,
+  and ownership metadata.
 
 Repository files are the evidence ledger. Design packets, witnesses, retros,
 release notes, and signpost docs record stable truth and proof after work is
@@ -103,14 +105,18 @@ See `docs/method/legends/` for the standing questions each legend owns.
 
 ## Default Loop
 
-1. Pull a GitHub Issue with the right goalpost milestone and `lane:*` label.
+1. Pull a GitHub Issue with the right goalpost milestone and either a
+   `triage:*` intake label or concrete `lane:vX.Y.Z` release label.
 2. Add `work-in-progress` while the slice is active.
-3. Write or update the design packet when the work needs durable design context.
-4. Write failing tests from the playback questions or issue acceptance criteria.
-5. Implement.
-6. Produce a reproducible witness.
-7. File follow-up work as GitHub Issues with the right milestone and lane.
-8. Update ship surfaces such as `docs/BEARING.md`, `CHANGELOG.md`, and release
+3. If the issue is still under `triage:*`, schedule it into a named release,
+   split it, move it, or close it before implementation.
+4. Write or update the design packet when the work needs durable design context.
+5. Write failing tests from the playback questions or issue acceptance criteria.
+6. Implement.
+7. Produce a reproducible witness.
+8. File follow-up work as GitHub Issues with the right goalpost and either a
+   `triage:*` intake label or concrete release lane.
+9. Update ship surfaces such as `docs/BEARING.md`, `CHANGELOG.md`, and release
    notes only from merged `main` state.
 
 Review state rides on branches and PRs. GitHub Issues, Milestones, Projects, and

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -57,6 +57,7 @@ link the relevant goalposts from the gate issue body.
 | **`lane:bad-code`**   | Technical debt that must be addressed.                                       |
 | **`lane:cool-ideas`** | Uncommitted experiments.                                                     |
 | **`lane:inbox`**      | Raw ideas before triage. Remove after milestone assignment or lane decision. |
+| **`lane:planned`**    | Accepted goalpost work that is planned but not active this cycle.            |
 | **`lane:release`**    | Release-gate or release-scoped work, usually in a `Release: ...` milestone.  |
 
 The former filesystem lane `up-next/` was migrated into `lane:asap`.
@@ -71,7 +72,8 @@ Legend labels preserve Wesley's work taxonomy: `legend:SOURCE`,
 Active work should carry `work-in-progress`. Follow-up work belongs in GitHub
 Issues, not in chat, TODO prose, or local-only backlog files.
 
-Open `lane:inbox` should be empty or genuinely raw. If an issue is assigned to a
+Every open issue should carry one `lane:*` label after triage. Open
+`lane:inbox` should be empty or genuinely raw. If an issue is assigned to a
 goalpost milestone, it is no longer inbox.
 
 ## The Cycle Loop

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -36,31 +36,28 @@ The Wesley work doctrine: GitHub Issues, a loop, and honest bookkeeping.
 
 ## Work Hierarchy
 
-| Concept              | Canonical Surface                                                           | Rule                                                       |
-| :------------------- | :-------------------------------------------------------------------------- | :--------------------------------------------------------- |
-| **Goalpost**         | GitHub Milestone named `Goalpost: ...`                                      | Groups implementation slices.                              |
-| **Slice**            | GitHub Issue                                                                | Assigned to exactly one goalpost milestone.                |
-| **Release**          | GitHub Milestone named `Release: vX.Y.Z`                                    | Holds release-gate issues, not every implementation slice. |
-| **Release Gate**     | GitHub Issue with `lane:release`                                            | Links to the goalposts selected for that version.          |
-| **Roadmap Board**    | [Wesley Roadmap Project](https://github.com/users/flyingrobots/projects/18) | Board/view layer over live GitHub Issues.                  |
-| **Lane/Legend/Type** | GitHub labels                                                               | Classification and triage metadata.                        |
+| Concept                     | Canonical Surface                                                           | Rule                                                       |
+| :-------------------------- | :-------------------------------------------------------------------------- | :--------------------------------------------------------- |
+| **Goalpost**                | GitHub Milestone named `Goalpost: ...`                                      | Groups implementation slices.                              |
+| **Slice**                   | GitHub Issue                                                                | Assigned to exactly one goalpost milestone.                |
+| **Release**                 | GitHub Milestone named `Release: vX.Y.Z`                                    | Holds release-gate issues, not every implementation slice. |
+| **Release Gate**            | GitHub Issue in a `Release: vX.Y.Z` milestone                               | Links to the goalposts and release-lane issues selected.   |
+| **Roadmap Board**           | [Wesley Roadmap Project](https://github.com/users/flyingrobots/projects/18) | Board/view layer over live GitHub Issues.                  |
+| **Triage/Lane/Legend/Type** | GitHub labels                                                               | Intake, release scheduling, and classification metadata.   |
 
 GitHub allows only one milestone per issue. Keep implementation issues in their
 goalpost milestones. Put release checklist/gate issues in release milestones and
 link the relevant goalposts from the gate issue body.
 
-## GitHub Issue Lanes
+## GitHub Issue Triage
 
-| Label                 | Purpose                                                                      |
-| :-------------------- | :--------------------------------------------------------------------------- |
-| **`lane:asap`**       | Imminent work; pull into the next cycle.                                     |
-| **`lane:bad-code`**   | Technical debt that must be addressed.                                       |
-| **`lane:cool-ideas`** | Uncommitted experiments.                                                     |
-| **`lane:inbox`**      | Raw ideas before triage. Remove after milestone assignment or lane decision. |
-| **`lane:planned`**    | Accepted goalpost work that is planned but not active this cycle.            |
-| **`lane:release`**    | Release-gate or release-scoped work, usually in a `Release: ...` milestone.  |
+Use [Issue Triage](./topics/contributing/triage.md) for the label contract.
+Short version:
 
-The former filesystem lane `up-next/` was migrated into `lane:asap`.
+- `triage:*` labels are unscheduled intake.
+- `lane:vX.Y.Z` labels are scheduled work for named future releases.
+- Do not use generic `lane:*` labels for active work.
+
 The directory `docs/method/backlog/` is now a compatibility signpost only, not
 the active queue.
 
@@ -72,9 +69,8 @@ Legend labels preserve Wesley's work taxonomy: `legend:SOURCE`,
 Active work should carry `work-in-progress`. Follow-up work belongs in GitHub
 Issues, not in chat, TODO prose, or local-only backlog files.
 
-Every open issue should carry one `lane:*` label after triage. Open
-`lane:inbox` should be empty or genuinely raw. If an issue is assigned to a
-goalpost milestone, it is no longer inbox.
+Every open issue should carry exactly one scheduling-state label: either one
+`triage:*` label or one `lane:vX.Y.Z` label.
 
 ## The Cycle Loop
 

--- a/docs/governance/DOCUMENTATION_STANDARD.md
+++ b/docs/governance/DOCUMENTATION_STANDARD.md
@@ -15,13 +15,14 @@ Live work state belongs in GitHub:
 
 | Work State     | Canonical Surface                                                           |
 | -------------- | --------------------------------------------------------------------------- |
-| Raw intake     | GitHub Issue with `lane:inbox`                                              |
+| Raw intake     | GitHub Issue with a `triage:*` label                                        |
 | Goalpost       | GitHub Milestone named `Goalpost: ...`                                      |
 | Slice          | GitHub Issue assigned to one goalpost milestone                             |
+| Release lane   | GitHub label named `lane:vX.Y.Z`                                            |
 | Release target | GitHub Milestone named `Release: vX.Y.Z`                                    |
 | Release gate   | GitHub Issue assigned to the release milestone                              |
 | Roadmap board  | [Wesley Roadmap Project](https://github.com/users/flyingrobots/projects/18) |
-| Classification | GitHub labels for lane, legend, work type, package, and status              |
+| Classification | GitHub labels for triage, release lane, legend, work type, package, status  |
 
 Repository docs may link to GitHub state. They must not mirror live counts,
 unchecked work queues, velocity, burn-down, or "next issue" lists.
@@ -95,8 +96,8 @@ coverage should be filed as GitHub Issues and assigned to a goalpost.
 - Do not add new Markdown backlog cards.
 - Do not add progress bars, score tables, live slice ledgers, or unchecked
   roadmap checklists to repo docs.
-- Do not let `lane:inbox` remain on an issue after it has been triaged into a
-  milestone or another lane.
+- Do not let `triage:*` remain on an issue after it has been scheduled into a
+  named release lane.
 - Do not move implementation issues into release milestones. Link goalposts
   from release-gate issues instead.
 - Do not cite chat as proof. Use code, tests, commits, PRs, releases, workflow

--- a/docs/governance/RELEASE_POLICY.md
+++ b/docs/governance/RELEASE_POLICY.md
@@ -27,8 +27,8 @@ lacks the human sign-off is not a valid release, and vice versa.
 
 | #   | Check                                                | Automated      | Human    |
 | --- | ---------------------------------------------------- | -------------- | -------- |
-| 1   | Zero open retired urgent-lane GitHub issues          | `xtask` + `gh` |          |
-| 2   | Zero open version-lane issues                        | `xtask` + `gh` |          |
+| 1   | Zero open current release-lane GitHub issues         | `xtask` + `gh` |          |
+| 2   | Zero open exact-version tracker references           | `xtask` + `gh` |          |
 | 3   | Strict preflight gate                                | `xtask`        |          |
 | 4   | Zero open issues from prior-version lanes            | `gh`           |          |
 | 5   | Version lockstep across all `Cargo.toml` manifests   | parse          |          |
@@ -56,16 +56,17 @@ lacks the human sign-off is not a valid release, and vice versa.
 
 `cargo xtask release-guard` calls the GitHub CLI to list open issues:
 
-- **Check 1** — retired urgent lane: during the label migration, any open issue
-  with the retired `lane:asap` label blocks the release regardless of version
-  affinity. Under the current triage doctrine, the fix is to schedule it into a
-  concrete `lane:vX.Y.Z`, split it, move it, or close it.
-- **Check 2** — Version-lane issues: open issues labeled or milestoned with the
-  release tag or version (e.g. `v0.1.0`) or matching the exact tag/version token
-  in issue title or body. Comments and automatic cross-reference chatter are not
-  release-lane ownership.
+- **Check 1** — Current release lane: open issues labeled with the concrete
+  release lane `lane:vX.Y.Z` block that release. Those issues are scheduled
+  work for the release being cut, so they must be closed, moved to a later
+  release lane, split, or explicitly removed from the release before tagging.
+- **Check 2** — Exact-version tracker references: open issues labeled or
+  milestoned with the release tag or version (e.g. `v0.1.0`) or matching the
+  exact tag/version token in issue title or body. Comments and automatic
+  cross-reference chatter are not release-lane ownership.
 - **Check 4** — Prior-version issues: open issues from older version lanes
-  (older SemVer milestone or label matches) that were never closed.
+  (older `lane:v*` labels, SemVer milestones, or exact SemVer labels) that were
+  never closed.
 
 ### Check 3: Strict Preflight Gate
 

--- a/docs/governance/RELEASE_POLICY.md
+++ b/docs/governance/RELEASE_POLICY.md
@@ -27,7 +27,7 @@ lacks the human sign-off is not a valid release, and vice versa.
 
 | #   | Check                                                | Automated      | Human    |
 | --- | ---------------------------------------------------- | -------------- | -------- |
-| 1   | Zero open `lane:asap` GitHub issues                  | `xtask` + `gh` |          |
+| 1   | Zero open retired urgent-lane GitHub issues          | `xtask` + `gh` |          |
 | 2   | Zero open version-lane issues                        | `xtask` + `gh` |          |
 | 3   | Strict preflight gate                                | `xtask`        |          |
 | 4   | Zero open issues from prior-version lanes            | `gh`           |          |
@@ -56,8 +56,10 @@ lacks the human sign-off is not a valid release, and vice versa.
 
 `cargo xtask release-guard` calls the GitHub CLI to list open issues:
 
-- **Check 1** — `lane:asap`: any open issue with this label blocks the release
-  regardless of version affinity.
+- **Check 1** — retired urgent lane: during the label migration, any open issue
+  with the retired `lane:asap` label blocks the release regardless of version
+  affinity. Under the current triage doctrine, the fix is to schedule it into a
+  concrete `lane:vX.Y.Z`, split it, move it, or close it.
 - **Check 2** — Version-lane issues: open issues labeled or milestoned with the
   release tag or version (e.g. `v0.1.0`) or matching the exact tag/version token
   in issue title or body. Comments and automatic cross-reference chatter are not
@@ -213,7 +215,9 @@ post-release merge to make the released commit truthful.
 
 If a release is discovered to have shipped in violation of this policy:
 
-1. File a `lane:asap` GitHub Issue immediately documenting the violation.
+1. File a `triage:bad-code` GitHub Issue immediately documenting the violation,
+   or schedule the corrective fix into a concrete patch release lane if the
+   release target is already known.
 2. Do not attempt to retroactively fix the published crate — crates.io publishes
    are permanent.
 3. If the violation involves a security defect, follow `SECURITY.md`.

--- a/docs/governance/labels.md
+++ b/docs/governance/labels.md
@@ -35,8 +35,10 @@ GitHub and can be reviewed with `gh label list`.
 | `lane:bad-code`   | Named technical debt or trust debt.                                                  |
 | `lane:cool-ideas` | Exploratory ideas with no commitment yet.                                            |
 | `lane:release`    | Release-gate or release-scoped work, usually assigned to a `Release: ...` milestone. |
+| `lane:planned`    | Accepted goalpost work that is planned but not active this cycle.                    |
 
-Open `lane:inbox` should be empty unless genuinely raw intake exists.
+Every open issue should carry one `lane:*` label after triage. Open
+`lane:inbox` should be empty unless genuinely raw intake exists.
 
 ## Legends
 

--- a/docs/governance/labels.md
+++ b/docs/governance/labels.md
@@ -22,23 +22,27 @@ GitHub and can be reviewed with `gh label list`.
 | `holmes`, `scoring`            | Work specific to the HOLMES evidence stack.                                                                     |
 | `status: non-blocking`         | Nice-to-have items that are not release blockers.                                                               |
 | `pkg:*`                        | Ownership hints for the affected package(s).                                                                    |
-| `lane:*`                       | METHOD lane classification.                                                                                     |
+| `triage:*`                     | Unscheduled intake classification.                                                                              |
+| `lane:v*`                      | Named future release scheduling.                                                                                |
 | `legend:*`                     | Wesley legend classification.                                                                                   |
 | `work:*`                       | Product, integrity, or enabler work shape.                                                                      |
 
-## METHOD lanes
+## Triage And Release Scheduling
 
-| Label             | Purpose                                                                              |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| `lane:inbox`      | Raw, untriaged intake only. Remove it after milestone assignment or lane decision.   |
-| `lane:asap`       | Imminent work that blocks the next cycle or release gate.                            |
-| `lane:bad-code`   | Named technical debt or trust debt.                                                  |
-| `lane:cool-ideas` | Exploratory ideas with no commitment yet.                                            |
-| `lane:release`    | Release-gate or release-scoped work, usually assigned to a `Release: ...` milestone. |
-| `lane:planned`    | Accepted goalpost work that is planned but not active this cycle.                    |
+See [Issue Triage](../topics/contributing/triage.md) for the full scheduling
+flow.
 
-Every open issue should carry one `lane:*` label after triage. Open
-`lane:inbox` should be empty unless genuinely raw intake exists.
+| Label               | Purpose                                                   |
+| ------------------- | --------------------------------------------------------- |
+| `triage:requests`   | Raw requests and incoming asks.                           |
+| `triage:bad-code`   | Debt intake awaiting scheduling, split, move, or closure. |
+| `triage:cool-ideas` | Idea intake awaiting scheduling, split, move, or closure. |
+| `lane:vX.Y.Z`       | Work scheduled for a named future release.                |
+
+Every open issue should carry exactly one scheduling-state label: either one
+`triage:*` label or one `lane:vX.Y.Z` label. Do not use generic labels such as
+`lane:asap`, `lane:inbox`, `lane:bad-code`, `lane:cool-ideas`,
+`lane:release`, or `lane:planned` for active work.
 
 ## Legends
 

--- a/docs/method/backlog/README.md
+++ b/docs/method/backlog/README.md
@@ -4,11 +4,10 @@ This directory is no longer Wesley's live work queue.
 
 GitHub Issues are the live Method tracker. Use lane labels:
 
-- `lane:inbox` for raw captured ideas
-- `lane:asap` for imminent work
-- `lane:cool-ideas` for non-commitment exploration
-- `lane:bad-code` for technical debt worth naming
-- `lane:release` for release-scoped work
+- `triage:requests` for raw captured ideas
+- `triage:cool-ideas` for exploratory idea intake
+- `triage:bad-code` for debt intake
+- `lane:vX.Y.Z` for work scheduled into a named future release
 
 Repository files are the evidence ledger. The former filesystem backlog cards
 were migrated on 2026-06-04 and archived under
@@ -17,10 +16,11 @@ were migrated on 2026-06-04 and archived under
 Use:
 
 ```bash
-gh issue list --label lane:asap
-gh issue list --label lane:bad-code
-gh issue list --label lane:cool-ideas
-gh issue list --label lane:inbox
+gh issue list --label triage:requests
+gh issue list --label triage:bad-code
+gh issue list --label triage:cool-ideas
+gh issue list --label lane:v0.2.0
 ```
 
 Do not add new live backlog cards here. Create or update GitHub Issues instead.
+See `docs/topics/contributing/triage.md` for the scheduling flow.

--- a/docs/method/backlog/asap/README.md
+++ b/docs/method/backlog/asap/README.md
@@ -1,11 +1,10 @@
 # ASAP
 
-This legacy lane is retained only as a signpost.
+This legacy lane is retained only as a historical signpost.
 
-Live imminent work is tracked with the GitHub label `lane:asap`:
-
-```bash
-gh issue list --label lane:asap
-```
+Wesley no longer uses a generic urgent lane. Schedule valid work into a named
+future release lane such as `lane:v0.2.0`, or keep it under `triage:*` until the
+release decision is ready.
 
 Do not add new files here. Add or update GitHub Issues instead.
+See `docs/topics/contributing/triage.md` for the scheduling flow.

--- a/docs/method/backlog/bad-code/README.md
+++ b/docs/method/backlog/bad-code/README.md
@@ -2,12 +2,14 @@
 
 This legacy lane is retained only as a signpost.
 
-Live technical debt is tracked with the GitHub label `lane:bad-code`:
+Live technical-debt intake is tracked with the GitHub label `triage:bad-code`:
 
 ```bash
-gh issue list --label lane:bad-code
+gh issue list --label triage:bad-code
 ```
 
 Former cards from this lane were archived under
 `docs/method/graveyard/github-issue-migration/bad-code/`.
-Do not add new files here. Add or update GitHub Issues instead.
+Do not add new files here. Add or update GitHub Issues instead. Once debt is
+scheduled, replace `triage:bad-code` with a concrete release lane such as
+`lane:v0.1.1`.

--- a/docs/method/backlog/cool-ideas/README.md
+++ b/docs/method/backlog/cool-ideas/README.md
@@ -2,12 +2,15 @@
 
 This legacy lane is retained only as a signpost.
 
-Live exploratory ideas are tracked with the GitHub label `lane:cool-ideas`:
+Live exploratory idea intake is tracked with the GitHub label
+`triage:cool-ideas`:
 
 ```bash
-gh issue list --label lane:cool-ideas
+gh issue list --label triage:cool-ideas
 ```
 
 Former cards from this lane were archived under
 `docs/method/graveyard/github-issue-migration/cool-ideas/`.
-Do not add new files here. Add or update GitHub Issues instead.
+Do not add new files here. Add or update GitHub Issues instead. Once an idea is
+scheduled, replace `triage:cool-ideas` with a concrete release lane such as
+`lane:v0.3.0`.

--- a/docs/method/backlog/inbox/README.md
+++ b/docs/method/backlog/inbox/README.md
@@ -2,10 +2,10 @@
 
 This legacy lane is retained only as a signpost.
 
-Raw intake is tracked with the GitHub label `lane:inbox`:
+Raw intake is tracked with the GitHub label `triage:requests`:
 
 ```bash
-gh issue list --label lane:inbox
+gh issue list --label triage:requests
 ```
 
 Former cards from this lane were archived under

--- a/docs/method/backlog/up-next/README.md
+++ b/docs/method/backlog/up-next/README.md
@@ -2,14 +2,16 @@
 
 This legacy lane is retained only as a signpost.
 
-METHOD no longer uses a separate `up-next` lane in Wesley. Former `up-next`
-cards were migrated to the canonical GitHub label `lane:asap` and archived
-under `docs/method/graveyard/github-issue-migration/up-next/`.
+METHOD no longer uses a separate `up-next` or generic urgent lane in Wesley.
+Former `up-next` cards were archived under
+`docs/method/graveyard/github-issue-migration/up-next/`.
 
 Use:
 
 ```bash
-gh issue list --label lane:asap
+gh issue list --label triage:requests
+gh issue list --label lane:v0.2.0
 ```
 
 Do not add new files here. Add or update GitHub Issues instead.
+See `docs/topics/contributing/triage.md` for the scheduling flow.

--- a/docs/method/guide.md
+++ b/docs/method/guide.md
@@ -7,8 +7,9 @@ It is lighter than doctrine in `README.md` or `docs/method/process.md`.
 
 If a work-worthy idea surfaces during the work, capture it now.
 
-Open a GitHub Issue with the right Method lane and legend labels instead of
-leaving the idea only in chat, in a dirty worktree, or buried inside a retro.
+Open a GitHub Issue with the right `triage:*` intake label, release lane if the
+target release is already known, and legend labels instead of leaving the idea
+only in chat, in a dirty worktree, or buried inside a retro.
 
 ## Retro versus Issues
 

--- a/docs/method/process.md
+++ b/docs/method/process.md
@@ -8,8 +8,10 @@ direction, and evidence.
 
 ## Rules
 
-- The queue lives in GitHub Issues, organized by Method labels such as
-  `lane:asap`, `lane:bad-code`, `lane:cool-ideas`, and `lane:inbox`.
+- The queue lives in GitHub Issues. Unscheduled intake uses `triage:*` labels;
+  scheduled work uses concrete release lanes such as `lane:v0.2.0`.
+- The full triage flow lives in
+  [`docs/topics/contributing/triage.md`](../topics/contributing/triage.md).
 - Goalposts live in GitHub Milestones named `Goalpost: ...`.
 - Versioned releases live in GitHub Milestones named `Release: ...`; their
   release-gate issues link to goalpost milestones because GitHub allows one
@@ -46,6 +48,8 @@ direction, and evidence.
 1. Pull a GitHub Issue into `docs/design/<cycle>/` when a design packet is
    needed, assign its goalpost milestone, and add it to the Wesley Roadmap
    Project if missing.
+   If the issue still has a `triage:*` label, schedule, split, move, or close it
+   before implementation.
 2. Write the design with both human and agent sponsors named.
 3. Write failing tests from the playback questions.
 4. Make the tests pass.

--- a/docs/method/release.md
+++ b/docs/method/release.md
@@ -31,8 +31,9 @@ in `docs/releases/`.
 ## Scope
 
 Releases aggregate shipped work. They do not create version-scoped filesystem
-backlog directories, and they do not move GitHub Issues by version. Method lane
-labels stay about priority and scope, not release membership.
+backlog directories, and implementation issues stay in goalpost milestones.
+Release membership is tracked with concrete release lane labels such as
+`lane:v0.2.0`; release milestones hold release-gate issues.
 
 The release design names and justifies the intended version before tagging.
 Commit history, diff inspection, and validation can support or challenge that

--- a/docs/topics/contributing/triage.md
+++ b/docs/topics/contributing/triage.md
@@ -1,0 +1,105 @@
+# Issue Triage
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Triage turns unscheduled intake into a named future release, a split issue, a
+repo move, or a closure. Topic grouping can help the discussion, but the
+decision that matters is when the work should ship.
+
+## Label Model
+
+Use two label namespaces for work state:
+
+| Namespace  | Meaning                                                                  |
+| ---------- | ------------------------------------------------------------------------ |
+| `triage:*` | Unscheduled intake that still needs a scheduling, closure, or move call. |
+| `lane:v*`  | Scheduled work for a named future release.                               |
+
+Current triage labels:
+
+| Label               | Meaning                         |
+| ------------------- | ------------------------------- |
+| `triage:requests`   | Raw requests and incoming asks. |
+| `triage:bad-code`   | Debt intake.                    |
+| `triage:cool-ideas` | Exploratory idea intake.        |
+
+Release lane labels are created only for named releases:
+
+```text
+lane:v0.1.1
+lane:v0.2.0
+lane:v0.3.0
+```
+
+Do not create generic `lane:*` labels. In particular, do not use
+`lane:asap`, `lane:inbox`, `lane:bad-code`, `lane:cool-ideas`,
+`lane:release`, or `lane:planned` for active work.
+
+## Invariants
+
+Every open issue must have exactly one work-state label:
+
+- either one `triage:*` label,
+- or one `lane:vX.Y.Z` label.
+
+An open issue must never have both `triage:*` and `lane:v*`. It must never have
+neither.
+
+Implementation issues stay in `Goalpost: ...` milestones. Release milestones
+hold release-gate issues only. A release-gate issue in `Release: vX.Y.Z` links
+to the goalposts and issue queries that define the release.
+
+## Triage Flow
+
+For each issue in `triage:requests`, `triage:bad-code`, or
+`triage:cool-ideas`:
+
+1. Decide whether it is valid Wesley work.
+2. If it is invalid, close it or move it to the owning repo.
+3. If it is valid but too broad, split it before scheduling.
+4. If it fits an existing named release, replace `triage:*` with
+   `lane:vX.Y.Z`.
+5. If it needs a future release that does not exist yet, propose the release
+   and create the release lane only after the release has a clear purpose.
+6. Leave it under `triage:*` only when the scheduling decision is genuinely not
+   ready.
+
+## Creating A Future Release Lane
+
+Create a new `lane:vX.Y.Z` only when the proposed release has:
+
+- a clear release purpose,
+- a coherent batch of issues or goalposts,
+- an ordering argument relative to existing releases,
+- a release milestone named `Release: vX.Y.Z`,
+- a release-gate issue in that milestone.
+
+The release-gate issue should link the scheduled work by GitHub query, usually
+`label:lane:vX.Y.Z`, and name any selected goalpost milestones.
+
+## Topic Labels
+
+Topic labels are useful, but they are not scheduling labels.
+
+Use `legend:*`, `group:*`, `pkg:*`, `work:*`, `priority:*`, and ordinary
+work-type labels (`bug`, `feature`, `chore`, `docs`, `tests`, `ci`) to explain
+what kind of work an issue represents. Use `triage:*` or `lane:v*` to explain
+where it sits in the scheduling flow.
+
+## Migration Notes
+
+The old generic lane labels are retired by this doctrine. During migration,
+replace them as follows:
+
+| Old label         | Replacement                                    |
+| ----------------- | ---------------------------------------------- |
+| `lane:inbox`      | `triage:requests`                              |
+| `lane:bad-code`   | `triage:bad-code` until scheduled or closed.   |
+| `lane:cool-ideas` | `triage:cool-ideas` until scheduled or closed. |
+| `lane:release`    | `lane:vX.Y.Z` for the selected release.        |
+| `lane:asap`       | A concrete `lane:vX.Y.Z`, or close/split.      |
+| `lane:planned`    | A concrete `lane:vX.Y.Z`, or triage intake.    |
+
+Before deleting retired GitHub labels, update any automation that still queries
+them. In particular, release checks must not depend on `lane:asap` after the
+label migration is complete.

--- a/docs/topics/contributing/triage.md
+++ b/docs/topics/contributing/triage.md
@@ -100,6 +100,5 @@ replace them as follows:
 | `lane:asap`       | A concrete `lane:vX.Y.Z`, or close/split.      |
 | `lane:planned`    | A concrete `lane:vX.Y.Z`, or triage intake.    |
 
-Before deleting retired GitHub labels, update any automation that still queries
-them. In particular, release checks must not depend on `lane:asap` after the
-label migration is complete.
+Release checks query concrete `lane:vX.Y.Z` labels. Retired generic lane labels
+are migration residue only; they are not release gates.

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -112,6 +112,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/contributing/triage.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/governance/RELEASE_POLICY.md",
       "status": "current",
       "owner": "@flyingrobots"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -455,7 +455,6 @@ fn run_release_guard_for_tag(tag: &str) -> Result<(), Error> {
     check_publish_manifest_versions(&version)?;
     check_release_required_files(&version)?;
     check_release_tracker_clear(tag, &version)?;
-    check_lane_asap_clear()?;
     check_readme_version_headline(&version)?;
     check_technical_teardown_version(&version)?;
     check_no_wip_fixup_commits(tag)?;
@@ -958,50 +957,6 @@ fn check_release_backlog_clear(tag: &str, version: &str) -> Result<(), Error> {
 fn check_release_tracker_clear(tag: &str, version: &str) -> Result<(), Error> {
     check_release_backlog_clear(tag, version)?;
     check_release_issue_tracker_clear(tag, version)
-}
-
-fn check_lane_asap_clear() -> Result<(), Error> {
-    let repo = release_github_repository()?;
-    let output = Command::new("gh")
-        .args([
-            "issue",
-            "list",
-            "--repo",
-            &repo,
-            "--label",
-            "lane:asap",
-            "--state",
-            "open",
-            "--json",
-            "number,title,url",
-        ])
-        .output()
-        .map_err(|source| {
-            Error::Usage(format!(
-                "failed to spawn `gh issue list --label lane:asap`: {source}"
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::CheckFailed {
-            check: "lane:asap issues".to_string(),
-            failures: vec![format!(
-                "`gh issue list --label lane:asap` failed: {}",
-                stderr.trim()
-            )],
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let issues = parse_release_issue_list(&stdout, "lane:asap")?;
-    finish_check(
-        "lane:asap issues",
-        issues
-            .into_iter()
-            .map(|issue| issue.display)
-            .collect::<Vec<_>>(),
-    )
 }
 
 fn check_readme_version_headline(version: &str) -> Result<(), Error> {
@@ -1555,7 +1510,13 @@ fn release_issue_queries(tag: &str, version: &str, repo: &str) -> Vec<Vec<String
 }
 
 fn release_issue_query_specs(tag: &str, version: &str, _repo: &str) -> Vec<ReleaseIssueQuery> {
+    let release_lane = format!("lane:{tag}");
     vec![
+        ReleaseIssueQuery {
+            args: release_issue_selector_query("--label", &release_lane),
+            source: format!("release lane `{release_lane}`"),
+            ignore_missing_selector: true,
+        },
         ReleaseIssueQuery {
             args: release_issue_selector_query("--milestone", tag),
             source: format!("milestone `{tag}`"),
@@ -1824,6 +1785,7 @@ fn version_lane_is_prior(lane: &str, current: &Version) -> bool {
 
 fn version_from_lane_name(lane: &str) -> Option<Version> {
     let lane = lane.trim();
+    let lane = lane.strip_prefix("lane:").unwrap_or(lane);
     let version = lane.strip_prefix('v').unwrap_or(lane);
     let parsed = Version::parse(version).ok()?;
     if parsed.build.is_empty() {
@@ -3048,6 +3010,16 @@ mod tests {
                     "list",
                     "--state",
                     "open",
+                    "--label",
+                    "lane:v1.2.3",
+                    "--json",
+                    "number,title,url",
+                ],
+                vec![
+                    "issue",
+                    "list",
+                    "--state",
+                    "open",
                     "--milestone",
                     "v1.2.3",
                     "--json",
@@ -3256,9 +3228,12 @@ mod tests {
                 "title": "Older label",
                 "url": "https://github.com/flyingrobots/wesley/issues/1",
                 "labels": [
-                    { "name": "lane:asap" },
+                    { "name": "triage:bad-code" },
+                    { "name": "lane:v0.0.4" },
                     { "name": "v0.0.4" },
+                    { "name": "lane:v0.0.5" },
                     { "name": "v0.0.5" },
+                    { "name": "lane:v0.0.4+build" },
                     { "name": "v0.0.4+build" }
                 ],
                 "milestone": null
@@ -3285,12 +3260,15 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(
             matches[0].display,
-            "#1 Older label https://github.com/flyingrobots/wesley/issues/1 (prior version label `v0.0.4`)"
+            "#1 Older label https://github.com/flyingrobots/wesley/issues/1 (prior version label `lane:v0.0.4`, label `v0.0.4`)"
         );
         assert_eq!(
             matches[1].display,
             "#2 Older milestone https://github.com/flyingrobots/wesley/issues/2 (prior version milestone `0.0.3`)"
         );
+        assert!(version_from_lane_name("lane:v0.0.4").is_some());
+        assert!(version_from_lane_name("triage:bad-code").is_none());
+        assert!(version_from_lane_name("lane:v0.0.4+build").is_none());
         assert!(version_from_lane_name("v0.0.4+build").is_none());
     }
 


### PR DESCRIPTION
## Summary
- add docs/topics/contributing/triage.md as the canonical issue triage flow
- define triage:* as unscheduled intake and lane:vX.Y.Z as named-release scheduling
- link the triage flow from AGENTS.md, CONTRIBUTING.md, METHOD, labels, and legacy backlog signposts
- retire generic lane labels in doctrine: lane:asap, lane:inbox, lane:bad-code, lane:cool-ideas, lane:release, lane:planned
- document the release-guard migration caveat for the existing lane:asap compatibility check

## Verification
- pnpm exec prettier --check touched docs and docs/truth-manifest.json
- pnpm run lint:docs-truth
- cargo xtask docs-check
- git diff --check
- pre-push Rust product preflight