### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-26
+
 ### Removed
 
 - **External host experiments**: Retired the browser, Bun, and Deno host
@@ -1530,7 +1532,8 @@ kind` instead of being silently accepted via structural duck-typing. All
 
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/flyingrobots/wesley/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/flyingrobots/wesley/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/flyingrobots/wesley/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/flyingrobots/wesley/compare/v0.0.3...v0.0.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-codec"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "wesley-core",
 ]
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-holmes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.0" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.1.0" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.1.0" }
+wesley-core = { path = "../wesley-core", version = "0.1.1" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.1.1" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.1.1" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-emit-codec/Cargo.toml
+++ b/crates/wesley-emit-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-codec"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Language-neutral LE-binary codec plan lowered from Wesley L1 IR, shared by the Rust and TypeScript codec emitters."
@@ -12,4 +12,4 @@ keywords = ["graphql", "compiler", "codec", "codegen"]
 categories = ["compilers"]
 
 [dependencies]
-wesley-core = { path = "../wesley-core", version = "0.1.0" }
+wesley-core = { path = "../wesley-core", version = "0.1.1" }

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.0" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.0" }
+wesley-core = { path = "../wesley-core", version = "0.1.1" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.1" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "TypeScript syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.0" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.0" }
+wesley-core = { path = "../wesley-core", version = "0.1.1" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.1" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-holmes/Cargo.toml
+++ b/crates/wesley-holmes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-holmes"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust Holmes law assurance foundation for Wesley semantic evidence"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wesley",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Core GraphQL compiler and assurance toolchain. Wesley brings the compiler; external modules bring target semantics.",


### PR DESCRIPTION
## Linked Issue
- Part of #624

## Why
This is the release-prep PR for Wesley v0.1.1. Releases must be cut from tagged `main`, so version metadata and changelog state need to land on `main` before the signed `v0.1.1` tag is created.

## Changes
- Bump the root package version to 0.1.1.
- Bump the Wesley Rust crates and workspace path dependency constraints to 0.1.1.
- Move the accumulated unreleased changelog entries under `0.1.1 - 2026-06-26` and update compare links.

## Risk
Low. This is metadata and changelog release prep only; no runtime or compiler behavior changes are introduced here.

## Backout
Revert this PR before tagging if release-prep validation fails. After a public tag/publish, do not rewrite history; follow up with a corrective patch release.

## Testing
- `cargo check --workspace --all-targets`
- `cargo xtask package-crates --version 0.1.1`
- `cargo xtask release-check`
- `pnpm install --lockfile-only --frozen-lockfile`
- `cargo xtask legacy-preflight`
- `cargo xtask docs-check`
- `pnpm run lint`
- `pnpm run preflight`
- `git diff --check`
- pre-push Rust product preflight
- pre-push JavaScript package preflight

## Release Gate
#624 remains open until this PR lands, synced `main` passes release guards, and the `v0.1.1` tag is cut from `main`.