### PR TITLE
docs(release): adapt lifecycle for Wesley

### DIFF
--- a/.continuum/release.yml
+++ b/.continuum/release.yml
@@ -75,6 +75,7 @@ docs:
     - docs/reference/
     - docs/releases/
   operator_docs:
+    - RELEASE.md
     - docs/method/release.md
     - docs/method/release-runbook.md
     - docs/CRATES_IO_RELEASE.md
@@ -83,6 +84,7 @@ docs:
   contributor_docs:
     - AGENTS.md
     - CONTRIBUTING.md
+    - RELEASE.md
     - docs/METHOD.md
     - docs/topics/contributing/triage.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ hash`, and `schema operations`.
   release profile and expanded the Wesley release doctrine/runbook around
   thesis, scope, goalposts, immutable tagged-main publication, verification,
   and retrospective evidence.
+- **Release process front door**: Added a thin root `RELEASE.md` and clarified
+  how Wesley adapts the Continuum release lifecycle around goalpost milestones,
+  version labels, manual signed tags, crates.io publication, and patch-forward
+  failure handling.
 - **Release documentation gate**: The release runbook, release policy, and
   human sign-off checklist now require a `docs/topics/` accuracy and coverage
   audit before tagging, with minimum 90% accuracy and 90% coverage floors.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ For complete history, read [CHANGELOG.md](./CHANGELOG.md).
 - [Directive truth table](./docs/reference/directives.md)
 - [Module authoring](./docs/guides/module-authoring.md)
 - [Technical teardown](./docs/TECHNICAL_TEARDOWN.md)
+- [Release process](./RELEASE.md)
 - [Release policy](./docs/governance/RELEASE_POLICY.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Support](./SUPPORT.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,80 @@
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+# Release Process
+
+Wesley follows the Continuum release lifecycle, adapted to this repository's
+actual shape: a domain-free Rust compiler/toolchain that publishes crates from
+signed tags on synced `main`.
+
+The rule is:
+
+```text
+plan deliberately -> merge reviewed main -> tag immutably -> publish from tag -> verify publicly -> record evidence
+```
+
+## Repo Profile
+
+Repo-specific mechanics live in [`.continuum/release.yml`](.continuum/release.yml).
+That profile declares:
+
+- version sources
+- published crates
+- release signposts
+- validation commands
+- publish workflow
+- GitHub issue model
+- release evidence paths
+
+Do not duplicate those facts in prose unless the profile changes too.
+
+## Wesley Shape
+
+Wesley intentionally differs from the generic Continuum template in these
+places:
+
+- Implementation work stays in `Goalpost: ...` GitHub milestones.
+- Version scheduling uses concrete `vX.Y.Z` labels because GitHub issues can
+  have only one milestone.
+- `Release: vX.Y.Z` milestones hold release-gate and closeout issues only.
+- Release guards query exact-version issue references and `vX.Y.Z` labels, not
+  release-gate milestones.
+- Autotag is not enabled. Maintainers create a signed tag manually after final
+  release guards pass from synced `main`.
+- Publication is tag-triggered through `.github/workflows/release-crates.yml`.
+- crates.io is the public package registry. npm/JSR dist-tag policy does not
+  apply to Wesley's current release surface.
+
+## Commands
+
+Prepare:
+
+```bash
+cargo xtask release-prep-guard --version X.Y.Z
+cargo xtask preflight
+cargo xtask release-check
+cargo xtask package-crates --version X.Y.Z
+```
+
+Tag from synced `main` only:
+
+```bash
+git switch main
+git pull --ff-only
+git fetch origin --tags
+git tag -s vX.Y.Z -m "release: vX.Y.Z"
+cargo xtask release-guard --tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag workflow publishes the crates and GitHub Release from the immutable tag.
+
+## Canonical Docs
+
+- [Release doctrine](docs/method/release.md)
+- [Execution runbook](docs/method/release-runbook.md)
+- [Release policy](docs/governance/RELEASE_POLICY.md)
+- [Human checklist](docs/governance/RELEASE_CHECKLIST.md)
+- [Crates.io procedure](docs/CRATES_IO_RELEASE.md)
+- [Release topic](docs/topics/releases.md)
+
+Do not move public tags. If a public release is wrong, patch forward.

