### PR TITLE
docs(signposts): refresh topic routing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Wesley
 
-Wesley is a local-first system for planning, rehearsing, certifying, and
-explaining semantic contract changes with durable compiler truth,
-evidence-backed judgment, and explicit extension boundaries.
+Wesley is a local-first, domain-free GraphQL-to-IR compiler and assurance
+toolchain with durable compiler truth, evidence-backed judgment, and explicit
+extension boundaries.
 
 This repo now uses METHOD for workflow. Wesley's product doctrine remains
 Wesley's. METHOD defines how work is queued, pulled, proved, and closed.
@@ -23,7 +23,8 @@ Read these surfaces in order:
 
 ## Repository Doctrine
 
-Wesley exists to make schema-authored semantic change trustworthy.
+Wesley exists to make schema-authored structural change trustworthy while
+letting external owners assign domain semantics.
 
 That means:
 
@@ -39,9 +40,9 @@ That means:
 - local-first operation beats unnecessary network dependence
 
 Wesley is not a database product, runtime, scheduler, or hidden platform for
-product policy. It is the semantic contract compiler and assurance toolchain;
-the `GraphQL -> whatever` side must enter through explicit modules or owning
-repos such as `wesley-postgres`.
+product policy. It extracts GraphQL structure into deterministic IR and
+evidence; the domain side must enter through explicit modules or owning repos
+such as `wesley-postgres`.
 
 ## Repo Queue
 
@@ -183,7 +184,7 @@ cargo xtask preflight
 node scripts/pre-push-sanity.mjs --dry-run --files <changed-file> ...
 cargo test -p wesley-core
 cargo test -p wesley-cli
-cargo wesley --help
+cargo run --bin wesley -- --help
 ```
 
 For autonomous contributors, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ wesley --help
 From a source checkout:
 
 ```bash
-cargo install --locked --path crates/wesley-cli
-cargo wesley --help
+cargo run --bin wesley -- --help
 cargo xtask preflight
 ```
 
 Lower GraphQL SDL into Wesley L1 IR:
 
 ```bash
-cargo wesley schema lower \
+cargo run --bin wesley -- schema lower \
   --schema test/fixtures/ir-parity/small-schema.graphql \
   --json
 ```
@@ -65,12 +64,12 @@ cargo wesley schema lower \
 Generate target-neutral Rust or TypeScript projections:
 
 ```bash
-cargo wesley emit rust \
+cargo run --bin wesley -- emit rust \
   --schema test/fixtures/weslaw/contract-bundle-shape.graphql \
   --out generated/model.rs \
   --metadata-out generated/model.metadata.json
 
-cargo wesley emit typescript \
+cargo run --bin wesley -- emit typescript \
   --schema test/fixtures/weslaw/contract-bundle-shape.graphql \
   --out generated/types.ts \
   --metadata-out generated/types.metadata.json
