### PR TITLE
docs(topics): tighten v0.2.0 release audit coverage

### DIFF
--- a/docs/architecture/holmes-integration.md
+++ b/docs/architecture/holmes-integration.md
@@ -105,6 +105,14 @@ reports/
 The PR comment builder detects that grouped layout and renders one anchored
 comment with separate sections for each schema set.
 
+Manifest `commentMode` controls the final PR comment behavior:
+
+| Mode     | Behavior                                    |
+| -------- | ------------------------------------------- |
+| `update` | Create or update one anchored PR comment.   |
+| `append` | Create a new PR comment for each run.       |
+| `silent` | Run analysis but do not write a PR comment. |
+
 ## Dashboard Artifact
 
 The workflow uploads `docs/holmes-dashboard` as a dashboard template and
@@ -127,11 +135,11 @@ own repo or through an explicitly designed external target boundary.
 Useful focused checks:
 
 ```bash
-cargo wesley config validate --json
-cargo wesley config changed-schemas \
+cargo run --bin wesley -- config validate --json
+cargo run --bin wesley -- config changed-schemas \
   --changed test/fixtures/examples/ecommerce.graphql \
   --json
-bats -t test/ci-workflows.bats
+BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 node --test packages/wesley-holmes/test/pr-comment.test.mjs
 ```
 

--- a/docs/reference/project-manifest.md
+++ b/docs/reference/project-manifest.md
@@ -58,6 +58,14 @@ Defaults:
 | `dashboard`   | disabled                     |
 | `targets`     | empty                        |
 
+`commentMode` accepts:
+
+| Value    | Behavior                                                          |
+| -------- | ----------------------------------------------------------------- |
+| `update` | Create or update one anchored automation comment.                 |
+| `append` | Create a new automation comment for each run.                     |
+| `silent` | Run automation and report artifacts without writing a PR comment. |
+
 ## Multi-Schema Manifest
 
 ```json

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -14,6 +14,7 @@ short path to the authoritative surface.
 | ------------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------ |
 | Decide whether a change belongs in Wesley or an extension.   | [Compiler Boundary](./compiler-boundary.md) | `docs/design/0014-domain-empty-core-boundary/`               |
 | Configure schema sets, changed-schema selection, or targets. | [Project Manifests](./project-manifests.md) | `docs/reference/project-manifest.md`                         |
+| Author or review descriptor-only extension fixtures.         | [Compiler Boundary](./compiler-boundary.md) | `docs/guides/module-authoring.md`                            |
 | Choose local checks before a PR or release.                  | [Validation](./validation.md)               | `cargo xtask preflight`, `docs/governance/RELEASE_POLICY.md` |
 | Understand HOLMES CI and evidence artifacts.                 | [HOLMES CI](./holmes-ci.md)                 | `.github/workflows/wesley-holmes.yml`, `docs/architecture/`  |
 | Prepare or judge a release.                                  | [Releases](./releases.md)                   | `docs/method/release-runbook.md`, `docs/governance/`         |

--- a/docs/topics/holmes-ci.md
+++ b/docs/topics/holmes-ci.md
@@ -26,6 +26,10 @@ inventing work.
 - CodeRabbit and HOLMES are separate review surfaces.
 - HOLMES report artifacts are grouped by schema set.
 - The dashboard artifact is an artifact viewer, not a Wesley website product.
+- `commentMode: silent` suppresses the aggregate PR comment; it does not skip
+  schema-set analysis or report artifacts.
+- Invalid manifests fail the workflow. Legacy fallback is only for the
+  no-manifest case.
 - Missing or invalid report artifacts should be reported as unavailable or
   diagnostic evidence, not hidden behind a passing workflow.
 - Target-specific facts belong in external modules that generate their own
@@ -34,8 +38,8 @@ inventing work.
 ## Local Checks
 
 ```bash
