### PR TITLE
docs(release): update README for v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ as release-scoped until the project declares a stable `1.0` surface.
 Install the published native CLI:
 
 ```bash
-cargo install wesley-cli --version 0.1.0
+cargo install wesley-cli --version 0.1.1
 wesley --help
 ```
 
@@ -120,12 +120,13 @@ extension consumes Wesley IR independently and emits its own artifacts.
 | Echo          | Echo-owned integration            | Runtime law, footprints, observation semantics        |
 | Continuum     | Continuum-owned module/repo       | Deferred protocol generation                          |
 
-## Current Release
+## What's New in v0.1.1
 
-Wesley `0.1.0` is the LE-binary codec-plan release. It ships the shared codec
-plan, TypeScript decode result cleanup, trailing-byte rejection, runtime port
-contracts, and the Rust-native compiler hardening staged before the release
-packet was finalized.
+Wesley `0.1.1` is the residue-purge and release-governance hardening release.
+It removes external host experiments and website/playground leftovers from the
+core release surface, keeps `0.1.x` public API compatibility aliases, vendors
+Bats helpers for deterministic CI, adds generated JSON schema validation, and
+hardens workflow, package-manager, and release scheduling guards.
 
 For complete history, read [CHANGELOG.md](./CHANGELOG.md).
 


### PR DESCRIPTION
## Linked Issue
- Release guard follow-up for #624

## Why
`cargo xtask release-guard --tag v0.1.1` failed because README still advertised the previous release in its install command and current-release section. The release tag has not been pushed.

## Changes
- Update the README install example to `wesley-cli --version 0.1.1`.
- Replace the old Current Release section with the exact `## What's New in v0.1.1` heading expected by the release guard.
- Summarize the v0.1.1 release from the changelog: residue purge, release governance hardening, compatibility aliases, deterministic CI helpers, generated JSON schema validation, and workflow/package-manager/release scheduling guards.

## Risk
Low. README-only release metadata correction.

## Backout
Revert this PR before tagging if v0.1.1 should not be released. After tag/publication, correct forward with a patch release.

## Testing
- `cargo xtask release-prep-guard --version 0.1.1`
- `cargo xtask docs-check`
- `git diff --check`
- README exact heading/version inspection with `rg`