### PR TITLE
docs(source): align directive examples with truth table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `cargo xtask release-guard` now block on concrete `lane:vX.Y.Z` release-lane
   issues for the release being cut, recognize older `lane:v*` labels as
   prior-version blockers, and no longer depend on the retired `lane:asap` label.
+- **Directive example honesty**: Current-path example fixtures now use only
+  directive families that the Rust-native SDL hot path actually lowers, while
+  broader RLS/RPC/reference fixtures are explicitly marked experimental or
+  historical.
 
 ## [0.1.0] - 2026-06-24
 

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -19,6 +19,7 @@ directives by what that path truly parses and lowers today.
 - `external`: owned by an external module or product repo, not by generic
   Wesley.
 - `deferred`: declared in the registry or docs, but not yet part of a stable public contract.
+- `dead`: historical syntax that generic Wesley must not present as supported.
 
 ## Current On The Main Database Compiler Path
 
@@ -78,7 +79,21 @@ The directive registry and draft docs still contain broader semantics than the m
 | ---------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Full `@wes_rls(...)` option matrix                                           | `deferred` | The registry exposes a broad option shape, but the stable hot-path contract today is the presence of `@wes_rls`, not the full option matrix. |
 | Broad alias support beyond the core compiler directives                      | `deferred` | The registry declares many alias forms, but the current parser alias map only covers the core compiler directives plus `@wes_rls`.           |
+| `@wes_join`, `@wes_view`                                                     | `deferred` | These are registered as generic metadata shapes, but no stable Rust-native user command interprets them end to end today.                    |
 | “Everything in `schemas/directives.graphql` is supported by native emitters” | `deferred` | That is not true today and should not be assumed.                                                                                            |
+
+## Dead Or Historical Syntax
+
+Older examples and migration archives still contain syntax from the deleted
+Node/Postgres era, Prisma-like sketches, or product-specific experiments. These
+forms are not current generic Wesley semantics.
+
+| Syntax family                                     | Status | Notes                                                                                           |
+| ------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `@check`, `@updatedAt`, `@email`                  | `dead` | Historical example-only annotations. Generic Wesley does not declare or lower these today.      |
+| `@hasOne`                                         | `dead` | Historical virtual-relation sketch. It is not in the generic registry or current Rust hot path. |
+| `@rpc`, `@function`                               | `dead` | Product/database RPC sketches from the deleted Node/Postgres era.                               |
+| Prisma-style `@@primaryKey(...)`, `@@unique(...)` | `dead` | Not GraphQL SDL directive syntax and not accepted as Wesley current-path SDL.                   |
 
 ## Practical Guidance
 
@@ -89,6 +104,24 @@ The directive registry and draft docs still contain broader semantics than the m
 - If you are working on protocol/TTD flows, use the Continuum-owned module or
   package; do not assume TTD directives are part of generic Wesley emitters or
   the generic `schemas/directives.graphql` registry.
+
+## Fixture Boundary
+
+Stable current-path examples:
+
+- `test/fixtures/examples/schema.graphql`
+- `test/fixtures/examples/schema-v2.graphql`
+- `test/fixtures/examples/ecommerce.graphql`
+
+Experimental or historical examples:
+
+- `test/fixtures/examples/schema-with-rls.graphql`
+- `test/fixtures/examples/multi-tenant.graphql`
+- `test/fixtures/examples/rpc-example.graphql`
+- `test/fixtures/reference/schema.graphql`
+
+Docs and quick starts must cite the stable current-path examples unless they
+are explicitly explaining an experimental or historical boundary.
 
 ## Minimal Happy-Path Example
 

--- a/schemas/directives.graphql
+++ b/schemas/directives.graphql
@@ -7,7 +7,10 @@ compiler metadata. Product-specific directive families belong in their owning
 modules.
 
 CANONICAL NAMESPACE: @wes_* (preferred)
