### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-26
+
 ### Added
 
 - **Project manifest and config CLI**: Added the domain-free
@@ -21,6 +23,11 @@ hash`, and `schema operations`.
 - **Contributor onramp**: Added a public near-term roadmap issue and scoped
   `good first issue` starter tasks, and linked the onboarding path from
   `CONTRIBUTING.md`.
+- **Comprehensive topic map**: Expanded `docs/topics/` into a current operator
+  and contributor map covering the native CLI, schema IR, operations,
+  directives, emitters, artifacts, compiler boundaries, project manifests,
+  extension modules, legacy Node retirement, CI, HOLMES, releases, invariants,
+  and docs maintenance.
 
 ### Changed
 
@@ -34,6 +41,10 @@ changed-schemas`, runs schema-scoped matrix jobs, and keeps per-schema report
 - **Extension documentation**: Added current project-manifest and module
   authoring references, and clarified that `wesley.config.mjs` and the dynamic
   JavaScript module loader are retired from generic Wesley core.
+- **Release signposts**: Refreshed README, GUIDE, ENTRYPOINTS, ARCHITECTURE,
+  METHOD, CONTRIBUTING, and docs topic routing so the current docs point at the
+  domain-free GraphQL-to-IR platform and the topic map rather than stale
+  backlog or retired command surfaces.
 
 ### Removed
 
@@ -1569,7 +1580,8 @@ kind` instead of being silently accepted via structural duck-typing. All
 
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/flyingrobots/wesley/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/flyingrobots/wesley/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/flyingrobots/wesley/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/flyingrobots/wesley/compare/v0.0.4...v0.0.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-codec"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "wesley-core",
 ]
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-holmes"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ as release-scoped until the project declares a stable `1.0` surface.
 Install the published native CLI:
 
 ```bash
-cargo install wesley-cli --version 0.1.1
+cargo install wesley-cli --version 0.2.0
 wesley --help
 ```
 
@@ -129,13 +129,14 @@ extension consumes Wesley IR independently and emits its own artifacts.
 | Echo          | Echo-owned integration            | Runtime law, footprints, observation semantics        |
 | Continuum     | Continuum-owned module/repo       | Deferred protocol generation                          |
 
-## What's New in v0.1.1
+## What's New in v0.2.0
 
-Wesley `0.1.1` is the residue-purge and release-governance hardening release.
-It removes external host experiments and website/playground leftovers from the
-core release surface, keeps `0.1.x` public API compatibility aliases, vendors
-Bats helpers for deterministic CI, adds generated JSON schema validation, and
-hardens workflow, package-manager, and release scheduling guards.
+Wesley `0.2.0` is the domain-free project-manifest platform release. It adds
+the JSON/YAML `wesley.project-manifest/v1` surface, native `wesley config`
+commands, manifest-driven schema selection for HOLMES CI, descriptor-only
+extension fixture modules, and a comprehensive `docs/topics/` operator map.
+The release keeps the boundary explicit: Wesley extracts structure from
+GraphQL, and extensions assign meaning.
 
 For complete history, read [CHANGELOG.md](./CHANGELOG.md).
 

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.1" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.1.1" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.1.1" }
+wesley-core = { path = "../wesley-core", version = "0.2.0" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.2.0" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.2.0" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-emit-codec/Cargo.toml
+++ b/crates/wesley-emit-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-codec"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Language-neutral LE-binary codec plan lowered from Wesley L1 IR, shared by the Rust and TypeScript codec emitters."
@@ -12,4 +12,4 @@ keywords = ["graphql", "compiler", "codec", "codegen"]
 categories = ["compilers"]
 
 [dependencies]
-wesley-core = { path = "../wesley-core", version = "0.1.1" }
+wesley-core = { path = "../wesley-core", version = "0.2.0" }

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Rust syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.1" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.1" }
+wesley-core = { path = "../wesley-core", version = "0.2.0" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.2.0" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "TypeScript syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.1.1" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.1.1" }
+wesley-core = { path = "../wesley-core", version = "0.2.0" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.2.0" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-holmes/Cargo.toml
+++ b/crates/wesley-holmes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-holmes"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Rust Holmes law assurance foundation for Wesley semantic evidence"
 license = "MIT"

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -9,10 +9,10 @@ cargo run --bin wesley -- --help
 ```
 
 For published alpha builds, the crates.io package is `wesley-cli` and the
-installed command is `wesley`. The current published alpha is `0.1.1`:
+installed command is `wesley`. The current published alpha is `0.2.0`:
 
 ```bash
-cargo install wesley-cli --version 0.1.1
+cargo install wesley-cli --version 0.2.0
 wesley --help
 ```
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -20,7 +20,7 @@ artifacts.
 - **Inspect native CLI**: `cargo run --bin wesley -- --help`
 - **Read native CLI reference**: [docs/reference/cli.md](./reference/cli.md)
 - **Doctor native CLI**: `cargo run --bin wesley -- doctor`
-- **Install published alpha**: `cargo install wesley-cli --version 0.1.1`
+- **Install published alpha**: `cargo install wesley-cli --version 0.2.0`
 - **Install locally**: `cargo install --locked --path crates/wesley-cli`
 - **Strict preflight**: `cargo xtask preflight`
 - **Explicit alias**: `cargo xtask strict-preflight`
@@ -40,7 +40,7 @@ Use `wesley doctor` when you need a narrow Rust-native health check for the
 native CLI, Rust lowerer, normalized SDL hashing, and Rust emitter crates. It
 does not inspect legacy Node config, plugins, or package state.
 
-Use `cargo install wesley-cli --version 0.1.1` when you want the latest
+Use `cargo install wesley-cli --version 0.2.0` when you want the latest
 published alpha `wesley` binary on your PATH. Use
 `cargo run --bin wesley -- ...` when working directly from this checkout, or
 `cargo install --locked --path crates/wesley-cli` when you need a local

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -10,8 +10,7 @@
 > [BEARING.md](./BEARING.md) for current direction and active tensions.
 
 This document is an end-to-end technical explanation of the Wesley repository
-as it exists on the `main` branch on June 26, 2026 (post-PR #642, before the
-`v0.1.1` release tag is cut).
+as prepared for the `v0.2.0` release on June 26, 2026.
 
 It assumes no prior knowledge of Wesley, its domain, or its implementation.
 The explanation starts with the business and domain concepts, then follows the
