### PR TITLE
docs(release): require topics audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **Release documentation gate**: The release runbook, release policy, and
+  human sign-off checklist now require a `docs/topics/` accuracy and coverage
+  audit before tagging, with minimum 90% accuracy and 90% coverage floors.
+
 ### Removed
 
 - **Rust Holmes law capability alias**: `wesley-holmes` no longer accepts the

--- a/docs/governance/RELEASE_CHECKLIST.md
+++ b/docs/governance/RELEASE_CHECKLIST.md
@@ -10,8 +10,8 @@ Automated checks are not listed here — those run inside
 creating a tag, run `cargo xtask release-check` locally; it runs the same
 strict preflight gate used by `release-guard`, then builds and packages the
 native release artifacts without publishing anything. This checklist covers
-checks 7, 10, 13, and 22 from the enforcement matrix, which require human
-judgment.
+checks 7, 10, 13, 18, 22, and 23 from the enforcement matrix, which require
+human judgment.
 
 See [`RELEASE_POLICY.md`](RELEASE_POLICY.md) for the full enforcement matrix
 and rationale.
@@ -40,6 +40,13 @@ and rationale.
       I spot-checked the guides in `docs/guides/` that are relevant to changes in
       this release. Commands, flags, file paths, and behavioral claims match the
       current codebase. I did not rely solely on the automated path/SHA checks.
+
+- [ ] **`docs/topics/` accuracy and coverage gate is met**
+      I audited every tracked file under `docs/topics/` for release-relevant
+      accuracy and coverage. At least 90% accuracy of audited topic claims and
+      at least 90% coverage of release-relevant contributor/operator topic
+      workflows are met. Any stale topic claim, obsolete instruction, missing
+      topic, or missing authoritative link was corrected before tagging.
 
 - [ ] **No known issues being silently shipped**
       I reviewed the open GitHub Issues for known defects or outstanding decisions

--- a/docs/governance/RELEASE_POLICY.md
+++ b/docs/governance/RELEASE_POLICY.md
@@ -49,6 +49,7 @@ lacks the human sign-off is not a valid release, and vice versa.
 | 20  | `BREAKING CHANGE` commits → major/minor version bump | git log        |          |
 | 21  | `cargo doc --workspace` builds with zero warnings    | cargo doc      |          |
 | 22  | No known issues silently shipped                     |                | reviewer |
+| 23  | `docs/topics/` accuracy and coverage gate            |                | reviewer |
 
 ## Automated Checks — Details
 
@@ -208,6 +209,17 @@ are being knowingly shipped without acknowledgment in the CHANGELOG or a
 documented follow-on issue. Automated issue-tracker checks surface issues by
 version label and milestone; they cannot detect an issue that was never labeled
 but is nonetheless blocking.
+
+### Check 23: `docs/topics/` Accuracy and Coverage Gate
+
+A human reviewer must audit every tracked file under `docs/topics/` before
+tagging. At least 90% of audited topic claims must match the current codebase,
+GitHub workflow, issue-triage model, and release policy, and at least 90% of
+release-relevant contributor/operator topic workflows must be covered by an
+existing `docs/topics/` page or by a clear link from `docs/topics/` to the
+authoritative current document. If either score is below 90%, the reviewer
+must update stale claims, remove obsolete instructions, add missing coverage,
+or link to the authoritative current surface before the release can proceed.
 
 The reviewer must also confirm that repo-resident release evidence is complete
 enough before tagging. Post-publish facts may live in the GitHub Release,

--- a/docs/method/release-runbook.md
+++ b/docs/method/release-runbook.md
@@ -63,6 +63,8 @@ per-version release log by default.
 
 Run validation strictly in order, using repo-native commands where available:
 
+- audit every tracked file under `docs/topics/` for release-relevant accuracy
+  and coverage
 - release pre-flight script, if the repo already has one
 - `cargo xtask release-prep-guard --version X.Y.Z`, before the tag exists
 - `cargo xtask preflight`
@@ -81,6 +83,20 @@ Run validation strictly in order, using repo-native commands where available:
 The Rust crates are the release authority for the native Wesley product. Do not
 use npm package publication as proof that a Wesley compiler release is ready;
 legacy packages are marked private while they remain in the retirement ledger.
+
+The `docs/topics/` audit is a release documentation gate, not a backlog
+exercise. Score it before continuing:
+
+- **Accuracy**: at least 90% of audited topic claims must match the current
+  codebase, GitHub workflow, issue-triage model, and release policy.
+- **Coverage**: at least 90% of release-relevant contributor/operator topic
+  workflows must be covered by an existing `docs/topics/` page or by a clear
+  link from `docs/topics/` to the authoritative current document.
+
+If either score is below 90%, act before continuing: update stale topic claims,
+remove obsolete instructions, add missing topic coverage, or link to the
+authoritative current surface. Abort only when the release cannot honestly
+reach the 90% accuracy and 90% coverage floors before tagging.
 
 Abort on the first hard failure. Do not claim success from queued or in-progress
 CI state.
@@ -113,4 +129,5 @@ minimum include:
 - tag and commit SHAs
 - GitHub Release URL
 - registry URLs
+- `docs/topics/` accuracy and coverage scores, with links to any corrections
 - any non-blocking warnings

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -37,6 +37,17 @@ load 'bats-plugins/bats-assert/load'
   assert_success
 }
 
+@test "release checklist includes docs topics accuracy and coverage gate" {
+  run grep -F 'docs/topics/' docs/governance/RELEASE_CHECKLIST.md
+  assert_success
+
+  run grep -F "90% accuracy" docs/governance/RELEASE_CHECKLIST.md
+  assert_success
+
+  run grep -F "90% coverage" docs/governance/RELEASE_CHECKLIST.md
+  assert_success
+}
+
 @test "entrypoints command map lists Rust LE binary emitter" {
   run grep -F "wesley emit le-binary-rust --schema <path> --out <path>" docs/ENTRYPOINTS.md
   assert_success


### PR DESCRIPTION
## Why

The release runbook did not explicitly require `docs/topics/` to be audited before tagging. Release prep needs a concrete human gate for topic accuracy and coverage, not just automated link checks.

## Changes

- Adds a Phase 3 validation step to audit every tracked file under `docs/topics/`.
- Defines a minimum 90% accuracy floor for topic claims.
- Defines a minimum 90% coverage floor for release-relevant contributor/operator workflows.
- Requires release engineers to update stale topic claims, remove obsolete instructions, add missing coverage, or link authoritative current docs before continuing.
- Records the topic audit scores and correction links in release evidence.

## Validation

- `cargo xtask docs-check`
- `git diff --check`
- Pre-push Rust product preflight

## Notes

No product/domain semantics changed. This is release-process documentation only.