--- a/docs/method/release-runbook.md
+++ b/docs/method/release-runbook.md
@@ -127,6 +127,43 @@ CI state.
 13. Record release evidence and retrospective before starting the next planned
     release train.
 
+## Idempotency And Failure Handling
+
+The public tag is immutable. Do not move it.
+
+If the tag exists but publication did not complete:
+
+1. Keep the tag fixed.
+2. Fix the workflow, credential, registry, or environment problem.
+3. Rerun publication for the same tag.
+4. Record both the failure and the successful rerun in release evidence.
+
+If one crate publishes and another fails:
+
+1. Keep the tag fixed.
+2. Confirm the already-published crate versions match the tag source.
+3. Fix the failing crate path.
+4. Rerun the workflow so it verifies existing crates and publishes only missing
+   artifacts where crates.io allows that path.
+
+If the GitHub Release fails:
+
+1. Keep the tag fixed.
+2. Recreate or update the GitHub Release for the same tag.
+3. Verify the release notes match the tag source.
+
+If a published artifact is bad:
+
+1. Do not move the tag.
+2. Cut a new patch release from `main`.
+3. Deprecate or warn on the bad version only when the registry policy and user
+   impact make that the right move.
+4. File fallout issues and record the patch-forward decision.
+
+Manual tagging is not an emergency bypass in Wesley. It is the normal mechanism
+because the release profile declares `autotag: none`. It still must happen only
+after final guards pass from clean, fetched, synced `main`.
+
 ## Phase 5: Retrospective And Closeout
 
 After the tag workflow publishes and public verification passes:

--- a/docs/method/release-runbook.md
+++ b/docs/method/release-runbook.md
@@ -134,9 +134,16 @@ The public tag is immutable. Do not move it.
 If the tag exists but publication did not complete:
 
 1. Keep the tag fixed.
-2. Fix the workflow, credential, registry, or environment problem.
-3. Rerun publication for the same tag.
-4. Record both the failure and the successful rerun in release evidence.
+2. Determine whether the failure is in release inputs or release machinery.
+3. Same-tag reruns are for credentials, permissions, transient registry, or
+   GitHub Release/API problems.
+4. If the workflow source checked into the tag is wrong, do not rerun the
+   immutable tag expecting a later workflow fix to apply.
+5. For workflow-source failures, patch forward from `main`, or use an explicit
+   maintainer-approved manual recovery only when no public artifact escaped and
+   the recovery still verifies the same tagged source.
+6. Record both the failure and the successful rerun or patch-forward release in
+   release evidence.
 
 If one crate publishes and another fails:
 

--- a/docs/method/release.md
+++ b/docs/method/release.md
@@ -277,8 +277,13 @@ Use these shapes for planned releases and heavier patch releases.
 
 ### Release Tracking Issue
 