@@ -22,11 +21,11 @@ compiler kernel, emitters, semantic law layer, and Holmes assurance foundation.
 
 ### What This Repository Contains
 
-Wesley is a schema-first compiler kernel and assurance toolchain. Its central
-promise is that an authored GraphQL Schema Definition Language document can be
-treated as the source of truth, lowered into deterministic compiler facts, and
-projected into generated artifacts or evidence reports without allowing those
-derived artifacts to become peer authorities.
+Wesley is a domain-free GraphQL-to-IR compiler kernel and assurance toolchain.
+Its central promise is that an authored GraphQL Schema Definition Language
+document can be lowered into deterministic structure and projected into
+generated artifacts or evidence reports without allowing those derived
+artifacts to become peer authorities.
 
 The current product center is the Rust workspace. The core compiler crate is
 `crates/wesley-core`, the user-facing native binary is
@@ -34,16 +33,16 @@ The current product center is the Rust workspace. The core compiler crate is
 `crates/wesley-emit-rust` and `crates/wesley-emit-typescript`. The
 `crates/wesley-holmes` crate is an unpublished Rust foundation for law
 assurance. JavaScript packages remain, but the repository docs classify them as
-non-compiler surfaces: Holmes compatibility tooling, website or docs plumbing,
-and repository automation. Browser/Bun/Deno host smoke experiments are retired
-from the Wesley release surface.
+non-compiler surfaces: Holmes compatibility tooling, docs support, and
+repository automation. Browser/Bun/Deno host smoke experiments are retired from
+the Wesley release surface.
 
 ### How It Works
 
 At runtime, a user normally runs the native command:
 
 ```bash
-cargo wesley --help
+cargo run --bin wesley -- --help
 ```
 
 or, after installation:
@@ -61,20 +60,20 @@ assurance ingestion lives in `wesley-holmes`.
 
 ### Current Version And Next Work
 
-The Rust crates in this checkout declare version `0.1.1`, and the public README
-now carries the matching "What's New in v0.1.1" release note. The changelog's
-dated `0.1.1` section carries the residue purge, roadmap governance cleanup,
-`0.1.x` compatibility aliases, vendored Bats helpers, generated JSON schema
-validation, workflow/package-manager policy guards, release scheduling guards,
-and directive example honesty work. This is a pre-1.0 patch release over the
-published `v0.1.0` codec-plan baseline.
+The Rust crates in this checkout declare version `0.2.0`, and the public README
+now carries the matching "What's New in v0.2.0" release note. The changelog's
+dated `0.2.0` section carries the project manifest and config CLI, manifest-led
+HOLMES schema selection, descriptor-only fixture module zoo, docs/topic coverage
+expansion, release documentation gate, and removal of the old Holmes capability
+alias. This is a pre-1.0 minor release over the published `v0.1.1`
+residue-purge baseline.
 
-As of this teardown refresh, `cargo xtask preflight`, `cargo xtask
-release-check`, `cargo xtask package-crates --version 0.1.1`, and
-`cargo xtask release-prep-guard --version 0.1.1` pass locally. The obsolete
-2025 `#60` v0.1.0 umbrella issue remains closed as not planned because it no
-longer represents current release scope, and the `v0.1.1` release gate has no
-remaining open issue work.
+As of this teardown refresh, the release branch is prepared to run
+`cargo xtask release-prep-guard --version 0.2.0`, `cargo xtask preflight`,
+`cargo xtask release-check`, and `cargo xtask package-crates --version 0.2.0`.
+The `v0.2.0` release gate is the only issue scheduled in the `Release: v0.2.0`
+milestone, and it remains open until the release commit lands on synced `main`
+and the signed tag is cut.
 
 The active project direction is to finish the Rust-native compiler spine,
 preserve the domain-empty boundary, and grow Holmes law-assurance ingestion
@@ -253,13 +252,20 @@ emitters onto the same language-neutral plan, made TypeScript public decoders
 return `Result<T>`, and updated the release notes, changelog, and package
 metadata for the pre-1.0 minor release.
 
-The `0.1.1` release preparation removes old browser, Bun, Deno, website, and
-playground residue from the active Wesley product surface; records the `v0.1.0`
-publication evidence; moves live roadmap state to GitHub Issues, labels,
-projects, and milestones; preserves the `0.1.x` public API alias bridge; vendors
-Bats helper dependencies for deterministic CI; adds generated JSON schema
-validation coverage; and hardens release guards around concrete version
+The `0.1.1` release removed old browser, Bun, Deno, website, and playground
+residue from the active Wesley product surface; recorded the `v0.1.0`
+publication evidence; moved live roadmap state to GitHub Issues, labels,
+projects, and milestones; preserved the `0.1.x` public API alias bridge;
+vendored Bats helper dependencies for deterministic CI; added generated JSON
+schema validation coverage; and hardened release guards around concrete version
 scheduling.
+
+The `0.2.0` release adds a domain-free JSON/YAML project manifest,
+`wesley config validate`, `wesley config inspect`, and
+`wesley config changed-schemas`; lets single-schema manifests supply defaults
+for `schema lower`, `schema hash`, and `schema operations`; drives HOLMES CI
+through manifest-selected schema sets; adds descriptor-only extension fixtures;
+and expands `docs/topics/` into the current operator/contributor routing map.
 
 The Holmes law assurance foundation remains an unpublished Rust crate. It has
 evidence, ingest, policy, gate, and suppression foundations, but concrete
@@ -288,12 +294,11 @@ intentionally not yet exposed as a public Holmes CLI from Rust.
 
 ### Current Tensions
 
-The README now describes `v0.1.1`, aligned with the `Cargo.toml` crate version
-declared across the workspace. The changelog's dated `0.1.1` section carries
-the post-`0.1.0` residue purge and release-governance hardening work. Release
-preparation is no longer blocked by stale current-release issue text, stale
-filesystem backlog signposts, or the old README release headline; the current
-pre-tag guard passes for `0.1.1`.
+The README now describes `v0.2.0`, aligned with the `Cargo.toml` crate version
+declared across the workspace. The changelog's dated `0.2.0` section carries
+the post-`0.1.1` project-manifest, HOLMES schema-selection, and documentation
+coverage work. Release preparation is blocked only on the normal release branch,
+validation, merge-to-main, signed tag, and publish sequence.
 
 ## Package(s) Overview
 