@@ -85,8 +84,8 @@ cargo xtask preflight
 Validate a project manifest when a repo wants config-driven schema selection:
 
 ```bash
-cargo wesley config validate --config wesley.config.json --json
-cargo wesley config changed-schemas \
+cargo run --bin wesley -- config validate --config wesley.config.json --json
+cargo run --bin wesley -- config changed-schemas \
   --config wesley.config.json \
   --changed test/fixtures/examples/ecommerce.graphql \
   --json
@@ -143,6 +142,7 @@ For complete history, read [CHANGELOG.md](./CHANGELOG.md).
 ## Reference Map
 
 - [Docs entrance](./docs/README.md)
+- [Topics](./docs/topics/README.md)
 - [Guide](./docs/GUIDE.md)
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Wesley North Star](./docs/NORTHSTAR.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,8 @@ The active ownership doctrine is
 If you are trying to figure out where to start, read
 [ENTRYPOINTS.md](./ENTRYPOINTS.md) first. This document is the deeper structural
 map; the entrypoint map is the short answer to "which Wesley do I run or edit?"
+If you already know the task, use [Topics](./topics/README.md) for the shortest
+path to the right command, workflow, or boundary page.
 
 For the noun-by-noun reference, use [WESLEY_GLOSSARY.md](./WESLEY_GLOSSARY.md).
 For current direction and active tensions, use [BEARING.md](./BEARING.md).
@@ -130,7 +132,7 @@ semantics.
 | `test/fixtures/`                 | GraphQL fixtures, Rust L1 goldens, package examples, and reference schemas.                                                                                                                                          |
 | `scripts/`                       | Preflight, docs truth, docs link, fixture generation, smoke, and CI helper scripts.                                                                                                                                  |
 | `docs/`                          | Operator docs, architecture, design packets, audits, specs, method docs, and archived backlog migration evidence.                                                                                                    |
-| `.github/workflows/`             | CI workflows for Rust, packages, docs, security, and progress badges.                                                                                                                                                |
+| `.github/workflows/`             | CI workflows for Rust, packages, docs, security, release, and assurance checks.                                                                                                                                      |
 
 Some directories still contain extraction residue. In particular,
 `packages/wesley-generator-echo/` exists on disk but is not an active tracked

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -5,17 +5,19 @@
 Wesley has one intended front door:
 
 ```bash
-cargo wesley --help
+cargo run --bin wesley -- --help
 ```
 
 For published alpha builds, the crates.io package is `wesley-cli` and the
-installed command is `wesley`. The `0.1.0` install command is valid after the
-tag-driven release workflow publishes that version:
+installed command is `wesley`. The current published alpha is `0.1.1`:
 
 ```bash