-cargo wesley config validate --json
-cargo wesley config changed-schemas --json
+cargo run --bin wesley -- config validate --json
+cargo run --bin wesley -- config changed-schemas --json
 BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 node --test packages/wesley-holmes/test/pr-comment.test.mjs
 ```

--- a/docs/topics/project-manifests.md
+++ b/docs/topics/project-manifests.md
@@ -47,6 +47,8 @@ wesley config changed-schemas --changed-file changed-files.txt --json
 - Top-level rebuild globs select every schema set.
 - Schema-local rebuild globs select only that schema set.
 - Selected multi-schema bundles are isolated under `bundleDir/<schema-id>`.
+- `commentMode` controls PR comment behavior for automation:
+  `update`, `append`, or `silent`.
 - Target names are metadata. External modules own target behavior.
 
 ## Related Authority


### PR DESCRIPTION
## Linked Issue

Release gate context: #625. This PR closes the `docs/topics/` release-gate correction found after PR #650 merged and before tagging v0.2.0.

## Branch / Issue-Title Check

- [x] Exception: `docs/topic-audit-v0.2.0` is a release-gate docs audit branch, not a single issue-title slug.

## Summary

Tightens `docs/topics/` coverage and accuracy for the just-merged v0.2.0 platform batch before cutting the release tag.

## Why

The v0.2.0 release checklist requires auditing `docs/topics/` for release-relevant accuracy and coverage. The post-merge audit found that the new topic surface existed, but two release-relevant facts were either wrong or under-covered:

- HOLMES local-check examples used invalid `cargo wesley ...` commands.
- Manifest `commentMode` behavior, especially `silent`, was not explicit in the topic/reference path.
- Descriptor-only extension fixture/module-authoring workflow was not discoverable from the topic index.

## Changes

- Corrected HOLMES local-check commands to use `cargo run --bin wesley -- ...`.
- Added `commentMode` behavior to the project manifest topic and reference page.
- Added `commentMode` and invalid-manifest fallback behavior to the HOLMES CI topic.
- Added `commentMode` behavior and corrected focused checks in the HOLMES integration architecture page.
- Added descriptor-only extension fixture workflow discovery to the topic index.

## Method Evidence

- [x] Design doc linked or not required: not required; this is release-gate documentation correction.
- [x] Tests or validation evidence included.
- [x] Playback/witness included or not required.
- [x] Retro or closeout evidence included or not required: release gate #625 remains open until v0.2.0 is tagged and published.

## Tracker Hygiene

- [x] Linked issue had `work-in-progress` while active, or no single linked implementation issue applies.
- [x] Linked issue lane/status/legend labels are current: #625 remains the v0.2.0 release gate.
- [x] Follow-up work is captured as GitHub Issues, not hidden in chat or local-only backlog files.

## Risk

Low. This is docs-only, but it is release-gate relevant because the corrected commands and topic coverage are part of the v0.2.0 release audit.

## Backout

Revert this PR before tagging v0.2.0, then rerun the `docs/topics/` release audit and document the exception in #625. Preferred path is to keep this correction and tag from the resulting `main` commit.

## Testing

- `cargo xtask docs-check`
- `git diff --check`
- `pnpm exec prettier --check docs/topics/README.md docs/topics/project-manifests.md docs/topics/holmes-ci.md docs/architecture/holmes-integration.md docs/reference/project-manifest.md`
- `cargo run --bin wesley -- config validate --json`
- `cargo run --bin wesley -- config changed-schemas --json`
- `BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats`
- `node --test packages/wesley-holmes/test/pr-comment.test.mjs`
- pre-push `cargo xtask preflight`

## EvidenceMap / SourceMap (if applicable)

N/A.

## Screenshots / Logs (optional)

N/A.

## Merge Strategy

- Merge commit only; no rebase.
- Delete branch after merge.

## Checklist

- [x] One-topic PR with tight diff
- [x] Rust-native preflight passes (`cargo xtask preflight` via pre-push)
- [x] Legacy package preflight not required for docs-only change
- [x] No widened permissions/secrets in workflows
- [x] Docs updated if behavior changed