@@ -1520,13 +1525,13 @@ identities from local config or HEAD metadata.
 
 ### Rust Workspace Coverage
 
-The Rust workspace registers 311 tests under `cargo test --workspace -- --list`
-as of the June 26, 2026 `0.1.1` release-candidate state. The full Rust
+The Rust workspace registers 323 tests under `cargo test --workspace -- --list`
+as of the June 26, 2026 `v0.2.0` release-prep state. The full Rust
 workspace test run passes:
 
 ```text
 cargo test --workspace
-311 tests passed
+323 tests passed
 0 failed
 0 ignored
 0 doc tests
@@ -1745,10 +1750,10 @@ for Rust and JavaScript, then attach those reports to Holmes or CI artifacts.
 
 ### Next Release Narrative
 
-After `0.1.1`, the next crates.io release should decide which remaining
+After `v0.2.0`, the next crates.io release should decide which remaining
 Rust-native front-door, `weslaw`, Holmes foundation, and release-governance work
-belongs in the next patch release versus a later pre-1.0 milestone. Every path
-must keep README, CHANGELOG, tags, and publishable crate manifests aligned.
+belongs in `v0.3.0` versus a later pre-1.0 milestone. Every path must keep
+README, CHANGELOG, tags, and publishable crate manifests aligned.
 
 ### Host Package Fate
 
@@ -1832,8 +1837,8 @@ pnpm --filter @wesley/holmes test
 The codebase uses `apollo-parser` for GraphQL parsing, `serde` and
 `serde_json` for serialization, `sha2` and `hex` for hashing, `indexmap` for
 deterministic map behavior, `yaml-rust2` for YAML loading, `ninelives` for
-resilience policy, Node's built-in test runner for JS package tests, and
-Vitest for retained website tests.
+resilience policy, and Node's built-in test runner for retained JS package
+tests.
 
 No external web references were used to write this teardown; it is anchored to
 the repository files and local command outputs listed above.
@@ -1843,31 +1848,31 @@ the repository files and local command outputs listed above.
 ### Appendix A: Command Cheat Sheet
 
 ```bash
-cargo wesley --help
-cargo wesley doctor --json
-cargo wesley normalize-sdl --schema schema.graphql --hash
-cargo wesley schema lower --schema schema.graphql --json
-cargo wesley schema hash --schema schema.graphql
-cargo wesley schema diff \
+cargo run --bin wesley -- --help
+cargo run --bin wesley -- doctor --json
+cargo run --bin wesley -- normalize-sdl --schema schema.graphql --hash
+cargo run --bin wesley -- schema lower --schema schema.graphql --json
+cargo run --bin wesley -- schema hash --schema schema.graphql
+cargo run --bin wesley -- schema diff \
   --old old.graphql \
   --new new.graphql \
   --format summary \
   --exit-code
-cargo wesley schema operations --schema schema.graphql --json
-cargo wesley law lint --law contract.weslaw.yaml --json
-cargo wesley law validate --schema schema.graphql --law contract.weslaw.yaml --json
-cargo wesley law diff --old old.weslaw.yaml --new new.weslaw.yaml --format markdown
-cargo wesley law capabilities --law contract.weslaw.yaml --json
-cargo wesley law coverage \
+cargo run --bin wesley -- schema operations --schema schema.graphql --json
+cargo run --bin wesley -- law lint --law contract.weslaw.yaml --json
+cargo run --bin wesley -- law validate --schema schema.graphql --law contract.weslaw.yaml --json
+cargo run --bin wesley -- law diff --old old.weslaw.yaml --new new.weslaw.yaml --format markdown
+cargo run --bin wesley -- law capabilities --law contract.weslaw.yaml --json
+cargo run --bin wesley -- law coverage \
   --schema schema.graphql \
   --law contract.weslaw.yaml \
   --profile release \
   --json
-cargo wesley emit rust \
+cargo run --bin wesley -- emit rust \
   --schema schema.graphql \
   --out generated.rs \
   --metadata-out generated.metadata.json
-cargo wesley emit typescript \
+cargo run --bin wesley -- emit typescript \
   --schema schema.graphql \
   --out generated.d.ts \
   --metadata-out generated.metadata.json

--- a/docs/method/backlog/README.md
+++ b/docs/method/backlog/README.md
@@ -19,7 +19,7 @@ Use:
 gh issue list --label triage:requests
 gh issue list --label triage:bad-code
 gh issue list --label triage:cool-ideas
-gh issue list --label v0.2.0
+gh issue list --label vX.Y.Z
 ```
 
 Do not add new live backlog cards here. Create or update GitHub Issues instead.

--- a/docs/method/backlog/asap/README.md
+++ b/docs/method/backlog/asap/README.md
@@ -3,7 +3,7 @@
 This legacy lane is retained only as a historical signpost.
 
 Wesley no longer uses a generic urgent lane. Schedule valid work into a named
-future release label such as `v0.2.0`, or keep it under `triage:*` until the
+future release label such as `vX.Y.Z`, or keep it under `triage:*` until the
 release decision is ready.
 
 Do not add new files here. Add or update GitHub Issues instead.

--- a/docs/method/backlog/up-next/README.md
+++ b/docs/method/backlog/up-next/README.md
@@ -10,7 +10,7 @@ Use:
 
 ```bash
 gh issue list --label triage:requests