+Keep the open gate issue title/body free of the target tag/version literal while
+it remains open. Record the concrete version in the release packet path, release
+label, PR, and tagged source, and link issue queries instead of spelling the
+target tag in the gate issue.
+
 ```markdown
-# Release gate: vX.Y.Z
+# Release gate: current planned release
 
 ## Thesis
 

--- a/docs/method/release.md
+++ b/docs/method/release.md
@@ -13,6 +13,25 @@ The repo-local mechanics live in [`.continuum/release.yml`](../../.continuum/rel
 This doctrine defines the standard; the profile defines the boring facts that
 automation and reviewers should enforce.
 
+## Wesley Adaptation
+
+Wesley uses the Continuum spine, but the generic template must be adapted in
+these important ways:
+
+| Generic lifecycle point | Wesley adaptation                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Version bucket          | Implementation issues stay in `Goalpost: ...` milestones. Concrete `vX.Y.Z` labels are the scheduling axis.                                        |
+| Release milestone       | `Release: vX.Y.Z` milestones hold release-gate and closeout issues only. They are not queried as pre-tag blockers.                                 |
+| Autotag                 | `.continuum/release.yml` declares `autotag: none`. Maintainers create a signed tag manually after final guards pass from synced `main`.            |
+| Package/channel policy  | crates.io is the public package registry. npm, JSR, and dist-tag policy do not apply to the current Wesley release surface.                        |
+| Publication             | `.github/workflows/release-crates.yml` runs from the tag and must verify tag, metadata, main reachability, package visibility, and GitHub Release. |
+| Public release boundary | The tag must point at the exact reviewed `main` commit. Do not merge post-release fixes into `main` and pretend they are part of the same release. |
+| Domain boundary         | Release scope must not add downstream domain semantics to Wesley core. Extensions and sibling repos own meaning.                                   |
+
+The root [release process](../../RELEASE.md) is a thin maintainer entrance. This
+page remains the doctrine. The command-by-command execution layer remains
+[`docs/method/release-runbook.md`](release-runbook.md).
+
 ## Doctrine
 
 A valid Wesley release has all of the following:
@@ -251,6 +270,155 @@ workflows.
 10. Verify delivery directly.
 11. Record the release witness and retrospective.
 12. Close the release and plan the next thesis.
+
+## Templates
+
+Use these shapes for planned releases and heavier patch releases.
+
+### Release Tracking Issue
+
+```markdown
+# Release gate: vX.Y.Z
+
+## Thesis
+
+This release advances `<capability boundary>` for `<primary user/operator>` by
+`<main outcome>`. It focuses on `<included scope>` and deliberately excludes
+`<not-included scope>`, which remains in `<future release/goalpost/research>`.
+
+## Release type
+
+planned | patch | emergency | security | prerelease | docs-only
+
+## Scope
+
+### Must-ship
+
+- ...
+
+### May-slip
+
+- ...
+
+### Explicitly not included
+
+- ...
+
+## Goalposts
+
+### 1. <name>
+
+Outcome:
+Evidence:
+Issues:
+
+## Release prep
+
+- [ ] Scope reconciled
+- [ ] Version metadata updated
+- [ ] Changelog updated
+- [ ] Signposts updated
+- [ ] Release prep validation passed
+- [ ] Release-prep PR merged to main
+
+## Publication
+
+- [ ] Signed tag created from synced main
+- [ ] Release guard passed against tag
+- [ ] Tag pushed
+- [ ] Release Crates workflow completed
+- [ ] GitHub Release visible
+- [ ] crates.io visibility verified
+
+## Evidence
+
+Tag:
+Commit:
+Release PR:
+Publish workflow:
+GitHub Release:
+Registry evidence:
+Smoke evidence:
+
+## Retrospective
+
+- [ ] Released work recorded
+- [ ] Unreleased work recorded
+- [ ] Plan-versus-actual recorded
+- [ ] Improvements recorded
+- [ ] Fallout issues filed
+- [ ] Next release thesis planned
+```
+
+### Release-Prep PR Body
+
+```markdown
+# release: vX.Y.Z
+
+## Summary
+
+Prepare vX.Y.Z for release.
+
+## Release type
+
+planned | patch | emergency | security | prerelease | docs-only
+
+## Thesis
+
+...
+
+## Previous public tag
+
+vPREVIOUS
+
+## Target tag
+
+vX.Y.Z
+
+## Scope reconciliation
+
+### Shipped
+
+- ...
+
+### Slipped
+
+- ...
+
+### Explicitly not included
+
+- ...
+
+## Version metadata
+
+- [ ] Cargo manifests updated
+- [ ] `package.json` updated
+- [ ] Lockfiles updated, if applicable
+
+## Release signposts
+
+- [ ] CHANGELOG.md
+- [ ] README/front door
+- [ ] Architecture docs
+- [ ] User docs
+- [ ] Operator docs
+- [ ] Contributor/maintainer docs
+- [ ] Migration/security docs, if applicable
+
+## Validation
+
+- [ ] `cargo xtask release-prep-guard --version X.Y.Z`
+- [ ] `cargo xtask preflight`
+- [ ] `cargo xtask release-check`
+- [ ] `cargo xtask package-crates --version X.Y.Z`
+- [ ] docs/topics accuracy and coverage audit
+- [ ] CI green
+
+## Publish notes
+
+Manual publish required: no. Push signed tag `vX.Y.Z`; tag workflow publishes
+crates and the GitHub Release.
+```
 
 ## User-Facing Release Notes
 

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -161,6 +161,17 @@ load 'bats-plugins/bats-assert/load'
   assert_success
 }
 
+@test "release gate issue template avoids exact version blocker tokens" {
+  run grep -F "# Release gate: vX.Y.Z" docs/method/release.md
+  assert_failure
+
+  run grep -F "# Release gate: current planned release" docs/method/release.md
+  assert_success
+
+  run grep -F "Keep the open gate issue title/body free of the target tag/version literal" docs/method/release.md
+  assert_success
+}
+
 @test "release lifecycle uses retrospected state name" {
   run rg -n "retrospectived" docs/method/release.md docs/topics/releases.md
   assert_failure

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -150,6 +150,17 @@ load 'bats-plugins/bats-assert/load'
   assert_success
 }
 
+@test "release runbook does not rerun immutable tag for workflow source fixes" {
+  run grep -F "workflow source checked into the tag is wrong" docs/method/release-runbook.md
+  assert_success
+
+  run grep -F "Same-tag reruns are for credentials, permissions" docs/method/release-runbook.md
+  assert_success
+
+  run grep -F "GitHub Release/API problems" docs/method/release-runbook.md
+  assert_success
+}
+
 @test "release lifecycle uses retrospected state name" {
   run rg -n "retrospectived" docs/method/release.md docs/topics/releases.md
   assert_failure

--- a/test/release-governance.bats
+++ b/test/release-governance.bats
@@ -104,6 +104,25 @@ load 'bats-plugins/bats-assert/load'
   assert_success
 }
 
+@test "release profile includes root release process signpost" {
+  run grep -Eq "^[[:space:]]*-[[:space:]]*RELEASE.md$" .continuum/release.yml
+  assert_success
+
+  run grep -F "[Release process](./RELEASE.md)" README.md
+  assert_success
+}
+
+@test "root release process documents Wesley-specific lifecycle deviations" {
+  run grep -F "Autotag is not enabled" RELEASE.md
+  assert_success
+
+  run grep -F "Release: vX.Y.Z" RELEASE.md
+  assert_success
+
+  run grep -F "crates.io is the public package registry" RELEASE.md
+  assert_success
+}
+
 @test "release doctrine lists profile user-doc signposts" {
   run grep -F '`docs/site/`' docs/method/release.md
   assert_success
@@ -120,6 +139,14 @@ load 'bats-plugins/bats-assert/load'
   assert_success
 
   run grep -F "retrospective and fallout issues" docs/method/release.md
+  assert_success
+}
+
+@test "release runbook requires patch-forward failure handling" {
+  run grep -F "The public tag is immutable. Do not move it." docs/method/release-runbook.md
+  assert_success
+
+  run grep -F "Cut a new patch release from \`main\`" docs/method/release-runbook.md
   assert_success
 }
 


### PR DESCRIPTION
## Summary

Adapt the Continuum release lifecycle to Wesley as a repo-local process:

- add a thin root `RELEASE.md` maintainer entrance
- mark `RELEASE.md` as an operator/contributor signpost in `.continuum/release.yml`
- clarify Wesley-specific deviations from the generic lifecycle: goalpost milestones, version labels, release-gate milestones, manual signed tags, crates.io publication, and domain-free scope
- add release tracking and release-prep PR templates to `docs/method/release.md`
- add patch-forward/idempotency failure handling to `docs/method/release-runbook.md`
- guard the release process signposts with Bats tests

## Validation

- `bats test/release-governance.bats`
- `pnpm exec prettier --check RELEASE.md .continuum/release.yml README.md docs/method/release.md docs/method/release-runbook.md CHANGELOG.md`
- `cargo xtask docs-check`
- `git diff --check`
- `cargo xtask preflight`
- pre-push hook: Rust product preflight + repo Bats smoke suite

## Notes

This keeps the Continuum spine but explicitly preserves Wesley invariants: no domain-specific behavior in core, release tags from reviewed synced `main`, and crates.io publication from immutable tags.