-Legacy aliases: @wesley_* and bare names (@table, @pk) supported with deprecation warnings
+
+This file is a registry, not a support guarantee. See docs/DIRECTIVES.md for
+the directive truth table that classifies current, experimental, external,
+deferred, and dead directive semantics.
 """
 
 # Shared scalars used by directives
@@ -112,7 +115,7 @@ directive @wes_rls(
 # ═══════════════════════════════════════════════════════════════════
 
 directive @wesley_table(name: String) on OBJECT
-directive @wesley_pk on FIELD_DEFINITION  
+directive @wesley_pk on FIELD_DEFINITION
 directive @wesley_fk(ref: String!) on FIELD_DEFINITION
 directive @wesley_unique on FIELD_DEFINITION
 directive @wesley_index(name: String, using: String) on FIELD_DEFINITION | OBJECT
@@ -147,7 +150,7 @@ directive @wesley_rls(
 
 directive @table on OBJECT
 directive @pk on FIELD_DEFINITION
-directive @fk(ref: String!) on FIELD_DEFINITION  
+directive @fk(ref: String!) on FIELD_DEFINITION
 directive @unique on FIELD_DEFINITION
 directive @index(name: String, using: String) on FIELD_DEFINITION | OBJECT
 directive @tenant(by: String!) on OBJECT

--- a/test/docs-governance.bats
+++ b/test/docs-governance.bats
@@ -10,3 +10,19 @@ load 'bats-plugins/bats-assert/load'
   run rg -n "BEARING\\.md.*campaign status|campaign slice lands" docs/design/TEMPLATE.md
   assert_failure
 }
+
+@test "directive registry points at truth table instead of overstating support" {
+  run rg -n "docs/DIRECTIVES\\.md" schemas/directives.graphql
+  assert_success
+
+  run rg -n "supported with deprecation warnings" schemas/directives.graphql
+  assert_failure
+}
+
+@test "current-path example fixtures avoid experimental directive families" {
+  run rg -n "@(uid|weight|critical|sensitive|pii|hasMany|hasOne|belongsTo|owner|grant|email|check|updatedAt|rpc|function)|@wes_(uid|weight|critical|sensitive|pii|hasMany|belongsTo|owner|grant|noRPC)|@@" \
+    test/fixtures/examples/schema.graphql \
+    test/fixtures/examples/schema-v2.graphql \
+    test/fixtures/examples/ecommerce.graphql
+  assert_failure
+}

--- a/test/fixtures/examples/README.md
+++ b/test/fixtures/examples/README.md
@@ -2,16 +2,32 @@
 
 Canonical schemas used by documentation, HOLMES tests, and CLI walkthroughs.
 
-## Files
+Directive support truth lives in
+[`docs/DIRECTIVES.md`](../../../docs/DIRECTIVES.md). Fixtures in this directory
+are split by whether they are current-path examples or experimental/historical
+coverage.
 
-- `schema.graphql` – Minimal schema used by HOLMES and quick-start docs.
-- `schema-v2.graphql` – Evolution of the minimal schema (adds fields/indexes).
-- `schema-with-rls.graphql` – Focused RLS example.
-- `multi-tenant.graphql` – Demonstrates tenant/owner directives.
-- `rpc-example.graphql` – Showcases experimental RPC directives.
+## Stable Current-Path Fixtures
+
+These fixtures must use only directive families marked `current` in
+`docs/DIRECTIVES.md`.
+
+- `schema.graphql` – Minimal schema used by HOLMES smoke tests.
+- `schema-v2.graphql` – Evolution of the minimal schema.
+- `ecommerce.graphql` – Quick-start and example generation schema.
+
+## Experimental Or Historical Fixtures
+
+These fixtures exercise broader ideas and must not be cited as the default
+compiler support surface.
+
+- `schema-with-rls.graphql` – Historical broad RLS option example.
+- `multi-tenant.graphql` – Historical tenant/owner/policy example.
+- `rpc-example.graphql` – Historical RPC and ownership sketch.
 
 ## Consuming Tests
 
 - `test/holmes-e2e.bats` copies `schema.graphql` when generating evidence bundles.
 
-When updating schemas, ensure docs, fixtures manifest, and any snapshot tests are updated accordingly.
+When updating schemas, ensure docs, fixture docs, and any snapshot tests are
+updated accordingly.

--- a/test/fixtures/examples/ecommerce.graphql
+++ b/test/fixtures/examples/ecommerce.graphql
@@ -1,75 +1,43 @@
-# E-Commerce Platform Schema - Production-Grade Demo
-# Shows Wesley + SHA-lock HOLMES capabilities
+# Stable current-path e-commerce fixture.
+#
+# This schema is used by quick-start docs and the example generation script, so
+# it must not rely on experimental directive families. Keep it aligned with
+# docs/DIRECTIVES.md current support.
 
 scalar UUID
 scalar DateTime
-scalar JSON
 
-directive @uid(value: String!) on OBJECT | FIELD_DEFINITION
-directive @weight(value: Int! = 5) on OBJECT | FIELD_DEFINITION
-directive @critical on OBJECT | FIELD_DEFINITION
-directive @sensitive on FIELD_DEFINITION
-directive @pii on FIELD_DEFINITION
-
-# Core User table with authentication
-type User @wes_table @critical @uid(value: "tbl:user") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid(value: "col:user.id")
-  email: String! @wes_unique @pii @weight(value: 9) @uid(value: "col:user.email")
-  password_hash: String! @sensitive @weight(value: 10) @uid(value: "col:user.password")
-  
-  full_name: String @pii @weight(value: 7) @uid(value: "col:user.full_name")
-  phone: String @pii @weight(value: 8) @uid(value: "col:user.phone")
-  
-  email_verified: Boolean! @wes_default(expr: "false") @weight(value: 8)
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  orders: [Order!]! @hasMany
+type Customer @wes_table {
+  id: UUID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  email: String! @wes_unique @wes_index
+  full_name: String
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-# Products with inventory tracking
-type Product @wes_table @uid(value: "tbl:product") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid(value: "col:product.id")
-  
-  sku: String! @wes_unique @weight(value: 9) @uid(value: "col:product.sku")
-  name: String! @weight(value: 8) @uid(value: "col:product.name")
-  slug: String! @wes_unique @wes_index @weight(value: 7) @uid(value: "col:product.slug")
-  
-  price_cents: Int! @weight(value: 9) @uid(value: "col:product.price")
-  stock_quantity: Int! @wes_default(expr: "0") @weight(value: 8)
-  
-  published: Boolean! @wes_default(expr: "false") @wes_index @weight(value: 7)
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  order_items: [OrderItem!]! @hasMany
+type Product @wes_table {
+  id: UUID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  sku: String! @wes_unique @wes_index
+  name: String!
+  slug: String! @wes_unique @wes_index
+  price_cents: Int!
+  stock_quantity: Int! @wes_default(value: "0")
+  published: Boolean! @wes_default(value: "false") @wes_index
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-# Orders with payment tracking
-type Order @wes_table @critical @uid(value: "tbl:order") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid(value: "col:order.id")
-  order_number: String! @wes_unique @weight(value: 10) @uid(value: "col:order.number")
-  user_id: UUID! @wes_fk(ref: "User.id") @wes_index @weight(value: 9)
-  
-  status: String! @weight(value: 9) @uid(value: "col:order.status")
-  total_cents: Int! @weight(value: 9)
-  
-  payment_intent_id: String @wes_unique @sensitive @weight(value: 9)
-  paid_at: DateTime @weight(value: 7)
-  
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  user: User! @belongsTo
-  items: [OrderItem!]! @hasMany
+type Order @wes_table @wes_tenant(by: "customer_id") @wes_rls {
+  id: UUID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  order_number: String! @wes_unique @wes_index
+  customer_id: UUID! @wes_fk(ref: "Customer.id") @wes_index
+  status: String! @wes_default(value: "'pending'") @wes_index
+  total_cents: Int!
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-# Order line items
-type OrderItem @wes_table @uid(value: "tbl:order_item") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()")
-  order_id: UUID! @wes_fk(ref: "Order.id") @wes_index @weight(value: 8)
-  product_id: UUID! @wes_fk(ref: "Product.id") @wes_index @weight(value: 7)
-  
-  quantity: Int! @weight(value: 8)
-  unit_price_cents: Int! @weight(value: 8)
-  
-  order: Order! @belongsTo
-  product: Product! @belongsTo
+type OrderItem @wes_table {
+  id: UUID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  order_id: UUID! @wes_fk(ref: "Order.id") @wes_index
+  product_id: UUID! @wes_fk(ref: "Product.id") @wes_index
+  quantity: Int! @wes_default(value: "1")
+  unit_price_cents: Int!
 }

--- a/test/fixtures/examples/multi-tenant.graphql
+++ b/test/fixtures/examples/multi-tenant.graphql
@@ -1,5 +1,8 @@
-# Multi-tenant SaaS Example Schema
-# Demonstrates Wesley's @tenant and @owner directives
+# Experimental/historical multi-tenant sketch.
+#
+# This file intentionally uses directive families that are not current-path
+# compiler guarantees. Use schema.graphql, schema-v2.graphql, or
+# ecommerce.graphql for stable current-path examples.
 
 type Org @wes_table {
   id: ID! @wes_pk

--- a/test/fixtures/examples/rpc-example.graphql
+++ b/test/fixtures/examples/rpc-example.graphql
@@ -1,5 +1,8 @@
-# RPC Example with New Parameter Strategy
-# Demonstrates jsonb parameter approach and ownership model
+# Experimental/historical RPC sketch.
+#
+# This file intentionally uses directive families that are not current-path
+# compiler guarantees. Use schema.graphql, schema-v2.graphql, or
+# ecommerce.graphql for stable current-path examples.
 
 type User @wes_table @grant(roles: ["authenticated", "anon"]) {
   id: ID! @wes_pk @uid(value: "user_001")

--- a/test/fixtures/examples/schema-v2.graphql
+++ b/test/fixtures/examples/schema-v2.graphql
@@ -1,105 +1,34 @@
-# Version 2 of schema - demonstrates migration generation
-# Changes from v1:
-# - Added 'phone' field to User (low risk)
-# - Added 'discount_code' to Order (low risk) 
-# - Changed Product.price_cents to BIGINT (medium risk)
-# - Added new ReviewSystem table (low risk)
-# - Dropped CartItem.added_at field (HIGH RISK - data loss)
+# Stable current-path evolution of schema.graphql.
+#
+# This fixture demonstrates additive and breaking shape changes without using
+# experimental directive families.
 
-scalar UUID
 scalar DateTime
-scalar JSON
 
-directive @uid(value: String!) on OBJECT | FIELD_DEFINITION
-directive @weight(value: Int! = 5) on OBJECT | FIELD_DEFINITION
-directive @critical on OBJECT | FIELD_DEFINITION
-directive @sensitive on FIELD_DEFINITION
-directive @pii on FIELD_DEFINITION
-
-type User @wes_table @critical @uid("tbl:user") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid("col:user.id")
-  email: String! @wes_unique @pii @weight(9) @uid("col:user.email")
-  password_hash: String! @sensitive @weight(10) @uid("col:user.password")
-  
-  full_name: String @pii @weight(7) @uid("col:user.full_name")
-  phone: String @pii @weight(8) @uid("col:user.phone")  # NEW FIELD
-  
-  email_verified: Boolean! @wes_default(expr: "false") @weight(8)
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  orders: [Order!]! @hasMany
-  reviews: [Review!]! @hasMany  # NEW RELATION
+type User @wes_table {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  email: String! @wes_unique @wes_index
+  username: String @wes_unique
+  display_name: String
+  phone: String
+  theme: String @wes_default(value: "'light'")
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-type Product @wes_table @uid("tbl:product") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid("col:product.id")
-  
-  sku: String! @wes_unique @weight(9) @uid("col:product.sku")
-  name: String! @weight(8) @uid("col:product.name")
-  slug: String! @wes_unique @wes_index @weight(7) @uid("col:product.slug")
-  
-  price_cents: BigInt! @weight(9) @uid("col:product.price")  # CHANGED TYPE
-  stock_quantity: Int! @wes_default(value: 0) @weight(8)
-  
-  published: Boolean! @wes_default(expr: "false") @wes_index @weight(7)
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  order_items: [OrderItem!]! @hasMany
-  reviews: [Review!]! @hasMany  # NEW RELATION
+type Post @wes_table @wes_tenant(by: "user_id") @wes_rls {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  user_id: ID! @wes_fk(ref: "User.id") @wes_index
+  title: String!
+  content: String
+  published: Boolean! @wes_default(value: "false") @wes_index
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-type Order @wes_table @critical @uid("tbl:order") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid("col:order.id")
-  order_number: String! @wes_unique @weight(10) @uid("col:order.number")
-  user_id: UUID! @wes_fk(ref: "User.id") @wes_index @weight(9)
-  
-  status: String! @weight(9) @uid("col:order.status")
-  total_cents: Int! @weight(9)
-  
-  discount_code: String @weight(5) @uid("col:order.discount")  # NEW FIELD
-  discount_amount_cents: Int @wes_default(value: 0) @weight(6)  # NEW FIELD
-  
-  payment_intent_id: String @wes_unique @sensitive @weight(9)
-  paid_at: DateTime @weight(7)
-  
-  created_at: DateTime! @wes_default(expr: "now()")
-  
-  user: User! @belongsTo
-  items: [OrderItem!]! @hasMany
+type Review @wes_table {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  post_id: ID! @wes_fk(ref: "Post.id") @wes_index
+  user_id: ID! @wes_fk(ref: "User.id") @wes_index
+  rating: Int!
+  body: String
+  created_at: DateTime! @wes_default(value: "now()")
 }
-
-type OrderItem @wes_table @uid("tbl:order_item") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()")
-  order_id: UUID! @wes_fk(ref: "Order.id") @wes_index @weight(8)
-  product_id: UUID! @wes_fk(ref: "Product.id") @wes_index @weight(7)
-  
-  quantity: Int! @weight(8)
-  unit_price_cents: Int! @weight(8)
-  
-  order: Order! @belongsTo
-  product: Product! @belongsTo
-}
-
-# NEW TABLE - Review system
-type Review @wes_table @uid("tbl:review") {
-  id: UUID! @wes_pk @wes_default(expr: "gen_random_uuid()") @uid("col:review.id")
-  product_id: UUID! @wes_fk(ref: "Product.id") @wes_index @weight(8) @uid("col:review.product_id")
-  user_id: UUID! @wes_fk(ref: "User.id") @wes_index @weight(7) @uid("col:review.user_id")
-  order_id: UUID @wes_fk(ref: "Order.id") @weight(6) @uid("col:review.order_id")
-  
-  rating: Int! @weight(8) @uid("col:review.rating")
-  title: String @weight(5) @uid("col:review.title")
-  content: String @weight(6) @uid("col:review.content")
-  
-  helpful_count: Int! @wes_default(value: 0) @weight(4)
-  verified_purchase: Boolean! @wes_default(expr: "false") @weight(7)
-  
-  created_at: DateTime! @wes_default(expr: "now()")
-  updated_at: DateTime! @wes_default(expr: "now()")
-  
-  product: Product! @belongsTo
-  user: User! @belongsTo
-  order: Order @belongsTo
-}
-
-# REMOVED: Cart and CartItem tables (assuming we're moving to session storage)

--- a/test/fixtures/examples/schema-with-rls.graphql
+++ b/test/fixtures/examples/schema-with-rls.graphql
@@ -1,5 +1,8 @@
-# Advanced E-Commerce Schema with RLS, Mutations, and RPC Functions
-# Demonstrates Wesley's production-grade capabilities
+# Experimental/historical broad RLS/RPC sketch.
+#
+# This file intentionally uses directive families and RLS option semantics that
+# are not current-path compiler guarantees. Use schema.graphql,
+# schema-v2.graphql, or ecommerce.graphql for stable current-path examples.
 
 scalar UUID
 scalar DateTime

--- a/test/fixtures/examples/schema.graphql
+++ b/test/fixtures/examples/schema.graphql
@@ -1,122 +1,32 @@
-# Wesley Example Schema - Demonstrates all features
-# This schema shows @uid, @weight, @critical, @sensitive directives
+# Stable current-path Wesley example schema.
+#
+# This fixture intentionally uses only directives that docs/DIRECTIVES.md marks
+# current on the Rust-native SDL hot path. It is copied by HOLMES smoke tests
+# and should stay boring.
 
-directive @uid(value: String!) on OBJECT | FIELD_DEFINITION
-directive @weight(value: Int! = 5) on OBJECT | FIELD_DEFINITION
-directive @critical on OBJECT | FIELD_DEFINITION  
-directive @sensitive on FIELD_DEFINITION
-directive @pii on FIELD_DEFINITION
+scalar DateTime
 
-type User @wes_table @uid(value: "tbl:user") @critical {
-  id: ID! 
-    @wes_pk 
-    @uid(value: "col:user.id")
-    @wes_default(expr: "gen_random_uuid()")
-  
-  email: String! 
-    @wes_unique 
-    @index
-    @pii
-    @uid(value: "col:user.email")
-    @weight(value: 8)
-  
-  password_hash: String! 
-    @sensitive
-    @uid(value: "col:user.password")
-    @weight(value: 10)
-    @check(expr: "char_length(password_hash) = 60")
-  
-  username: String
-    @wes_unique
-    @uid(value: "col:user.username")
-    @weight(value: 6)
-  
-  theme: String
-    @wes_default(expr: "'light'")
-    @weight(value: 2)
-  
-  created_at: DateTime!
-    @wes_default(expr: "now()")
-    @uid(value: "col:user.created_at")
-  
-  updated_at: DateTime!
-    @wes_default(expr: "now()")
-    @updatedAt
-    @uid(value: "col:user.updated_at")
-  
-  # Virtual relations
-  posts: [Post!]! @hasMany
+type User @wes_table {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  email: String! @wes_unique @wes_index
+  username: String @wes_unique
+  theme: String @wes_default(value: "'light'")
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-type Post @wes_table @uid(value: "tbl:post") @wes_rls(
-  select: "true"
-  insert: "auth.uid() = user_id"
-  update: "auth.uid() = user_id"  
-  delete: "auth.uid() = user_id"
-) {
-  id: ID!
-    @wes_pk
-    @uid(value: "col:post.id")
-    @wes_default(expr: "gen_random_uuid()")
-  
-  user_id: ID!
-    @wes_fk(ref: "User.id")
-    @index
-    @uid(value: "col:post.user_id")
-    @weight(value: 7)
-  
+type Post @wes_table @wes_tenant(by: "user_id") @wes_rls {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  user_id: ID! @wes_fk(ref: "User.id") @wes_index
   title: String!
-    @uid(value: "col:post.title")
-    @weight(value: 5)
-  
   content: String
-    @uid(value: "col:post.content")
-    @weight(value: 4)
-  
-  published: Boolean!
-    @wes_default(expr: "false")
-    @uid(value: "col:post.published")
-    @weight(value: 3)
-  
-  published_at: DateTime
-    @uid(value: "col:post.published_at")
-  
-  created_at: DateTime!
-    @wes_default(expr: "now()")
-    @uid(value: "col:post.created_at")
-  
-  # Virtual relations
-  user: User! @hasOne
-  comments: [Comment!]! @hasMany
+  published: Boolean! @wes_default(value: "false") @wes_index
+  created_at: DateTime! @wes_default(value: "now()")
 }
 
-type Comment @wes_table @uid(value: "tbl:comment") {
-  id: ID!
-    @wes_pk
-    @uid(value: "col:comment.id")
-    @wes_default(expr: "gen_random_uuid()")
-  
-  post_id: ID!
-    @wes_fk(ref: "Post.id")
-    @index
-    @uid(value: "col:comment.post_id")
-    @weight(value: 6)
-  
-  user_id: ID!
-    @wes_fk(ref: "User.id")
-    @index
-    @uid(value: "col:comment.user_id")
-    @weight(value: 6)
-  
+type Comment @wes_table {
+  id: ID! @wes_pk @wes_default(value: "gen_random_uuid()")
+  post_id: ID! @wes_fk(ref: "Post.id") @wes_index
+  user_id: ID! @wes_fk(ref: "User.id") @wes_index
   content: String!
-    @uid(value: "col:comment.content")
-    @weight(value: 4)
-  
-  created_at: DateTime!
-    @wes_default(expr: "now()")
-    @uid(value: "col:comment.created_at")
-  
-  # Virtual relations
-  post: Post! @hasOne
-  user: User! @hasOne
+  created_at: DateTime! @wes_default(value: "now()")
 }

--- a/test/fixtures/reference/README.md
+++ b/test/fixtures/reference/README.md
@@ -1,9 +1,12 @@
 # Reference Schema Fixture
 
-A comprehensive GraphQL SDL that exercises most Wesley directives. Useful for:
+A historical GraphQL SDL that exercises broad directive and alias coverage.
+Useful for:
 
 - Ad hoc experimentation (manual `wesley generate` runs)
 - Parser/regression tests when you need a fully-populated schema
 - Comparing directive coverage with the curated examples in `../examples`
 
-This schema is not wired into CI by default but serves as a handy foundation for new fixtures or docs examples.
+This schema is not wired into CI by default and is not a current-path happy
+path. Do not copy its legacy aliases into user-facing docs without checking
+`docs/DIRECTIVES.md`.


### PR DESCRIPTION
## Summary

- align current-path example GraphQL fixtures with directives marked current in docs/DIRECTIVES.md
- mark broader RLS/RPC/reference fixtures as experimental or historical instead of current-path examples
- add docs-governance regression coverage for directive registry/support-boundary drift

Closes #591

## Validation

- bats -t test/docs-governance.bats
- pnpm exec prettier --check CHANGELOG.md docs/DIRECTIVES.md schemas/directives.graphql test/fixtures/examples/README.md test/fixtures/examples/schema.graphql test/fixtures/examples/schema-v2.graphql test/fixtures/examples/ecommerce.graphql test/fixtures/examples/multi-tenant.graphql test/fixtures/examples/rpc-example.graphql test/fixtures/examples/schema-with-rls.graphql test/fixtures/reference/README.md
- cargo xtask docs-check
- cargo run --bin wesley -- schema lower --schema test/fixtures/examples/schema.graphql --json
- cargo run --bin wesley -- schema lower --schema test/fixtures/examples/schema-v2.graphql --json
- cargo run --bin wesley -- schema lower --schema test/fixtures/examples/ecommerce.graphql --json
- cargo run --bin wesley -- schema hash --schema test/fixtures/examples/ecommerce.graphql
- cargo run --bin wesley -- emit typescript --schema test/fixtures/examples/ecommerce.graphql --out /tmp/wesley-ecommerce.d.ts --metadata-out /tmp/wesley-ecommerce.metadata.json
- git diff --check
- pnpm run preflight
- pre-push Rust product preflight
- pre-push repo Bats smoke suite