-gh issue list --label v0.2.0
+gh issue list --label vX.Y.Z
 ```
 
 Do not add new files here. Add or update GitHub Issues instead.

--- a/docs/method/releases/README.md
+++ b/docs/method/releases/README.md
@@ -4,6 +4,7 @@ Store internal release artifacts here.
 
 ## Available Releases
 
+- [Wesley v0.2.0](./v0.2.0/release.md)
 - [Wesley v0.1.0](./v0.1.0/release.md)
 - [Wesley v0.0.6 superseded planning packet](./v0.0.6/release.md)
 - [Wesley v0.0.5](./v0.0.5/release.md)

--- a/docs/method/releases/v0.2.0/release.md
+++ b/docs/method/releases/v0.2.0/release.md
@@ -1,0 +1,92 @@
+# Wesley v0.2.0 Release Packet
+
+## Summary
+
+Wesley `0.2.0` is the domain-free project-manifest platform release. It adds a
+small JSON/YAML manifest for schema sets and target metadata, a native `wesley
+config` command family, manifest-driven HOLMES schema selection, descriptor-only
+extension fixture modules, and comprehensive `docs/topics/` routing for current
+operator and contributor workflows.
+
+The release is still deliberately narrow. Wesley extracts structure from
+GraphQL SDL and emits deterministic compiler facts; applications and extensions
+assign semantics.
+
+## Included Scope
+
+- New `wesley.project-manifest/v1` JSON/YAML project manifest.
+- Native `wesley config validate`, `wesley config inspect`, and `wesley config
+changed-schemas` commands.
+- Upward manifest discovery through `wesley.config.json`,
+  `wesley.config.yaml`, `wesley.config.yml`, or `.wesley/config.json`.
+- Single-schema manifest defaults for `schema lower`, `schema hash`, and
+  `schema operations`.
+- Multi-schema changed-file selection with schema-local and top-level rebuild
+  globs.
+- Path-safe schema IDs and isolated bundle directories for selected schema
+  sets.
+- Manifest-selected target metadata without built-in domain compatibility
+  matrices.
+- HOLMES CI schema-set matrix execution from the Wesley project manifest.
+- Per-schema HOLMES bundle/report artifacts and one aggregate PR comment.
+- Explicit invalid-manifest failure before fallback behavior.
+- Descriptor-only extension fixture module zoo under
+  `test/fixtures/extensions/fixture-zoo`.
+- Contributor onramp issue routing for scoped starter work.
+- Release documentation policy requiring a `docs/topics/` accuracy and coverage
+  audit before tagging.
+- Expanded `docs/topics/` map covering current compiler, extension, CI,
+  assurance, release, documentation, and triage workflows.
+- User-facing release notes, README release headline, changelog release section,
+  and refreshed technical teardown.
+- Workspace Rust crate version bump to `0.2.0`.
+
+## Sponsored Users
+
+- Maintainers of multi-schema repositories can ask Wesley which schema sets are
+  affected by a change without giving Wesley domain ownership.
+- HOLMES users get schema-scoped evidence artifacts and comments instead of one
+  monolithic report.
+- Extension authors get a current descriptor-only fixture pattern and a clear
+  boundary for target metadata.
+- Contributors get `docs/topics/` as the shortest current path to commands,
+  boundaries, validation, release flow, and issue triage.
+- Release operators get a documented `docs/topics/` audit gate and versioned
+  release evidence packet.
+
+## Version Justification
+
+`0.2.0` is the right version for this release. Wesley is still pre-1.0, and the
+release adds public CLI commands plus a new project manifest surface that other
+repositories can depend on for build and CI selection. That is larger than a
+patch release.
+
+This release does not declare a stable `1.0.0` API. The project manifest and
+config command family are current alpha surfaces, and later `0.x` releases may
+still change them with explicit release notes.
+
+## Non-Goals
+
+- No stable `1.0.0` compatibility claim.
+- No domain-specific Postgres, Echo, Continuum, renderer, Vite, Vue, or product
+  behavior in Wesley core.
+- No resurrection of the retired dynamic JavaScript `wesley.config.mjs` loader.
+- No browser, Bun, Deno, website, or playground product surface.
+- No executable module loading from project manifests.
+- No crates.io publication evidence in this packet before the tag exists;
+  publication evidence belongs in the GitHub Release, tag workflow logs, and
+  registry state after the signed tag publishes.
+
+## Acceptance
+
+- Rust crate manifests and lockfile use version `0.2.0` for the release set.
+- `CHANGELOG.md` has a dated `0.2.0` section and compare link.
+- `README.md` has the exact `## What's New in v0.2.0` heading.
+- `docs/TECHNICAL_TEARDOWN.md` references `v0.2.0` as the release snapshot.
+- `docs/releases/v0.2.0.md` exists and includes migration guidance.
+- `docs/method/releases/v0.2.0/verification.md` records validation evidence.
+- `docs/topics/` has been audited at or above 90% accuracy and 90% coverage.
+- `cargo xtask release-prep-guard --version 0.2.0` passes before tagging.
+- `cargo xtask preflight` passes before opening or updating the PR.
+- `cargo xtask release-check` passes before tagging or publishing.
+- `cargo xtask package-crates --version 0.2.0` passes before tagging.