-cargo install wesley-cli --version 0.1.0
+cargo install wesley-cli --version 0.1.1
 wesley --help
 ```
+
+Use [Topics](./topics/README.md) when you know the task and need the shortest
+current route to the right command, workflow, or boundary document.
 
 The native command is now the first user-facing Rust surface for compiler facts.
 The deeper source of truth is still the Rust library under `crates/wesley-core`.
@@ -51,7 +53,7 @@ Rust Wesley is the emerging compiler kernel.
 
 It can:
 
-- parse and lower GraphQL SDL into the L1 semantic IR
+- parse and lower GraphQL SDL into domain-empty L1 IR
 - consolidate `extend type` blocks before lowering
 - print a normalized SDL view of Rust compiler facts and its SHA-256 evidence
   hash

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,10 +1,14 @@
 # Guide — Wesley
 
-This is the developer-level operator guide for Wesley. Use it for orientation, the productive-fast path, and to understand how the contract compiler orchestrates shared truth.
+This is the developer-level operator guide for Wesley. Use it for orientation,
+the productive-fast path, and the domain-free compiler/toolchain split.
 
 For deep-track doctrine, IR model internals, and custom generator development, use [ADVANCED_GUIDE.md](./ADVANCED_GUIDE.md).
 
 If you need the main Wesley nouns and the layer split before reading anything else, start with [WESLEY_GLOSSARY.md](./WESLEY_GLOSSARY.md).
+
+If you know the task you are trying to perform and need the shortest current
+route, start with [Topics](./topics/README.md).
 
 ## Choose Your Lane
 
@@ -13,16 +17,16 @@ If you need the main Wesley nouns and the layer split before reading anything el
 Compile authored GraphQL into generic or explicitly selected generated
 artifacts.
 
-- **Inspect native CLI**: `cargo wesley --help`
+- **Inspect native CLI**: `cargo run --bin wesley -- --help`
 - **Read native CLI reference**: [docs/reference/cli.md](./reference/cli.md)
-- **Doctor native CLI**: `cargo wesley doctor`
-- **Install published alpha**: `cargo install wesley-cli --version 0.1.0`
+- **Doctor native CLI**: `cargo run --bin wesley -- doctor`
+- **Install published alpha**: `cargo install wesley-cli --version 0.1.1`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Strict preflight**: `cargo xtask preflight`
 - **Explicit alias**: `cargo xtask strict-preflight`
 - **Release check**: `cargo xtask release-check`
-- **Project manifest**: `cargo wesley config validate --json`
-- **Changed schemas**: `cargo wesley config changed-schemas --changed <path> --json`
+- **Project manifest**: `cargo run --bin wesley -- config validate --json`
+- **Changed schemas**: `cargo run --bin wesley -- config changed-schemas --changed <path> --json`
 
 The Rust-native CLI is now the normal front door for Wesley core work. The
 native binary stays small while core behavior moves into the Rust library.
@@ -36,11 +40,12 @@ Use `wesley doctor` when you need a narrow Rust-native health check for the
 native CLI, Rust lowerer, normalized SDL hashing, and Rust emitter crates. It
 does not inspect legacy Node config, plugins, or package state.
 
-Use `cargo install wesley-cli --version 0.1.0` when you want the published
-`0.1.0` alpha `wesley` binary on your PATH. Before the release workflow has
-published that version, use `cargo install --locked --path crates/wesley-cli`
-when working from this checkout. Use `cargo xtask preflight` before opening a
-PR. This is the strict quality gate: it runs `cargo fmt --check`,
+Use `cargo install wesley-cli --version 0.1.1` when you want the latest
+published alpha `wesley` binary on your PATH. Use
+`cargo run --bin wesley -- ...` when working directly from this checkout, or
+`cargo install --locked --path crates/wesley-cli` when you need a local
+installed binary. Use `cargo xtask preflight` before opening a PR. This is the
+strict quality gate: it runs `cargo fmt --check`,
 `cargo clippy --workspace --all-targets -- -D warnings`,
 `pnpm audit --prod=false --json`, docs checks, workspace tests, and a native
 CLI smoke test. Use `cargo xtask release-check` before cutting native release
@@ -91,10 +96,11 @@ validation output.
 
 ### 2. External Module Lane
 
-Bring the `whatever` side of `GraphQL -> whatever` through an owning module,
-package, or sibling repo. The historical Node dynamic module loader and
-`wesley.config.mjs` command-dispatch path are retired; the native Rust CLI does
-not currently load arbitrary JavaScript modules as product commands.
+Bring the domain side of `GraphQL SDL -> deterministic Wesley IR -> your domain`
+through an owning module, package, or sibling repo. The historical Node dynamic
+module loader and `wesley.config.mjs` command-dispatch path are retired; the
+native Rust CLI does not currently load arbitrary JavaScript modules as product
+commands.
 
 External targets still own target semantics, generators, witness scopes,
 release profiles, and runtime conventions. Today that ownership is expressed
@@ -183,7 +189,8 @@ Wesley is a tiered engine designed to enforce contract integrity across platform
 
 ## Rule of Thumb
 
-If you need the native command reference, use `cargo wesley --help`.
+If you need the native command reference, use [CLI Reference](./reference/cli.md)
+or `cargo run --bin wesley -- --help`.
 
 If you need to know "what's true right now," use [BEARING.md](./BEARING.md).
 

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -23,6 +23,7 @@ The Wesley work doctrine: GitHub Issues, a loop, and honest bookkeeping.
 | :-------------------------------------------------- | :------------------------------------------------------------------ |
 | **`README.md`**                                     | Public front door and project identity.                             |
 | **`docs/GUIDE.md`**                                 | Orientation and productive-fast path.                               |
+| **`docs/topics/`**                                  | Task-oriented routes across references, workflows, and boundaries.  |
 | **`BEARING.md`**                                    | Current direction and active tensions.                              |
 | **`VISION.md`**                                     | Core tenets and the "Trustworthy Change" mission.                   |
 | **`docs/ARCHITECTURE.md`**                          | Authoritative system map and pipeline.                              |
@@ -112,6 +113,7 @@ Use [Wesley Documentation Standard](./governance/DOCUMENTATION_STANDARD.md) for
 the repo-specific documentation contract. The short version:
 
 - docs explain stable truth, direction, and evidence
+- `docs/topics/` routes task readers to the current authoritative surface
 - GitHub tracks backlog, progress, release gates, and roadmap state
 - design packets are not live status boards
 - `CHANGELOG.md` records merged behavior, not plans

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ which signpost is supposed to answer which question.
 | [Project Manifest](./reference/project-manifest.md)                         | Current JSON/YAML manifest schema for schemas, rebuild selection, bundles, and target metadata.       |
 | [Directive Truth Table](./reference/directives.md)                          | Current directive support levels, aliases, external families, and fixture boundaries.                 |
 | [Topics](./topics/README.md)                                                | Operator and contributor task pages that bridge references, governance, and workflows.                |
+| [Docs Orientation](./topics/docs-orientation.md)                            | Task page for choosing the right signpost without turning docs into a backlog mirror.                 |
 | [VISION](./VISION.md)                                                       | Bounded executive synthesis grounded in repo-visible truth.                                           |
 | [Design Packets](./design/README.md)                                        | Active design packets and doctrinal boundary notes.                                                   |
 | [METHOD Process](./method/process.md)                                       | How cycles run, close, and reconcile in this repo.                                                    |
@@ -83,6 +84,8 @@ It also now has a more explicit METHOD closeout surface under
 ### Product Orientation
 
 - [README.md](../README.md)
+- [Topics](./topics/README.md)
+- [Docs Orientation](./topics/docs-orientation.md)
 - [END_TO_END.md](./END_TO_END.md)
 - [ENTRYPOINTS.md](./ENTRYPOINTS.md)
 - [LEGACY_NODE_MIGRATION.md](./LEGACY_NODE_MIGRATION.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ This reference describes the Rust-native `wesley` command shipped by the
 `wesley-cli` crate.
 
 The command help text is the implementation source of truth. Refresh this page
-from `cargo wesley --help` and the nested `--help` commands whenever the CLI
+from `cargo run --bin wesley -- --help` and the nested `--help` commands whenever the CLI
 surface changes.
 
 ## Root Command

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -44,10 +44,11 @@ short path to the authoritative surface.
 
 ### Contributor Process
 
-| Task                              | Start Here                                | Authority                                       |
-| --------------------------------- | ----------------------------------------- | ----------------------------------------------- |
-| Triage issues into release lanes. | [Issue Triage](./contributing/triage.md)  | GitHub Issues, Milestones, Projects, and labels |
-| Keep docs accurate and covered.   | [Docs Maintenance](./docs-maintenance.md) | `docs/governance/DOCUMENTATION_STANDARD.md`     |
+| Task                               | Start Here                                | Authority                                       |
+| ---------------------------------- | ----------------------------------------- | ----------------------------------------------- |
+| Find the right documentation path. | [Docs Orientation](./docs-orientation.md) | `docs/README.md`                                |
+| Triage issues into release lanes.  | [Issue Triage](./contributing/triage.md)  | GitHub Issues, Milestones, Projects, and labels |
+| Keep docs accurate and covered.    | [Docs Maintenance](./docs-maintenance.md) | `docs/governance/DOCUMENTATION_STANDARD.md`     |
 
 ## Coverage Rule
 

--- a/docs/topics/docs-orientation.md
+++ b/docs/topics/docs-orientation.md
@@ -1,0 +1,42 @@
+# Docs Orientation
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Use this topic when you need the right documentation entry point and do not
+want to reverse-engineer the repo map.
+
+Wesley docs have one job per surface. Use the task map here to pick the right
+surface, then follow that surface's authority links.
+
+## Common Tasks
+
+| Task                                   | Start Here                                                             |
+| -------------------------------------- | ---------------------------------------------------------------------- |
+| Understand what Wesley is.             | [README](../../README.md)                                              |
+| Find a task-specific path.             | [Topics Index](./README.md)                                            |
+| Orient across all docs signposts.      | [Docs Entrance](../README.md)                                          |
+| Understand the current architecture.   | [Architecture](../ARCHITECTURE.md)                                     |
+| Understand current direction.          | [Bearing](../BEARING.md)                                               |
+| Understand work doctrine.              | [Method](../METHOD.md)                                                 |
+| Pick the right command surface.        | [Native CLI](./native-cli.md)                                          |
+| Decide whether work belongs in Wesley. | [Compiler Boundary](./compiler-boundary.md)                            |
+| Maintain docs without shadow planning. | [Docs Maintenance](./docs-maintenance.md)                              |
+| Prepare or judge a release.            | [Releases](./releases.md)                                              |
+| Triage or schedule GitHub issues.      | [Issue Triage](./contributing/triage.md)                               |
+| Find live roadmap or release work.     | [GitHub Milestones](https://github.com/flyingrobots/wesley/milestones) |
+
+## Rules Of Thumb
+
+- Start with `docs/topics/` when you know the task.
+- Start with `docs/README.md` when you need the full documentation map.
+- Start with `docs/BEARING.md` when you need current direction, not live
+  progress.
+- Use GitHub Issues, Milestones, Projects, and labels for live work state.
+- Do not add a new signpost unless it has a distinct reader job.
+
+## Related Authority
+
+- [Docs Entrance](../README.md)
+- [Documentation Standard](../governance/DOCUMENTATION_STANDARD.md)
+- [Docs Maintenance](./docs-maintenance.md)
+- [Method](../METHOD.md)

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -157,6 +157,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/docs-orientation.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/topics/emitters.md",
       "status": "current",
       "owner": "@flyingrobots"

--- a/test/docs-planning-boundary.bats
+++ b/test/docs-planning-boundary.bats
@@ -84,3 +84,22 @@ load 'bats-plugins/bats-assert/load'
   run test -e docs/method/graveyard/EXTERNAL_echo-ir-v2.md
   assert_success
 }
+
+@test "front-door signposts route task readers through docs topics" {
+  run grep -F "[Topics](./docs/topics/README.md)" README.md
+  assert_success
+
+  run grep -F "[Topics](./topics/README.md)" docs/README.md
+  assert_success
+
+  run grep -F "[Docs Orientation](./topics/docs-orientation.md)" docs/README.md
+  assert_success
+
+  run grep -F "[Docs Orientation](./docs-orientation.md)" docs/topics/README.md
+  assert_success
+}
+
+@test "active signposts do not advertise the retired 0.1.0 install command" {
+  run rg -n "cargo install wesley-cli --version 0\\.1\\.0" README.md docs/GUIDE.md docs/ENTRYPOINTS.md CONTRIBUTING.md
+  assert_failure
+}


### PR DESCRIPTION
## Summary

- add a `docs/topics/docs-orientation.md` topic for choosing the right documentation signpost
- route README, docs entrance, guide, architecture, method, entrypoints, and contributing docs through the expanded topic map
- refresh active install/source-checkout examples away from stale `wesley-cli 0.1.0` and toward current `0.1.1` / `cargo run --bin wesley -- ...`
- add Bats guards that keep front-door signposts connected to `docs/topics` and prevent the retired `0.1.0` install command from returning

## Verification

- `BATS_LIB_PATH=test/vendor bats -t test/docs-planning-boundary.bats`
- `cargo xtask docs-check`
- `node scripts/check-doc-cli-commands.mjs`
- `pnpm exec prettier --check README.md CONTRIBUTING.md docs/README.md docs/GUIDE.md docs/ARCHITECTURE.md docs/ENTRYPOINTS.md docs/METHOD.md docs/reference/cli.md docs/topics/*.md docs/topics/contributing/triage.md docs/truth-manifest.json`
- `BATS_LIB_PATH=test/vendor bats -t test/release-governance.bats`
- `git diff --check`
- `cargo xtask preflight`
- pre-push Rust product preflight + repo Bats smoke suite
