### PR TITLE
docs(release): remove stale v0.1.1 backlog signpost

### DIFF
--- a/docs/method/backlog/bad-code/README.md
+++ b/docs/method/backlog/bad-code/README.md
@@ -12,4 +12,4 @@ Former cards from this lane were archived under
 `docs/method/graveyard/github-issue-migration/bad-code/`.
 Do not add new files here. Add or update GitHub Issues instead. Once debt is
 scheduled, replace `triage:bad-code` with a concrete release lane such as
-`v0.1.1`.
+`vX.Y.Z`.


### PR DESCRIPTION
## Linked Issue
- Release guard follow-up for #624

## Why
`cargo xtask release-prep-guard --version 0.1.1` failed because the legacy backlog signpost used `v0.1.1` as an example release lane. Active backlog signposts must not name the release being cut.

## Changes
- Replace the concrete `v0.1.1` example in `docs/method/backlog/bad-code/README.md` with `vX.Y.Z`.
- Left the signpost behavior unchanged: live debt intake remains GitHub Issues plus release labels.

## Risk
Very low. Documentation wording only.

## Backout
Revert this PR if the release guard should permit current-release examples in backlog signposts, though that would weaken the release gate.

## Testing
- `cargo xtask release-prep-guard --version 0.1.1`
- `cargo xtask docs-check`
- `git diff --check`
- pre-push Rust product preflight