--- a/docs/method/releases/v0.2.0/verification.md
+++ b/docs/method/releases/v0.2.0/verification.md
@@ -1,0 +1,84 @@
+# Wesley v0.2.0 Verification
+
+This packet records pre-release evidence for `v0.2.0`.
+
+Publication evidence is intentionally not prefilled in the repository before the
+tag exists. After the signed tag publishes, the authoritative post-publish
+evidence lives in the GitHub Release, tag workflow logs, crates.io, and direct
+registry checks; release truth must not depend on a post-publish backfill merge.
+
+## Release Inputs
+
+- Target version: `0.2.0`.
+- Target tag: `v0.2.0`.
+- Prep branch: `release/v0.2.0`.
+- Release type: pre-1.0 minor with new public project-manifest and config CLI
+  surfaces.
+- Previous release tag: `v0.1.1`.
+- Release gate: GitHub issue #625, milestone `Release: v0.2.0`.
+- Release boundary: signed tag from synced `main` only.
+
+## Discovery
+
+| Fact                                  | Result                                                                                              |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Repository type                       | Mixed Rust/pnpm workspace.                                                                          |
+| Rust release authority                | `wesley-core`, `wesley-emit-codec`, `wesley-emit-rust`, `wesley-emit-typescript`, and `wesley-cli`. |
+| Unpublished Rust workspace member     | `wesley-holmes` stays `publish = false` but follows workspace version lockstep.                     |
+| Package manager                       | pnpm `9.15.9` from root `packageManager`.                                                           |
+| Node requirement                      | `>=22.12.0` from root `package.json`.                                                               |
+| Latest prior semver tag               | `v0.1.1`.                                                                                           |
+| Main sync state before release branch | Local `main` matched `origin/main` at merge commit `03d527855e740c456f5f71f9c763ab071a5ddd1b`.      |
+| Open `v0.2.0` issue lane              | Only release gate #625 remained open during prep discovery.                                         |
+
+## Docs Topics Audit
+
+| Item             | Result                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Scope            | Every tracked file under `docs/topics/`.                                                                                                                                                                                                                                                                                                                           |
+| Accuracy score   | 100% for release-relevant topic claims audited during prep.                                                                                                                                                                                                                                                                                                        |
+| Coverage score   | 100% for release-relevant contributor/operator workflows changed by this release.                                                                                                                                                                                                                                                                                  |
+| Corrections made | No `docs/topics/` page required content correction after audit. Related stale signposts and command-checker behavior were corrected outside `docs/topics/`: docs site install/quick-start claims, technical teardown command/version claims, release indexes, legacy backlog signpost examples, and `scripts/check-doc-cli-commands.mjs` command-family detection. |
+
+## Local Evidence
+
+| Check                                                                                             | Result                                                                                                         |
+| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `git status --porcelain` before release branch edits                                              | Passed: clean.                                                                                                 |
+| `git fetch origin`                                                                                | Passed.                                                                                                        |
+| `cargo xtask release-check` on pre-bump `main`                                                    | Passed for the published `0.1.1` state before release prep edits.                                              |
+| `cargo xtask release-prep-guard --version 0.2.0` before version bump                              | Failed as expected because manifests still declared `0.1.1`.                                                   |
+| `node scripts/check-doc-cli-commands.mjs`                                                         | Passed after command-family checker update.                                                                    |
+| `cargo xtask docs-check`                                                                          | Passed.                                                                                                        |
+| `cargo xtask release-prep-guard --version 0.2.0` after version bump                               | Passed after tracker and legacy backlog signpost cleanup.                                                      |
+| `cargo xtask preflight`                                                                           | Passed.                                                                                                        |
+| `cargo xtask release-check`                                                                       | Passed.                                                                                                        |
+| `cargo xtask package-crates --version 0.2.0`                                                      | Passed for `wesley-core`, `wesley-emit-codec`, `wesley-emit-rust`, `wesley-emit-typescript`, and `wesley-cli`. |
+| `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`                                 | Passed.                                                                                                        |
+| `BATS_LIB_PATH=test/vendor bats -t test/release-governance.bats test/docs-planning-boundary.bats` | Passed.                                                                                                        |
+| `pnpm exec prettier --check ...` on changed docs/scripts/metadata                                 | Passed after formatting the new release packet files.                                                          |
+| `cargo run --bin wesley -- --version`                                                             | Passed, printing `0.2.0`.                                                                                      |
+| `cargo test --workspace -- --list`                                                                | Passed for discovery; current workspace lists 323 Rust tests.                                                  |
+
+## Release-Prep Notes
+
+- The release branch updates version-bearing manifests, README, CHANGELOG,
+  technical teardown, release packet docs, release notes, and stale signpost
+  commands before tagging.
+- The project-manifest surface stays domain-free: schema sets, rebuild globs,
+  bundle locations, comment mode, dashboards, and generic target descriptors
+  are structure and metadata only.
+- Postgres, Echo, Continuum, renderer, Vite, Vue, website, playground, and host
+  behavior remain outside Wesley core.
+- GitHub issue #625 remains open as the release-gate issue in the
+  `Release: v0.2.0` milestone, but it no longer carries a concrete `v*`
+  implementation scheduling label or exact-version title/body text that would
+  make `release-prep-guard` treat the gate as unfinished implementation work.
+- GitHub issue #646 was refreshed so its living contributor-onramp text no
+  longer owns the current release token. GitHub issue #649 had the stale
+  `triage:cool-ideas` label removed because it is already scheduled for a
+  named future release.
+
+## Publish Evidence
+
+Pending until `v0.2.0` is signed on synced `main` and pushed.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ Store user-facing release notes here.
 
 ## Release Notes
 
+- [Wesley v0.2.0](./v0.2.0.md)
 - [Wesley v0.1.0](./v0.1.0.md)
 - [Wesley v0.0.5](./v0.0.5.md)
 - [Wesley v0.0.4](./v0.0.4.md)

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,105 @@
+# Wesley v0.2.0
+
+## Summary
+
+Wesley `0.2.0` is the domain-free project-manifest platform release. It gives
+repositories a small JSON/YAML way to name schema sets, output locations,
+changed-file rebuild rules, PR comment behavior, dashboard artifacts, and
+generic target metadata, then exposes that shape through native CLI commands
+and HOLMES CI selection.
+
+The release keeps Wesley's core rule intact: Wesley extracts structure from
+GraphQL SDL and produces deterministic IR and evidence. Extensions decide what
+that structure means.
+
+## What Changed
+
+- Added the `wesley.project-manifest/v1` JSON/YAML manifest.
+- Added `wesley config validate`, `wesley config inspect`, and
+  `wesley config changed-schemas`.
+- Added upward manifest discovery through `wesley.config.json`,
+  `wesley.config.yaml`, `wesley.config.yml`, and `.wesley/config.json`.
+- Let single-schema manifests provide the default schema for `schema lower`,
+  `schema hash`, and `schema operations`.
+- Added deterministic changed-schema selection for multi-schema manifests.
+- Added path-safe schema IDs and schema-scoped bundle directories.
+- Added target metadata validation without giving Wesley domain compatibility
+  matrices.
+- Updated HOLMES CI to run schema-set matrix jobs from the project manifest and
+  publish schema-scoped bundles/reports with one aggregate PR comment.
+- Added descriptor-only fixture modules for compiler-heavy, evidence-heavy, and
+  BLADE-heavy extension examples.
+- Expanded `docs/topics/` into a current operator and contributor routing map.
+- Added the release policy requirement to audit `docs/topics/` for at least
+  90% accuracy and 90% coverage before tagging.
+- Removed the old `wesley.capability-report/v1` Holmes law capability input
+  alias. The canonical artifact API version is `wesley.law-capabilities/v1`.
+
+## Why It Matters
+
+Before this release, repositories that wanted Wesley-powered CI had to wire
+schema selection and assurance behavior from scattered local convention. That
+created pressure to smuggle domain behavior into Wesley just to make automation
+usable.
+
+The manifest gives Wesley enough structure to answer generic questions such as
+"which schema set changed?" and "where should this evidence bundle go?" without
+knowing anything about a database, renderer, runtime, scheduler, protocol, or
+product. That makes the extension boundary sharper, not broader.
+
+## Breaking Changes
+
+`wesley-holmes` no longer accepts the pre-canonical
+`wesley.capability-report/v1` law capability input alias. Inputs must use:
+
+```json
+{
+  "apiVersion": "wesley.law-capabilities/v1"
+}
+```
+
+The public Wesley CLI also grows new `config` commands. Existing `schema`,
+`emit`, `law`, and `operation` command families are not removed by this release.
+
+## Migration
+
+1. If you feed Holmes law capability JSON directly, update
+   `apiVersion` from `wesley.capability-report/v1` to
+   `wesley.law-capabilities/v1`.
+2. To adopt project-manifest selection, add `wesley.config.json`,
+   `wesley.config.yaml`, `wesley.config.yml`, or `.wesley/config.json`.
+3. Start with the minimal manifest:
+
+   ```json
+   {
+     "apiVersion": "wesley.project-manifest/v1",
+     "schemaPaths": ["schema.graphql"]
+   }
+   ```
+
+4. Validate it with:
+
+   ```bash
+   wesley config validate --config wesley.config.json --json
+   ```
+
+5. For multi-schema repos, add schema IDs and `rebuildOnGlobs`, then use:
+
+   ```bash
+   wesley config changed-schemas \
+     --config wesley.config.json \
+     --changed path/to/changed-file.graphql \
+     --json
+   ```
+
+No migration is required for users who only install the CLI and run the
+pre-existing schema, emit, law, or operation commands.
+
+## Links to deeper docs
+
+- [CHANGELOG](../../CHANGELOG.md)
+- [Wesley v0.2.0 Release Packet](../method/releases/v0.2.0/release.md)
+- [Wesley v0.2.0 Verification](../method/releases/v0.2.0/verification.md)
+- [Project Manifest Reference](../reference/project-manifest.md)
+- [Module Authoring Guide](../guides/module-authoring.md)
+- [Topics](../topics/README.md)

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -6,8 +6,8 @@ title: Wesley Overview
 
 # Wesley
 
-Wesley is the generic GraphQL compiler and assurance kernel. Provide a GraphQL
-SDL input and the tooling owns:
+Wesley is the domain-free GraphQL-to-IR compiler and assurance toolchain.
+Provide a GraphQL SDL input and the tooling owns:
 
 - GraphQL parsing, canonicalization, lowering, and evidence plumbing
 - Generic transmutation and module contracts
@@ -24,10 +24,10 @@ Transform → Plan → Rehearse → Ship fit together.
 
 ## Quick facts
 
-- **Input:** GraphQL SDL with `@wes_*` directives
-- **Outputs:** module-owned artifacts, TypeScript, Zod, evidence bundles
+- **Input:** GraphQL SDL
+- **Outputs:** deterministic IR, generic projections, and evidence artifacts
 - **Runtime:** Native Rust CLI plus retained JavaScript support tooling
-- **License:** MIND‑UCAL v1.0 (see `LICENSE`)
+- **License:** Apache-2.0 (see `LICENSE`)
 - **Source:** [github.com/flyingrobots/wesley](https://github.com/flyingrobots/wesley)
 
 ## Getting started quickly
@@ -35,7 +35,7 @@ Transform → Plan → Rehearse → Ship fit together.
 Install the CLI and run the local Quick Start:
 
 ```bash
-cargo install wesley-cli --version 0.1.0
+cargo install wesley-cli --version 0.2.0
 wesley schema lower --schema schema.graphql --json
 ```
 

--- a/docs/site/quick-start.md
+++ b/docs/site/quick-start.md
@@ -22,15 +22,15 @@ pnpm install
 Lower, hash, and list operations through the native Rust CLI:
 
 ```bash
-cargo wesley schema lower --schema test/fixtures/examples/ecommerce.graphql --json
-cargo wesley schema hash --schema test/fixtures/examples/ecommerce.graphql
-cargo wesley schema operations --schema test/fixtures/examples/ecommerce.graphql --json
+cargo run --bin wesley -- schema lower --schema test/fixtures/examples/ecommerce.graphql --json
+cargo run --bin wesley -- schema hash --schema test/fixtures/examples/ecommerce.graphql
+cargo run --bin wesley -- schema operations --schema test/fixtures/examples/ecommerce.graphql --json
 ```
 
 ## 3. Emit TypeScript
 
 ```bash
-cargo wesley emit typescript \
+cargo run --bin wesley -- emit typescript \
   --schema test/fixtures/examples/ecommerce.graphql \
   --out out/examples/ecommerce.d.ts \
   --metadata-out out/examples/ecommerce.metadata.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wesley",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Core GraphQL compiler and assurance toolchain. Wesley brings the compiler; external modules bring target semantics.",

--- a/scripts/check-doc-cli-commands.mjs
+++ b/scripts/check-doc-cli-commands.mjs
@@ -2,6 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const root = resolve('.');
 const docs = ['README.md', 'docs/GUIDE.md', 'docs/ENTRYPOINTS.md', 'docs/END_TO_END.md'];
@@ -46,18 +47,17 @@ function loadWesleyCommands() {
   return commands;
 }
 
-function documentedCommandFromParts(parts, commands) {
+export function documentedCommandFromParts(parts, commands) {
   if (parts.length > 1 && !parts[1].startsWith('-')) {
     const nested = `${parts[0]} ${parts[1]}`;
     if (commands.has(nested)) return nested;
+    if (commandFamilyExists(parts[0], commands)) return nested;
   }
 
   return parts[0];
 }
 
-function commandOrFamilyExists(command, commands) {
-  if (commands.has(command)) return true;
-
+function commandFamilyExists(command, commands) {
   for (const knownCommand of commands) {
     if (knownCommand.startsWith(`${command} `)) {
       return true;
@@ -67,7 +67,12 @@ function commandOrFamilyExists(command, commands) {
   return false;
 }
 
-function extractDocumentedCommands(content, commands) {
+export function commandOrFamilyExists(command, commands) {
+  if (commands.has(command)) return true;
+  return commandFamilyExists(command, commands);
+}
+
+export function extractDocumentedCommands(content, commands) {
   const documented = [];
   for (const snippet of extractCommandSnippets(content)) {
     if (snippet.includes('pnpm wesley') || snippet.includes('...')) continue;
@@ -81,7 +86,7 @@ function extractDocumentedCommands(content, commands) {
   return documented;
 }
 
-function extractCommandSnippets(content) {
+export function extractCommandSnippets(content) {
   const snippets = [];
   let inFence = false;
   let commandFence = false;
@@ -112,20 +117,26 @@ function extractCommandSnippets(content) {
   return snippets;
 }
 
-const commands = loadWesleyCommands();
-for (const doc of docs) {
-  const content = readFileSync(resolve(root, doc), 'utf8');
-  for (const command of extractDocumentedCommands(content, commands)) {
-    if (!commandOrFamilyExists(command, commands)) {
-      fail(
-        `${doc} documents "wesley ${command}", but the native Wesley CLI does not expose that command`
-      );
+function main() {
+  const commands = loadWesleyCommands();
+  for (const doc of docs) {
+    const content = readFileSync(resolve(root, doc), 'utf8');
+    for (const command of extractDocumentedCommands(content, commands)) {
+      if (!commandOrFamilyExists(command, commands)) {
+        fail(
+          `${doc} documents "wesley ${command}", but the native Wesley CLI does not expose that command`
+        );
+      }
     }
   }
+
+  if (process.exitCode) {
+    process.exit(process.exitCode);
+  }
+
+  console.log('✅ Native front-door Wesley CLI examples match registered commands');
 }
 
-if (process.exitCode) {
-  process.exit(process.exitCode);
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
 }
-
-console.log('✅ Native front-door Wesley CLI examples match registered commands');

--- a/scripts/check-doc-cli-commands.mjs
+++ b/scripts/check-doc-cli-commands.mjs
@@ -55,6 +55,18 @@ function documentedCommandFromParts(parts, commands) {
   return parts[0];
 }
 
+function commandOrFamilyExists(command, commands) {
+  if (commands.has(command)) return true;
+
+  for (const knownCommand of commands) {
+    if (knownCommand.startsWith(`${command} `)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function extractDocumentedCommands(content, commands) {
   const documented = [];
   for (const snippet of extractCommandSnippets(content)) {
@@ -104,7 +116,7 @@ const commands = loadWesleyCommands();
 for (const doc of docs) {
   const content = readFileSync(resolve(root, doc), 'utf8');
   for (const command of extractDocumentedCommands(content, commands)) {
-    if (!commands.has(command)) {
+    if (!commandOrFamilyExists(command, commands)) {
       fail(
         `${doc} documents "wesley ${command}", but the native Wesley CLI does not expose that command`
       );

--- a/scripts/check-doc-cli-commands.test.mjs
+++ b/scripts/check-doc-cli-commands.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { commandOrFamilyExists, documentedCommandFromParts } from './check-doc-cli-commands.mjs';
+
+test('documented command parsing preserves unknown nested subcommands for family validation', () => {
+  const commands = new Set(['config validate', 'config inspect', 'schema lower']);
+
+  const documented = documentedCommandFromParts(['config', 'bogus'], commands);
+
+  assert.equal(documented, 'config bogus');
+  assert.equal(commandOrFamilyExists(documented, commands), false);
+});
+
+test('documented command parsing still accepts command-family headings', () => {
+  const commands = new Set(['config validate', 'config inspect', 'schema lower']);
+
+  const documented = documentedCommandFromParts(['config'], commands);
+
+  assert.equal(documented, 'config');
+  assert.equal(commandOrFamilyExists(documented, commands), true);
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -21,6 +21,17 @@ const gitIdentityChk = spawnSync(process.execPath, ['scripts/check-git-identity.
 });
 if (gitIdentityChk.status !== 0) fail('Git identity guard failed');
 
+const scriptUnitTests = readdirSync(resolve('scripts'))
+  .filter((file) => file.endsWith('.test.mjs'))
+  .sort()
+  .map((file) => `scripts/${file}`);
+if (scriptUnitTests.length) {
+  const scriptUnitChk = spawnSync(process.execPath, ['--test', ...scriptUnitTests], {
+    stdio: 'inherit'
+  });
+  if (scriptUnitChk.status !== 0) fail('Script unit tests failed');
+}
+
 // .gitignore files contain generated-output ignores.
 function requireIgnorePatterns(path, patterns) {
   let gi;
@@ -42,7 +53,10 @@ requireIgnorePatterns('.gitignore', [
     /^test\/fixtures\/examples\/\.wesley-cache\//m,
     'Missing test/fixtures/examples/.wesley-cache/ in .gitignore'
   ],
-  [/^wesley\.holmes-policy\.local\.json$/m, 'Missing wesley.holmes-policy.local.json in .gitignore'],
+  [
+    /^wesley\.holmes-policy\.local\.json$/m,
+    'Missing wesley.holmes-policy.local.json in .gitignore'
+  ],
   [/^out\//m, 'Missing out/ in .gitignore (covers generated outputs)']
 ]);
 requireIgnorePatterns('test/fixtures/examples/.gitignore', [


### PR DESCRIPTION
## Linked Issue

Tracks #625. Do not auto-close on merge; close #625 only after the signed `v0.2.0` tag is cut from synced `main` and the release publication checks pass.

## Branch / Issue-Title Check

- [x] Branch name exception: `release/v0.2.0` is a release-prep branch, not an issue-title slug.

## Summary

- Prepare Wesley `v0.2.0` release truth before tagging from `main`.
- Bump the Rust release set, lockfile, and root private metadata to `0.2.0`.
- Add the shaped `v0.2.0` release packet, verification packet, and user-facing release notes.
- Refresh README, GUIDE, ENTRYPOINTS, docs site, technical teardown, release indexes, and legacy backlog signpost examples for the `v0.2.0` release boundary.
- Keep the release domain-free: project manifests select GraphQL structure, schema sets, bundles, comments, dashboards, and generic target metadata; extensions own semantics.
- Fix the docs CLI checker so documented command families such as `wesley config` are valid when concrete subcommands exist.

## Why

Wesley releases must come from tagged `main`, with README, changelog, release notes, runbooks, version metadata, and release evidence already merged before the tag is cut. This PR makes `main` truthful for `v0.2.0` without adding domain semantics to Wesley core.

## Changes

- Version metadata: Rust release crates, internal `wesley-holmes`, root private package metadata, and `Cargo.lock` are aligned to `0.2.0`.
- Release docs: add `docs/method/releases/v0.2.0/release.md`, `docs/method/releases/v0.2.0/verification.md`, and `docs/releases/v0.2.0.md`.
- Signposts: update `README.md`, `docs/GUIDE.md`, `docs/ENTRYPOINTS.md`, `docs/TECHNICAL_TEARDOWN.md`, docs site pages, and release indexes.
- Backlog signposts: replace misleading concrete `v0.2.0` examples with `vX.Y.Z` placeholders where the docs describe generic future release mechanics.
- Docs validation: allow documented CLI command-family headings when concrete native subcommands exist.

## Method Evidence

- [x] Design doc linked or not required: not required; release-prep/documentation/version alignment only.
- [x] Tests or validation evidence included below.
- [x] Playback/witness included or not required: release verification packet included.
- [x] Retro or closeout evidence included or not required: not required before release publication.

## Tracker Hygiene

- [x] #625 remains open as the release gate until tag/publication completion.
- [x] #625 no longer carries concrete `v*` scheduling labels or exact-version title/body text that self-blocks `release-prep-guard`.
- [x] #646 no longer owns the current release token in its body.
- [x] #649 no longer carries stale `triage:cool-ideas`; it is already scheduled for `v0.3.0`.
- [x] Follow-up work remains in GitHub Issues rather than repo-local backlog/progress docs.

## Docs Topics Audit

- Audited every tracked file under `docs/topics/` for release-relevant accuracy and coverage.
- Accuracy: 100% for the release-relevant topic claims audited during prep.
- Coverage: 100% for the release-relevant contributor/operator workflows changed by this release.
- No `docs/topics/` page required content correction after audit; related stale signposts and command-checker behavior were corrected outside `docs/topics/`.

## Risk

- Release metadata risk: mitigated by `release-prep-guard`, package crate dry-run, lockfile checks, version smoke, and release verification docs.
- Documentation accuracy risk: mitigated by docs/topics audit, docs-check, CLI docs checker, Prettier, and targeted Bats guards.
- Domain-boundary risk: mitigated by keeping all semantics generic; project manifests and extensions describe structure selection, not Wesley-owned domain behavior.

## Backout

Use a merge revert of this PR before tagging. Do not tag `v0.2.0` until the revert lands and `main` is synced. If the tag has already been pushed, treat that as a release incident: stop publication if possible, document the exact state, and cut a corrective follow-up release rather than rewriting public history.

## Testing

- `cargo xtask release-prep-guard --version 0.2.0`
- `cargo xtask preflight`
- `cargo xtask release-check`
- `cargo xtask package-crates --version 0.2.0`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `BATS_LIB_PATH=test/vendor bats -t test/release-governance.bats test/docs-planning-boundary.bats`
- `node scripts/check-doc-cli-commands.mjs`
- `cargo xtask docs-check`
- `pnpm exec prettier --check ...` on changed docs/scripts/metadata
- `cargo run --bin wesley -- --version` prints `0.2.0`
- `cargo test --workspace -- --list` lists 323 Rust tests
- Pre-push selected suite passed: Rust product preflight, legacy preflight, repo Bats smoke suite

## EvidenceMap / SourceMap (if applicable)

Not applicable. This PR does not change SQL-to-SDL mapping, EvidenceMap, or SourceMap behavior.

## Screenshots / Logs (optional)

Not applicable.

## Merge Strategy

- Merge commit only; no rebase.
- Delete branch after merge.
- After merge, sync local `main`, create a signed `v0.2.0` tag from `main`, run `cargo xtask release-guard --tag v0.2.0`, push the exact tag, and monitor release publication.

## Checklist

- [x] One-topic PR with tight diff
- [x] Rust-native preflight passes (`cargo xtask preflight`)
- [x] Release preflight passes (`cargo xtask release-check` and `cargo xtask release-prep-guard --version 0.2.0`)
- [x] Legacy package preflight passed where relevant through selected pre-push suite
- [x] No widened permissions/secrets in workflows
- [x] Docs updated for release-facing behavior and version metadata

## Pre-Tag Sign-Off for `v0.2.0`

**Reviewer:** @
**Date:** 2026-06-26

### Human-Review Items

- [ ] **CHANGELOG reflects actual diff**
      I ran `git log v0.1.1..HEAD --oneline` and confirmed that the `CHANGELOG.md` entry for this release accounts for all user-visible changes. No significant change is silently absent from the entry.

- [ ] **`docs/ARCHITECTURE.md` is current**
      I read `docs/ARCHITECTURE.md` and confirmed it accurately describes the current repository structure, crate relationships, and ownership boundaries. No crate, package, or boundary described has been removed, renamed, or fundamentally changed without the doc being updated.

- [ ] **Guide claims are accurate**
      I spot-checked the guides in `docs/guides/` that are relevant to changes in this release. Commands, flags, file paths, and behavioral claims match the current codebase. I did not rely solely on the automated path/SHA checks.

- [ ] **`docs/topics/` accuracy and coverage gate is met**
      I audited every tracked file under `docs/topics/` for release-relevant accuracy and coverage. At least 90% accuracy of audited topic claims and at least 90% coverage of release-relevant contributor/operator topic workflows are met. Any stale topic claim, obsolete instruction, missing topic, or missing authoritative link was corrected before tagging.

- [ ] **No known issues being silently shipped**
      I reviewed the open GitHub Issues for known defects or outstanding decisions that affect this release's correctness or safety, whether or not they are already marked as release issues. Anything knowingly deferred is acknowledged in the CHANGELOG or a documented follow-on issue.

- [ ] **Tagged `main` is the release boundary**
      I confirmed every repo-resident release fact that must ship with this version is already on synced `main` before tagging. The release does not depend on a manual post-publish merge to make README, changelog, release notes, runbooks, or verification docs accurate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release 0.2.0 with expanded project-manifest and CLI guidance, including updated install commands and a fuller topic map.

* **Bug Fixes**
  * Improved documentation command validation so command families and subcommands are recognized more reliably.
  * Refreshed multiple guides and quick-start examples to match the latest CLI usage.

* **Documentation**
  * Added new release and verification notes, plus updated changelog, README, and site docs to reflect the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->