### PR TITLE
feat(xtask): add IR benchmark evidence command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Rejected duplicate non-repeatable custom directives during SDL lowering,
+  including duplicates split across type definitions and extensions, while
+  preserving ordered arrays for directives declared `repeatable`.
 - Escaped law-backed Rust validator error messages before emission so hostile
   case values containing quotes, backslashes, or control characters cannot break
   generated Rust source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added `cargo xtask bench-ir`, an advisory Rust-native IR lowering benchmark
   that generates scale fixtures, reports structural counters and timing
   summaries, and can write JSON release evidence.
+- Added a first-PR contributor path with docs-only, fixture-only, emitter-test,
+  and CLI bug fast lanes plus maintainer starter-issue checks.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   summaries, and can write JSON release evidence.
 - Added a first-PR contributor path with docs-only, fixture-only, emitter-test,
   and CLI bug fast lanes plus maintainer starter-issue checks.
+- Added a security-tooling posture topic that records Wesley's current scanner
+  baseline, rejects DAST for the current compiler-only surface, and gates future
+  Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   concept-only assurance vocabulary.
 - Added an external target protocol MVP specification for future
   descriptor-verified external-process target execution.
+- Added `cargo xtask bench-ir`, an advisory Rust-native IR lowering benchmark
+  that generates scale fixtures, reports structural counters and timing
+  summaries, and can write JSON release evidence.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,11 @@ Wesley's. METHOD defines how work is queued, pulled, proved, and closed.
 
 ## Start Here
 
-Read these surfaces in order:
+For a first small PR, start with
+[First PR](docs/topics/contributing/first-pr.md). It gives the shortest path
+from a scoped GitHub issue to a local validation command and PR body.
+
+For broader orientation, read these surfaces in order:
 
 - [README.md](README.md) for doctrine and repo shape
 - [docs/BEARING.md](docs/BEARING.md) for current direction and tensions
@@ -63,13 +67,20 @@ done. The Chronicle files in the repo root are historical archive only.
 New contributors should start from scoped GitHub Issues, not from repo-local
 backlog files:
 
+- [First PR path](docs/topics/contributing/first-pr.md)
 - [Good first issues](https://github.com/flyingrobots/wesley/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
 - [Near-term roadmap issue](https://github.com/flyingrobots/wesley/issues/646)
 - [Wesley Roadmap Project](https://github.com/users/flyingrobots/projects/18)
 
-Starter issues must already have a goalpost milestone and one scheduling-state
-label such as `v0.3.0`. If an issue still has a `triage:*` label, it is not a
-starter task until a maintainer schedules, splits, moves, or closes it.
+Starter issues must have one scheduling-state label such as `v0.3.0`, one
+primary file or tiny file set, and one local validation command. If an issue
+still has a `triage:*` label, it is not a starter task until a maintainer
+schedules, splits, moves, or closes it.
+
+The normal first-contribution lanes are docs-only PRs, fixture-only PRs,
+emitter-test PRs, and CLI bug PRs. Advanced architecture, assurance, and
+release docs are background for these lanes, not required reading unless the
+issue says otherwise.
 
 ## Design Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,9 @@ backlog files:
 - [Wesley Roadmap Project](https://github.com/users/flyingrobots/projects/18)
 
 Starter issues must have one scheduling-state label such as `v0.3.0`, one
-primary file or tiny file set, and one local validation command. If an issue
-still has a `triage:*` label, it is not a starter task until a maintainer
-schedules, splits, moves, or closes it.
+`Goalpost: ...` milestone, one primary file or tiny file set, and one local
+validation command. If an issue still has a `triage:*` label, it is not a
+starter task until a maintainer schedules, splits, moves, or closes it.
 
 The normal first-contribution lanes are docs-only PRs, fixture-only PRs,
 emitter-test PRs, and CLI bug PRs. Advanced architecture, assurance, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,9 @@ artifacts through generic emitters and external modules.
 
 - Keep dependency updates reviewable and run repository preflight before
   release.
+- Scope security scanners to Wesley's compiler and tooling surface. The current
+  baseline and candidate-gate decisions live in
+  [`docs/topics/security-tooling.md`](docs/topics/security-tooling.md).
 - Prefer deterministic inputs, injected clocks, and explicit host permissions
   for portable capability work.
 - Do not grant portable modules ambient filesystem, network, process, or clock
@@ -94,5 +97,6 @@ artifacts through generic emitters and external modules.
 - Domain-empty compiler boundary that keeps target security policy out of core
 - Hash-linked evidence and artifact review surfaces
 - Dependency and documentation preflight checks
+- Documented scanner-fit posture for advisory and static-analysis gates
 - Explicit external-module responsibility for database, runtime, and product
   security behavior

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -400,25 +400,21 @@ impl ApolloLoweringAdapter {
     ) -> Result<(), WesleyError> {
         match def {
             TypeDefinitionNode::Scalar(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
             }
             TypeDefinitionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.fields_definition() {
                     self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
@@ -427,49 +423,41 @@ impl ApolloLoweringAdapter {
                 if let Some(interfaces) = node.implements_interfaces() {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.fields_definition() {
                     self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeDefinitionNode::Union(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(member_types) = node.union_member_types() {
                     collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeDefinitionNode::Enum(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(values_def) = node.enum_values_definition() {
                     collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeDefinitionNode::InputObject(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.input_fields_definition() {
                     self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
@@ -487,25 +475,21 @@ impl ApolloLoweringAdapter {
     ) -> Result<(), WesleyError> {
         match ext {
             TypeExtensionNode::Scalar(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
             }
             TypeExtensionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.fields_definition() {
                     self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
@@ -514,53 +498,57 @@ impl ApolloLoweringAdapter {
                 if let Some(interfaces) = node.implements_interfaces() {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.fields_definition() {
                     self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeExtensionNode::Union(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(member_types) = node.union_member_types() {
                     collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeExtensionNode::Enum(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(values_def) = node.enum_values_definition() {
                     collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeExtensionNode::InputObject(node) => {
-                if let Some(dirs) = node.directives() {
-                    Self::extract_directives_with_repeatability(
-                        dirs,
-                        &mut acc.directives,
-                        repeatable_directives,
-                    )?;
-                }
+                Self::extract_optional_directives(
+                    node.directives(),
+                    &mut acc.directives,
+                    repeatable_directives,
+                )?;
                 if let Some(fields_def) = node.input_fields_definition() {
                     self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn extract_optional_directives(
+        dirs: Option<cst::Directives>,
+        map: &mut IndexMap<String, serde_json::Value>,
+        repeatable_directives: &BTreeSet<String>,
+    ) -> Result<(), WesleyError> {
+        if let Some(dirs) = dirs {
+            Self::extract_directives_with_repeatability(dirs, map, repeatable_directives)?;
         }
 
         Ok(())

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -130,6 +130,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
     }
 
     let doc = cst.document();
+    let repeatable_directives = repeatable_directive_names_from_document(&doc)?;
     let mut root_types = RootTypes::default();
     for def in doc.definitions() {
         match def {
@@ -151,6 +152,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
                     node.name(),
                     node.fields_definition(),
                     &root_types,
+                    &repeatable_directives,
                     &mut operations,
                 )?;
             }
@@ -159,6 +161,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
                     node.name(),
                     node.fields_definition(),
                     &root_types,
+                    &repeatable_directives,
                     &mut operations,
                 )?;
             }
@@ -175,6 +178,15 @@ struct TypeAggregate {
     kind: TypeKind,
     definitions: Vec<TypeDefinitionNode>,
     extensions: Vec<TypeExtensionNode>,
+}
+
+#[derive(Default)]
+struct TypeBuildAccumulator {
+    directives: IndexMap<String, serde_json::Value>,
+    implements: Vec<String>,
+    fields: Vec<Field>,
+    enum_values: Vec<String>,
+    union_members: Vec<String>,
 }
 
 enum TypeDefinitionNode {
@@ -244,6 +256,7 @@ impl ApolloLoweringAdapter {
         }
 
         let doc = cst.document();
+        let repeatable_directives = repeatable_directive_names_from_document(&doc)?;
         let mut aggregates: BTreeMap<String, TypeAggregate> = BTreeMap::new();
 
         for def in doc.definitions() {
@@ -314,7 +327,7 @@ impl ApolloLoweringAdapter {
 
         let mut types = Vec::new();
         for agg in aggregates.values() {
-            types.push(self.build_type_from_aggregate(agg)?);
+            types.push(self.build_type_from_aggregate(agg, &repeatable_directives)?);
         }
 
         Ok(WesleyIR {
@@ -351,110 +364,114 @@ impl ApolloLoweringAdapter {
     fn build_type_from_aggregate(
         &self,
         agg: &TypeAggregate,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<TypeDefinition, WesleyError> {
-        let mut directives = IndexMap::new();
-        let mut implements = Vec::new();
-        let mut fields = Vec::new();
-        let mut enum_values = Vec::new();
-        let mut union_members = Vec::new();
+        let mut acc = TypeBuildAccumulator::default();
         let mut description = None;
 
         for def in &agg.definitions {
             if description.is_none() {
                 description = description_from(def.description());
             }
-            self.merge_definition(
-                def,
-                &mut directives,
-                &mut implements,
-                &mut fields,
-                &mut enum_values,
-                &mut union_members,
-            )?;
+            self.merge_definition(def, &mut acc, repeatable_directives)?;
         }
 
         for ext in &agg.extensions {
-            self.merge_extension(
-                ext,
-                &mut directives,
-                &mut implements,
-                &mut fields,
-                &mut enum_values,
-                &mut union_members,
-            )?;
+            self.merge_extension(ext, &mut acc, repeatable_directives)?;
         }
 
         Ok(TypeDefinition {
             name: agg.name.clone(),
             kind: agg.kind,
             description,
-            directives,
-            implements,
-            fields,
-            enum_values,
-            union_members,
+            directives: acc.directives,
+            implements: acc.implements,
+            fields: acc.fields,
+            enum_values: acc.enum_values,
+            union_members: acc.union_members,
         })
     }
 
     fn merge_definition(
         &self,
         def: &TypeDefinitionNode,
-        directives: &mut IndexMap<String, serde_json::Value>,
-        implements: &mut Vec<String>,
-        fields: &mut Vec<Field>,
-        enum_values: &mut Vec<String>,
-        union_members: &mut Vec<String>,
+        acc: &mut TypeBuildAccumulator,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         match def {
             TypeDefinitionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
             }
             TypeDefinitionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeDefinitionNode::Interface(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeDefinitionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(member_types) = node.union_member_types() {
-                    collect_union_members(member_types, union_members)?;
+                    collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeDefinitionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(values_def) = node.enum_values_definition() {
-                    collect_enum_values(values_def, enum_values)?;
+                    collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeDefinitionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.input_fields_definition() {
-                    self.collect_input_fields(fields_def, fields)?;
+                    self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
         }
@@ -465,62 +482,83 @@ impl ApolloLoweringAdapter {
     fn merge_extension(
         &self,
         ext: &TypeExtensionNode,
-        directives: &mut IndexMap<String, serde_json::Value>,
-        implements: &mut Vec<String>,
-        fields: &mut Vec<Field>,
-        enum_values: &mut Vec<String>,
-        union_members: &mut Vec<String>,
+        acc: &mut TypeBuildAccumulator,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         match ext {
             TypeExtensionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
             }
             TypeExtensionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeExtensionNode::Interface(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeExtensionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(member_types) = node.union_member_types() {
-                    collect_union_members(member_types, union_members)?;
+                    collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeExtensionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(values_def) = node.enum_values_definition() {
-                    collect_enum_values(values_def, enum_values)?;
+                    collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeExtensionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.input_fields_definition() {
-                    self.collect_input_fields(fields_def, fields)?;
+                    self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
         }
@@ -528,10 +566,11 @@ impl ApolloLoweringAdapter {
         Ok(())
     }
 
-    fn extract_directives(
+    fn extract_directives_with_repeatability(
         &self,
         dirs: cst::Directives,
         map: &mut IndexMap<String, serde_json::Value>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for dir in dirs.directives() {
             let dir_name = dir
@@ -568,7 +607,8 @@ impl ApolloLoweringAdapter {
                 ));
             }
 
-            insert_directive_value(map, canonical_name, val);
+            let repeatable = core_name.is_none() && repeatable_directives.contains(&canonical_name);
+            insert_directive_value(map, canonical_name, val, repeatable)?;
         }
         Ok(())
     }
@@ -577,9 +617,10 @@ impl ApolloLoweringAdapter {
         &self,
         fields_def: cst::FieldsDefinition,
         fields: &mut Vec<Field>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for field_def in fields_def.field_definitions() {
-            fields.push(self.build_field(field_def)?);
+            fields.push(self.build_field(field_def, repeatable_directives)?);
         }
 
         Ok(())
@@ -589,15 +630,20 @@ impl ApolloLoweringAdapter {
         &self,
         fields_def: cst::InputFieldsDefinition,
         fields: &mut Vec<Field>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for field_def in fields_def.input_value_definitions() {
-            fields.push(self.build_input_field(field_def)?);
+            fields.push(self.build_input_field(field_def, repeatable_directives)?);
         }
 
         Ok(())
     }
 
-    fn build_field(&self, field_def: cst::FieldDefinition) -> Result<Field, WesleyError> {
+    fn build_field(
+        &self,
+        field_def: cst::FieldDefinition,
+        repeatable_directives: &BTreeSet<String>,
+    ) -> Result<Field, WesleyError> {
         let name = field_def
             .name()
             .ok_or(WesleyError::LoweringError {
@@ -614,13 +660,20 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives(dirs, &mut field_directives)?;
+            self.extract_directives_with_repeatability(
+                dirs,
+                &mut field_directives,
+                repeatable_directives,
+            )?;
         }
 
         Ok(Field {
             name,
             r#type: self.build_type_reference(type_node)?,
-            arguments: field_arguments_from_definition(field_def.arguments_definition())?,
+            arguments: field_arguments_from_definition(
+                field_def.arguments_definition(),
+                repeatable_directives,
+            )?,
             default_value: None,
             directives: field_directives,
             description: description_from(field_def.description()),
@@ -630,6 +683,7 @@ impl ApolloLoweringAdapter {
     fn build_input_field(
         &self,
         field_def: cst::InputValueDefinition,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<Field, WesleyError> {
         let name = field_def
             .name()
@@ -647,7 +701,11 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives(dirs, &mut field_directives)?;
+            self.extract_directives_with_repeatability(
+                dirs,
+                &mut field_directives,
+                repeatable_directives,
+            )?;
         }
         let default_value = field_def
             .default_value()
@@ -869,6 +927,7 @@ fn type_reference_shape_from_type(
 
 fn field_arguments_from_definition(
     arguments_definition: Option<cst::ArgumentsDefinition>,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<Vec<FieldArgument>, WesleyError> {
     let Some(arguments_definition) = arguments_definition else {
         return Ok(Vec::new());
@@ -876,12 +935,13 @@ fn field_arguments_from_definition(
 
     arguments_definition
         .input_value_definitions()
-        .map(field_argument_from_input_value)
+        .map(|input_value| field_argument_from_input_value(input_value, repeatable_directives))
         .collect()
 }
 
 fn field_argument_from_input_value(
     input_value: cst::InputValueDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<FieldArgument, WesleyError> {
     let name = input_value
         .name()
@@ -903,7 +963,11 @@ fn field_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(FieldArgument {
@@ -1056,12 +1120,46 @@ fn canonical_core_directive_name(name: &str) -> Option<&str> {
     }
 }
 
+fn repeatable_directive_names_from_document(
+    doc: &cst::Document,
+) -> Result<BTreeSet<String>, WesleyError> {
+    let mut repeatable = BTreeSet::new();
+    for definition in doc.definitions() {
+        let cst::Definition::DirectiveDefinition(directive) = definition else {
+            continue;
+        };
+        if directive.repeatable_token().is_none() {
+            continue;
+        }
+
+        let name = directive
+            .name()
+            .map(|name| name.text().to_string())
+            .ok_or_else(|| {
+                lowering_error_value("directive", "Directive definition missing name".to_string())
+            })?;
+        let canonical_name = canonical_core_directive_name(&name)
+            .unwrap_or(name.as_str())
+            .to_string();
+        repeatable.insert(canonical_name);
+    }
+
+    Ok(repeatable)
+}
+
 fn insert_directive_value(
     map: &mut IndexMap<String, serde_json::Value>,
     name: String,
     value: serde_json::Value,
-) {
+    repeatable: bool,
+) -> Result<(), WesleyError> {
     match map.get_mut(&name) {
+        Some(_) if !repeatable => {
+            return Err(lowering_error_value(
+                "directive",
+                format!("Duplicate non-repeatable directive '@{name}'"),
+            ));
+        }
         Some(serde_json::Value::Array(values)) => values.push(value),
         Some(existing) => {
             let first = std::mem::take(existing);
@@ -1071,6 +1169,8 @@ fn insert_directive_value(
             map.insert(name, value);
         }
     }
+
+    Ok(())
 }
 
 /// Resolves response-path field selections from a single GraphQL operation.
@@ -3468,6 +3568,7 @@ fn collect_schema_operations_from_object(
     name: Option<cst::Name>,
     fields_definition: Option<cst::FieldsDefinition>,
     root_types: &RootTypes,
+    repeatable_directives: &BTreeSet<String>,
     operations: &mut Vec<SchemaOperation>,
 ) -> Result<(), WesleyError> {
     let type_name = type_node_name(name, "Object type missing name")?;
@@ -3486,6 +3587,7 @@ fn collect_schema_operations_from_object(
                 *operation_type,
                 &type_name,
                 field_def.clone(),
+                repeatable_directives,
             )?);
         }
     }
@@ -3497,6 +3599,7 @@ fn schema_operation_from_field(
     operation_type: OperationType,
     root_type_name: &str,
     field_def: cst::FieldDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<SchemaOperation, WesleyError> {
     let field_name = field_def
         .name()
@@ -3513,14 +3616,21 @@ fn schema_operation_from_field(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = field_def.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(SchemaOperation {
         operation_type,
         root_type_name: root_type_name.to_string(),
         field_name,
-        arguments: operation_arguments_from_definition(field_def.arguments_definition())?,
+        arguments: operation_arguments_from_definition(
+            field_def.arguments_definition(),
+            repeatable_directives,
+        )?,
         result_type: type_reference_from_type(result_type, true)?,
         directives,
     })
@@ -3528,6 +3638,7 @@ fn schema_operation_from_field(
 
 fn operation_arguments_from_definition(
     arguments_definition: Option<cst::ArgumentsDefinition>,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<Vec<OperationArgument>, WesleyError> {
     let Some(arguments_definition) = arguments_definition else {
         return Ok(Vec::new());
@@ -3535,12 +3646,13 @@ fn operation_arguments_from_definition(
 
     arguments_definition
         .input_value_definitions()
-        .map(operation_argument_from_input_value)
+        .map(|input_value| operation_argument_from_input_value(input_value, repeatable_directives))
         .collect()
 }
 
 fn operation_argument_from_input_value(
     input_value: cst::InputValueDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<OperationArgument, WesleyError> {
     let name = input_value
         .name()
@@ -3562,7 +3674,11 @@ fn operation_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(OperationArgument {

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -401,7 +401,7 @@ impl ApolloLoweringAdapter {
         match def {
             TypeDefinitionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -413,7 +413,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -428,7 +428,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -440,7 +440,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -452,7 +452,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -464,7 +464,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -488,7 +488,7 @@ impl ApolloLoweringAdapter {
         match ext {
             TypeExtensionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -500,7 +500,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -515,7 +515,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -527,7 +527,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -539,7 +539,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -551,7 +551,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -567,7 +567,6 @@ impl ApolloLoweringAdapter {
     }
 
     fn extract_directives_with_repeatability(
-        &self,
         dirs: cst::Directives,
         map: &mut IndexMap<String, serde_json::Value>,
         repeatable_directives: &BTreeSet<String>,
@@ -660,7 +659,7 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives_with_repeatability(
+            Self::extract_directives_with_repeatability(
                 dirs,
                 &mut field_directives,
                 repeatable_directives,
@@ -701,7 +700,7 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives_with_repeatability(
+            Self::extract_directives_with_repeatability(
                 dirs,
                 &mut field_directives,
                 repeatable_directives,
@@ -963,7 +962,7 @@ fn field_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,
@@ -3616,7 +3615,7 @@ fn schema_operation_from_field(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = field_def.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,
@@ -3674,7 +3673,7 @@ fn operation_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -599,13 +599,6 @@ impl ApolloLoweringAdapter {
                 serde_json::Value::Object(args_map)
             };
 
-            if core_name.is_some() && map.contains_key(&canonical_name) {
-                return Err(lowering_error_value(
-                    "directive",
-                    format!("Duplicate directive '@{canonical_name}'"),
-                ));
-            }
-
             let repeatable = core_name.is_none() && repeatable_directives.contains(&canonical_name);
             insert_directive_value(map, canonical_name, val, repeatable)?;
         }

--- a/crates/wesley-core/tests/lowering_validation.rs
+++ b/crates/wesley-core/tests/lowering_validation.rs
@@ -143,14 +143,17 @@ async fn rejects_duplicate_canonical_directives() {
     let message = err.to_string();
 
     assert!(
-        message.contains("Duplicate directive '@wes_table'"),
+        message.contains("Duplicate non-repeatable directive '@wes_table'"),
         "unexpected error: {message}"
     );
 
     let diagnostic = err.diagnostic();
     assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
     assert_eq!(diagnostic.severity, "ERROR");
-    assert_eq!(diagnostic.message, "Duplicate directive '@wes_table'");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@wes_table'"
+    );
     assert_eq!(diagnostic.line, None);
     assert_eq!(diagnostic.column, None);
 }
@@ -191,7 +194,10 @@ async fn diagnostic_fixture_rejects_duplicate_canonical_directives() {
     let diagnostic = err.diagnostic();
 
     assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
-    assert_eq!(diagnostic.message, "Duplicate directive '@wes_table'");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@wes_table'"
+    );
 }
 
 #[tokio::test]

--- a/crates/wesley-core/tests/lowering_validation.rs
+++ b/crates/wesley-core/tests/lowering_validation.rs
@@ -290,6 +290,143 @@ async fn preserves_repeated_custom_directives_as_ordered_values() {
 }
 
 #[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_on_same_location() {
+    let sdl = r#"
+        directive @tag(name: String!) on FIELD_DEFINITION
+
+        type Thing {
+          name: String @tag(name: "alpha") @tag(name: "beta")
+        }
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("non-repeatable custom directive duplicates should fail");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_across_base_and_extension() {
+    let sdl = r#"
+        directive @tag(name: String!) on OBJECT
+
+        type Thing @tag(name: "base") {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "extension")
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("base and extension non-repeatable custom directives should collide");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_across_extensions() {
+    let sdl = r#"
+        directive @tag(name: String!) on OBJECT
+
+        type Thing {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "first")
+        extend type Thing @tag(name: "second")
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("extension non-repeatable custom directives should collide");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn preserves_repeatable_custom_directives_across_extensions() {
+    let sdl = r#"
+        directive @tag(name: String!) repeatable on OBJECT
+
+        type Thing @tag(name: "base") {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "first")
+        extend type Thing @tag(name: "second")
+    "#;
+
+    let adapter = create_adapter();
+    let ir = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect("repeatable custom directives should accumulate across extensions");
+    let thing = find_type(&ir.types, "Thing");
+    let tag_values = thing.directives["tag"]
+        .as_array()
+        .expect("repeatable type directives should be preserved as an array");
+
+    assert_eq!(tag_values.len(), 3);
+    assert_eq!(
+        tag_values[0]["name"],
+        serde_json::Value::String("base".into())
+    );
+    assert_eq!(
+        tag_values[1]["name"],
+        serde_json::Value::String("first".into())
+    );
+    assert_eq!(
+        tag_values[2]["name"],
+        serde_json::Value::String("second".into())
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_undefined_custom_directives() {
+    let sdl = r#"
+        type Thing {
+          name: String @externalTag(name: "alpha") @externalTag(name: "beta")
+        }
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("undefined custom directive duplicates should not become arrays");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@externalTag'"
+    );
+}
+
+#[tokio::test]
 async fn lowers_graphql_type_families_into_l1_ir() {
     let sdl = r#"
         scalar DateTime @specifiedBy(url: "https://example.com/datetime")

--- a/docs/design/0013-rust-ir-parity-sentinel/EVIDENCE_rust-core-performance-baseline.md
+++ b/docs/design/0013-rust-ir-parity-sentinel/EVIDENCE_rust-core-performance-baseline.md
@@ -17,46 +17,47 @@ not make performance claims without fixture-backed measurements.
 ## Hill
 
 Wesley has a repeatable Rust CLI lowering wall-clock baseline over the explicit
-Rust IR fixture corpus before any default cutover.
+Rust IR scale fixture corpus.
 
-This slice does not claim JS/Rust speedup, Node binding overhead, WASM overhead,
-peak RSS, or external consumer runtime performance. Those need separate
-harnesses.
+This slice does not claim JS/Rust speedup, Node binding overhead, WASM
+overhead, peak RSS, or external consumer runtime performance. Those need
+separate harnesses.
 
 ## Implemented Slice
 
-`pnpm perf:ir` runs:
+The active Rust-native command is:
 
 ```bash
-node scripts/measure-ir-performance.mjs
+cargo xtask bench-ir
 ```
 
-The v0 report records Rust CLI `schema lower` wall-clock samples over the
-explicit valid Rust IR fixture corpus:
+It builds the native `wesley` binary, generates advisory scale fixtures in a
+temporary directory, lowers each fixture through `wesley schema lower --json`,
+and reports wall-clock samples plus structural size counters.
 
-- `test/fixtures/ir-parity/small-schema.graphql`
-- `test/fixtures/ir-parity/medium-schema.graphql`
-- `test/fixtures/ir-parity/large-schema.graphql`
-- `test/fixtures/ir-parity/directive-heavy-schema.graphql`
-- `test/fixtures/ir-parity/legacy-alias-schema.graphql`
-- `test/fixtures/ir-parity/schema-extensions-schema.graphql`
-- `test/fixtures/ir-parity/nested-list-schema.graphql`
+The generated scale corpus currently covers:
+
+- wide object and query field surfaces
+- deep nested input references
+- directive-heavy object, field, and argument surfaces
+- operation-heavy Query and Mutation surfaces
+- pathological-but-valid extension folding
 
 The report includes:
 
-- report tool version
+- report API version
 - current Git head
 - lowerer command
 - warmup and measured iteration counts
-- fixture path
+- fixture name
 - SDL byte size
-- Rust L1 output byte size
-- Rust L1 semantic hash with top-level `metadata` removed
+- L1 JSON output byte size
 - type count
+- field count
+- directive count
+- operation count
 - duration samples, minimum, median, mean, and maximum milliseconds
-- optional in-process legacy JS lowering samples when
-  `--include-legacy-js` is passed
-- explicit `memory.status: "not-captured"`
+- explicit `memory.peakRss: "not-captured"`
 
 The command is evidence, not a threshold. It exits nonzero only when a fixture
 cannot be lowered or the report cannot be assembled.
@@ -64,11 +65,23 @@ cannot be lowered or the report cannot be assembled.
 Useful invocations:
 
 ```bash
-pnpm perf:ir -- --json
-pnpm perf:ir -- --include-legacy-js --json
-pnpm perf:ir -- --markdown --output out/rust-ir-performance-baseline.md
-pnpm perf:ir -- --fixture test/fixtures/ir-parity/large-schema.graphql --iterations 5
+cargo xtask bench-ir
+cargo --quiet xtask bench-ir --json
+cargo xtask bench-ir --iterations 5 --warmups 1
+cargo xtask bench-ir --output out/rust-ir-performance-baseline.json
 ```
+
+The JSON report is most useful through `--output` when it needs to become
+release evidence. Operators should store generated reports as release artifacts
+or evidence attachments, not as recurring committed churn.
+
+## Historical Surface
+
+The v0.0.6 performance command was `pnpm perf:ir`, backed by
+`scripts/measure-ir-performance.mjs` and `test/ir-performance-baseline.bats`.
+Those files were deleted during the legacy Node retirement. Mentions of that
+surface in historical release notes are archival, not current operator
+guidance.
 
 ## Deferred Evidence
 
@@ -79,7 +92,7 @@ These remain intentionally outside v0:
 - Node binding overhead
 - WASM binding overhead
 - external consumer in-process measurements
-- pass/fail cutover thresholds
+- pass/fail cutover thresholds beyond catastrophic command failure
 
 The follow-on queue item is
 `docs/design/0016-rust-core-binding-observatory/EVIDENCE_rust-core-binding-and-memory-baselines.md`.
@@ -87,20 +100,17 @@ The follow-on queue item is
 ## Playback Questions
 
 1. Does Wesley have one command that measures Rust CLI lowering over the
-   explicit valid IR fixture corpus?
+   explicit scale fixture corpus?
 2. Does the report include stable fixture identity, output identity, sample
    counts, and summary timings without implying a speed threshold?
-3. Does the report explicitly say memory is not captured in v0?
-4. Can optional JS comparison evidence be captured without presenting it as
-   Node binding, WASM, memory, or cutover evidence?
-5. Can tests exercise the report contract through a fake lowerer without
-   relying on real timing values?
+3. Does the report include type, field, directive, and operation counts?
+4. Does the report explicitly say peak RSS is not captured instead of guessing?
+5. Do tests exercise the options, fixture corpus, metric counting, and summary
+   math without relying on real timing values?
 
 ## Repo Evidence
 
 - `docs/design/0009-rust-core-and-wasm-capability-abi/rust-core-and-wasm-capability-abi.md`
 - `docs/design/0013-rust-ir-parity-sentinel/SOURCE_wesley-core-rs-ir-contract-and-fixtures.md`
 - `docs/design/0013-rust-ir-parity-sentinel/rust-ir-parity-sentinel.md`
-- `scripts/measure-ir-performance.mjs`
-- `test/ir-performance-baseline.bats`
-- `test/fixtures/ir-parity/`
+- `xtask/src/main.rs`

--- a/docs/design/0013-rust-ir-parity-sentinel/SOURCE_wesley-core-rs-ir-contract-and-fixtures.md
+++ b/docs/design/0013-rust-ir-parity-sentinel/SOURCE_wesley-core-rs-ir-contract-and-fixtures.md
@@ -99,8 +99,8 @@ Current v0.0.6 behavior:
 - fixture corpus covers small, medium, large, directive-heavy, invalid,
   legacy-alias, schema-extension, and nested-list SDL cases
 - expected diagnostics include stable codes and spans where available
-- baseline Rust lowering wall-clock evidence is captured for the valid fixture
-  corpus by `pnpm perf:ir`
+- baseline Rust lowering wall-clock evidence is captured for generated scale
+  fixtures by `cargo xtask bench-ir`
 - memory and binding overhead remain separate follow-on evidence instead of
   hidden claims inside the wall-clock baseline
 - parity failure output shows the first semantic mismatch, not just a raw diff
@@ -119,6 +119,6 @@ Current v0.0.6 behavior:
 - `scripts/generate-ir-fixtures.mjs`
 - `scripts/check-ir-parity.mjs`
 - `scripts/check-parser-parity.mjs`
-- `scripts/measure-ir-performance.mjs`
+- `xtask/src/main.rs`
 - `test/fixtures/ir-parity/`
 - `test/fixtures/ir-parity-invalid/`

--- a/docs/design/0013-rust-ir-parity-sentinel/rust-ir-parity-sentinel.md
+++ b/docs/design/0013-rust-ir-parity-sentinel/rust-ir-parity-sentinel.md
@@ -222,21 +222,21 @@ adding a third projection.
 
 The pulled
 [Rust core performance baseline](./EVIDENCE_rust-core-performance-baseline.md)
-slice adds:
+slice now uses the Rust-native advisory command:
 
 ```bash
-pnpm perf:ir
+cargo xtask bench-ir
 ```
 
-The v0 baseline measures Rust CLI `schema lower` wall-clock samples over the
-valid Rust IR fixture corpus, including `large-schema.graphql`. It records
-fixture identity, SDL byte size, output byte size, Rust L1 semantic hash, type
-count, sample durations, and summary timings.
+The current baseline measures Rust CLI `schema lower` wall-clock samples over
+generated scale fixtures covering wide schemas, deep input references,
+directive-heavy schemas, operation-heavy schemas, and extension folding. It
+records fixture identity, SDL byte size, output byte size, type count, field
+count, directive count, operation count, sample durations, and summary timings.
 
-`pnpm perf:ir -- --include-legacy-js` also records in-process legacy JS lowerer
-wall-clock samples for the same fixture run. This is comparison evidence only;
-it is not Node binding overhead, WASM binding overhead, peak RSS, or a cutover
-threshold.
+The retired `pnpm perf:ir` command and legacy JS comparison mode are archival
+v0.0.6 evidence only. The active command is not Node binding overhead, WASM
+binding overhead, peak RSS, or a cutover threshold.
 
 ## Type-Family Projection
 

--- a/docs/design/0015-resilience-policy-boundary/resilience-policy-boundary.md
+++ b/docs/design/0015-resilience-policy-boundary/resilience-policy-boundary.md
@@ -100,10 +100,12 @@ Resilience policy does not make Wesley the owner of:
   sleeping on wall-clock time.
 - Rust policy tests include a synchronous-poll guard proving the wrapper does
   not present CPU-bound in-process parser work as preemptible.
-- `scripts/resilient-process.mjs` centralizes Alfred-backed child-process
-  timeout and output-buffer policy for JavaScript tooling.
-- `pnpm parity:ir` and `pnpm perf:ir` both use the shared runner for native CLI
-  probes.
+- `scripts/resilient-process.mjs` centralized Alfred-backed child-process
+  timeout and output-buffer policy for historical JavaScript tooling.
+- Historical `pnpm parity:ir` and `pnpm perf:ir` probes used the shared runner
+  before legacy Node retirement.
+- Current Rust-native IR benchmark evidence is emitted by
+  `cargo xtask bench-ir`.
 - JavaScript timeout behavior is covered with Alfred `TestClock`.
 
 ## Playback Questions

--- a/docs/design/0016-rust-core-binding-observatory/EVIDENCE_rust-core-binding-and-memory-baselines.md
+++ b/docs/design/0016-rust-core-binding-observatory/EVIDENCE_rust-core-binding-and-memory-baselines.md
@@ -40,7 +40,8 @@ The report captures:
 - Cutover criteria as explicit `not-evaluated` release posture.
 
 The fixture corpus remains useful as historical evidence, but the active
-product gate is now `cargo xtask preflight`.
+product gate is now `cargo xtask preflight`, and the active Rust-native
+lowering benchmark is `cargo xtask bench-ir`.
 
 ## Deferred Evidence
 
@@ -72,4 +73,5 @@ These remain intentionally outside this slice:
   legacy Node retirement.
 - Historical test: `test/ir-performance-baseline.bats` was deleted during
   legacy Node retirement.
+- Current Rust-native advisory command: `cargo xtask bench-ir`
 - [Rust core performance baseline](../0013-rust-ir-parity-sentinel/EVIDENCE_rust-core-performance-baseline.md)

--- a/docs/design/0016-rust-core-binding-observatory/rust-core-binding-observatory.md
+++ b/docs/design/0016-rust-core-binding-observatory/rust-core-binding-observatory.md
@@ -62,6 +62,13 @@ It may also be emitted through:
 pnpm perf:ir -- --observatory --json
 ```
 
+Those commands are historical surfaces from before legacy Node retirement.
+Current Rust-native lowering evidence is emitted by:
+
+```bash
+cargo xtask bench-ir --output out/rust-ir-performance-baseline.json
+```
+
 The v0 contract records:
 
 - `tool: "rust-core-binding-observatory.v0"`
@@ -130,7 +137,8 @@ A future non-Rust host binding decision must combine:
 
 1. Does `pnpm perf:bindings -- --json` emit a report with named adapter
    statuses?
-2. Does the report preserve the same explicit fixture corpus as `pnpm perf:ir`?
+2. Does the report preserve the same explicit fixture corpus as the then-current
+   performance command?
 3. Does Rust CLI evidence remain separate from Node binding overhead?
 4. Does legacy JS evidence include heap-delta samples without claiming peak RSS?
 5. Are Node binding and WASM binding marked as `not-implemented` rather than

--- a/docs/design/0017-rust-native-front-door-and-node-retirement/PARITY_SENTINEL_ARCHIVE.md
+++ b/docs/design/0017-rust-native-front-door-and-node-retirement/PARITY_SENTINEL_ARCHIVE.md
@@ -18,12 +18,12 @@ Rust self-consistency is the product gate:
 
 ## Archived Migration Evidence
 
-| Surface              | Historical role                              | Current role                                                               |
-| -------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
-| `pnpm parity:ir`     | Compared selected JS and Rust IR projections | Optional migration evidence while legacy JS lowerer files still exist.     |
-| `pnpm parity:parser` | Compared parser/lowerer acceptance outcomes  | Optional acceptance archaeology for legacy fixtures.                       |
-| `pnpm perf:ir`       | Measured Rust CLI and optional JS lowerer    | Rust CLI baseline plus optional legacy comparison, not a release decision. |
-| `pnpm perf:bindings` | Named future binding cutover report slots    | Observatory evidence only; it does not authorize a binding choice.         |
+| Surface              | Historical role                              | Current role                                                                |
+| -------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
+| `pnpm parity:ir`     | Compared selected JS and Rust IR projections | Optional migration evidence while legacy JS lowerer files still exist.      |
+| `pnpm parity:parser` | Compared parser/lowerer acceptance outcomes  | Optional acceptance archaeology for legacy fixtures.                        |
+| `pnpm perf:ir`       | Measured Rust CLI and optional JS lowerer    | Retired; use `cargo xtask bench-ir` for current Rust CLI baseline evidence. |
+| `pnpm perf:bindings` | Named future binding cutover report slots    | Observatory evidence only; it does not authorize a binding choice.          |
 
 ## Retirement Rule
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -43,11 +43,11 @@ lowering, hashing, diffing, and emitter flows.
 Directive values in L1 IR follow GraphQL repeatability:
 
 - non-repeatable directives lower to a single directive value
-- duplicate non-repeatable directives fail lowering, including duplicates split
-  across a base definition and extensions
+- custom directives are non-repeatable unless their SDL directive definition
+  is marked `repeatable`
+- duplicate non-repeatable directives fail lowering across base definitions
+  and any extensions, including extension-to-extension collisions
 - directives declared with `repeatable` lower to ordered arrays when repeated
-- unknown custom directives are treated as non-repeatable unless the SDL
-  declares them `repeatable`
 
 Canonical Wesley directive aliases, such as `@table` and `@wes_table`, still
 collide as their canonical `@wes_*` directive and are rejected when repeated.

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -27,16 +27,30 @@ directives by what that path truly parses and lowers today.
 These directives are the stable SDL surface for the current Rust-native schema
 lowering, hashing, diffing, and emitter flows.
 
-| Directive                      | Status    | Current lowering                            | Aliases accepted by current parser | Notes                                                                                                                  |
-| ------------------------------ | --------- | ------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `@wes_table`                   | `current` | Admits an object type to structured IR      | `@wesley_table`, `@table`          | Historical name; downstream modules decide whether that structure becomes SQL, models, validators, or something else. |
-| `@wes_pk`                      | `current` | Marks the primary identity field            | `@wesley_pk`, `@pk`, `@primaryKey` | Current lowering enforces at most one primary identity field and requires it to be non-null.                           |
-| `@wes_fk(ref: "Type.field")`   | `current` | Lowers structured reference metadata        | `@wesley_fk`, `@fk`, `@foreignKey` | Main path validates the `Type.field` format and target existence.                                                      |
-| `@wes_unique`                  | `current` | Lowers a uniqueness marker                  | `@wesley_unique`, `@unique`        | Preserved in IR for downstream emitters and external targets.                                                          |
-| `@wes_index`                   | `current` | Lowers an index marker                      | `@wesley_index`, `@index`          | Field-level indexing metadata is current; target-specific index semantics are downstream-owned.                        |
-| `@wes_tenant(by: "...")`       | `current` | Lowers tenant metadata on the object        | `@wesley_tenant`, `@tenant`        | The `by` field must exist on the same type.                                                                            |
-| `@wes_default(value: "...")`   | `current` | Lowers a default expression/value marker    | `@wesley_default`, `@default`      | Canonical argument is `value`; the parser still accepts legacy `expr` on the hot path.                                 |
-| `@wes_rls`                     | `current` | Preserves an RLS marker                     | `@wesley_rls`, `@rls`              | Treat this as a marker today; full policy semantics belong to downstream modules.                                      |
+| Directive                    | Status    | Current lowering                         | Aliases accepted by current parser | Notes                                                                                                                 |
+| ---------------------------- | --------- | ---------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `@wes_table`                 | `current` | Admits an object type to structured IR   | `@wesley_table`, `@table`          | Historical name; downstream modules decide whether that structure becomes SQL, models, validators, or something else. |
+| `@wes_pk`                    | `current` | Marks the primary identity field         | `@wesley_pk`, `@pk`, `@primaryKey` | Current lowering enforces at most one primary identity field and requires it to be non-null.                          |
+| `@wes_fk(ref: "Type.field")` | `current` | Lowers structured reference metadata     | `@wesley_fk`, `@fk`, `@foreignKey` | Main path validates the `Type.field` format and target existence.                                                     |
+| `@wes_unique`                | `current` | Lowers a uniqueness marker               | `@wesley_unique`, `@unique`        | Preserved in IR for downstream emitters and external targets.                                                         |
+| `@wes_index`                 | `current` | Lowers an index marker                   | `@wesley_index`, `@index`          | Field-level indexing metadata is current; target-specific index semantics are downstream-owned.                       |
+| `@wes_tenant(by: "...")`     | `current` | Lowers tenant metadata on the object     | `@wesley_tenant`, `@tenant`        | The `by` field must exist on the same type.                                                                           |
+| `@wes_default(value: "...")` | `current` | Lowers a default expression/value marker | `@wesley_default`, `@default`      | Canonical argument is `value`; the parser still accepts legacy `expr` on the hot path.                                |
+| `@wes_rls`                   | `current` | Preserves an RLS marker                  | `@wesley_rls`, `@rls`              | Treat this as a marker today; full policy semantics belong to downstream modules.                                     |
+
+### IR Encoding Rule
+
+Directive values in L1 IR follow GraphQL repeatability:
+
+- non-repeatable directives lower to a single directive value
+- duplicate non-repeatable directives fail lowering, including duplicates split
+  across a base definition and extensions
+- directives declared with `repeatable` lower to ordered arrays when repeated
+- unknown custom directives are treated as non-repeatable unless the SDL
+  declares them `repeatable`
+
+Canonical Wesley directive aliases, such as `@table` and `@wes_table`, still
+collide as their canonical `@wes_*` directive and are rejected when repeated.
 
 ### Composition Directives
 
@@ -71,8 +85,8 @@ ships a public `compile-ttd` command or old core TTD package export.
 | Directive family                                                                                     | Status     | Current surface                                                                                                                                    |
 | ---------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@wes_channel`, `@wes_op`, `@wes_rule`, `@wes_invariant`                                             | `external` | Declared in `continuum/wesley/ttd/schemas/ttd-directives.graphql` and parsed by `continuum/wesley/ttd/directives.mjs`, not by generic Wesley core. |
-| `@wes_emission`, `@wes_footprint`, `@wes_requires`, `@wes_produces`, `@wes_emitsTo`, `@wes_mustEmit` | `external` | Current in the relocated Continuum TTD extraction/manifest path, not in generic Wesley.                                            |
-| `@wes_codec`, `@wes_version`                                                                         | `external` | Current for relocated Continuum TTD/type-registry compilation paths and related manifests, not for generic Wesley.                 |
+| `@wes_emission`, `@wes_footprint`, `@wes_requires`, `@wes_produces`, `@wes_emitsTo`, `@wes_mustEmit` | `external` | Current in the relocated Continuum TTD extraction/manifest path, not in generic Wesley.                                                            |
+| `@wes_codec`, `@wes_version`                                                                         | `external` | Current for relocated Continuum TTD/type-registry compilation paths and related manifests, not for generic Wesley.                                 |
 
 ## Deferred Or Unstable Surface
 

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -39,6 +39,7 @@ short path to the authoritative surface.
 | ------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Choose local checks before a PR or release. | [Validation](./validation.md)                 | `cargo xtask preflight`, `docs/governance/RELEASE_POLICY.md`                       |
 | Interpret GitHub Actions checks.            | [CI Workflows](./ci-workflows.md)             | `docs/ci.md`, `.github/workflows/`                                                 |
+| Evaluate security scanners and gates.       | [Security Tooling](./security-tooling.md)     | `SECURITY.md`, `.github/workflows/`, `docs/governance/RELEASE_POLICY.md`           |
 | Understand HOLMES CI and PR comments.       | [HOLMES CI](./holmes-ci.md)                   | `.github/workflows/wesley-holmes.yml`, `docs/architecture/`                        |
 | Work with assurance evidence and policies.  | [Assurance Evidence](./assurance-evidence.md) | `docs/reference/assurance-capability-matrix.md`, `docs/holmes-policy-spec.md`      |
 | Prepare or judge a release.                 | [Releases](./releases.md)                     | `.continuum/release.yml`, `docs/method/release.md`, `docs/governance/`             |

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -48,6 +48,7 @@ short path to the authoritative surface.
 
 | Task                               | Start Here                                             | Authority                                       |
 | ---------------------------------- | ------------------------------------------------------ | ----------------------------------------------- |
+| Make a first small PR.             | [First PR](./contributing/first-pr.md)                 | `CONTRIBUTING.md`, GitHub Issues                |
 | Make a first generic compiler PR.  | [Plain Wesley](./plain-wesley.md#contributor-tutorial) | `docs/guides/extending.md`                      |
 | Find the right documentation path. | [Docs Orientation](./docs-orientation.md)              | `docs/README.md`                                |
 | Triage issues into release lanes.  | [Issue Triage](./contributing/triage.md)               | GitHub Issues, Milestones, Projects, and labels |

--- a/docs/topics/ci-workflows.md
+++ b/docs/topics/ci-workflows.md
@@ -17,6 +17,7 @@ diff or running focused checks before a PR.
 | Compatibility smoke          | Workspace compatibility and Rust product smoke.    |
 | CodeQL / analysis            | Static analysis for supported languages.           |
 | Dependency review            | Dependency risk in PRs.                            |
+| Security posture             | Advisory gates, scanner fit, and false positives.  |
 | HOLMES workflow              | Schema-selected assurance reports and PR comments. |
 | SHIPME certificate           | Post-merge evidence for the landed `main` SHA.     |
 
@@ -54,6 +55,7 @@ BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 ## Related Authority
 
 - [Continuous Integration](../ci.md)
+- [Security Tooling](./security-tooling.md)
 - [HOLMES CI](./holmes-ci.md)
 - [Validation](./validation.md)
 - [Release Workflow](./releases.md)

--- a/docs/topics/contributing/first-pr.md
+++ b/docs/topics/contributing/first-pr.md
@@ -1,0 +1,128 @@
+# First PR
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Use this page when you want one small, safe Wesley contribution without
+learning the whole architecture first.
+
+The short version: pick a scoped GitHub issue, change the named file or small
+file set, run the command named in the issue, then open one PR for that issue.
+
+## Required Reading
+
+Read only what your issue needs:
+
+- the issue body and acceptance criteria
+- this page
+- the task topic linked from the issue, if it has one
+- [Validation](../validation.md) for local checks before the PR
+- [Issue Triage](./triage.md) only if you are helping maintain the queue
+
+These are useful background, not required first-hour reading:
+
+- [Vision](../../VISION.md)
+- [Architecture](../../ARCHITECTURE.md)
+- [Design packets](../../design/README.md)
+- assurance vocabulary such as Holmes, Watson, Moriarty, BLADE, witness
+  surfaces, or realization shells
+
+If a starter issue requires advanced vocabulary, the issue should either define
+the term in plain English or stop being marked `good first issue`.
+
+## Optional Consumer Examples
+
+Wesley keeps some consumer-shaped fixtures so compiler changes can be tested
+against realistic schema pressure without depending on sibling checkouts.
+[Jedit Capability Evidence](../../JEDIT_CAPABILITY_EVIDENCE.md) is the current
+example. Treat it as Wesley-side compiler evidence only: jedit, Echo, and other
+consumers own their own product behavior and runtime semantics.
+
+## Pick A Starter Issue
+
+Use the
+[good first issue query](https://github.com/flyingrobots/wesley/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+and choose an issue that has:
+
+- exactly one scheduling label such as `v0.3.0`, not a `triage:*` label
+- no `work-in-progress` label
+- one primary file or a very small file set
+- one local validation command in the acceptance criteria
+- plain wording in the title and summary
+
+Leave broad design, release, assurance, or architecture issues for maintainers
+unless the issue explicitly says it is scoped for a first PR.
+
+## Fast Paths
+
+| Path            | Typical Files                                        | Local Command                                     | Good First Shape                                      |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
+| Docs-only PR    | `docs/topics/*.md`, `docs/guides/*.md`, `README.md`  | `cargo xtask docs-check`                          | Clarify one page, fix one route, or add one example.  |
+| Fixture-only PR | `test/fixtures/**/*.graphql`, related golden fixture | Issue-named test command                          | Add one domain-free schema shape and its expectation. |
+| Emitter-test PR | `crates/wesley-emit-rust/src/lib.rs` or TypeScript   | `cargo test -p wesley-emit-rust` or issue command | Add one schema case and assert generated type shape.  |
+| CLI bug PR      | `crates/wesley-cli/tests/cli.rs`                     | `cargo test -p wesley-cli --test cli <filter>`    | Reproduce one command failure with a clear assertion. |
+
+Do not start by refactoring shared architecture. A first PR should leave a
+reviewer able to answer: issue, file, command, result.
+
+## Branch And PR
+
+1. Start from an up-to-date `main` unless a maintainer asks you to stack on
+   another branch.
+2. Name the branch after the issue, for example
+   `docs/project-manifest-starter`.
+3. Keep one issue per PR.
+4. Mention the issue in the PR body with `Closes #NNN` when the PR fully
+   completes it.
+5. Include the exact validation command and result in the PR body.
+
+If you cannot add labels yourself, comment on the issue that you are taking it.
+A maintainer should add `work-in-progress` while the slice is active.
+
+## Maintainer Starter-Issue Checklist
+
+Before applying `good first issue`, make the issue executable without private
+context:
+
+- title uses ordinary terms
+- summary explains the task in two or three sentences
+- scope names one primary file or tiny file set
+- acceptance criteria include exactly one required local command
+- labels include exactly one scheduling state: either one `triage:*` label or
+  one `vX.Y.Z` label
+- scheduled starter issues use a `vX.Y.Z` label instead of `triage:*`
+- no advanced Wesley term appears without a plain-English alias
+
+Useful commands:
+
+```bash
+gh issue edit <number> --add-label "good first issue"
+gh issue edit <number> --remove-label triage:requests --add-label v0.3.0
+gh issue edit <number> --add-label work-in-progress
+gh issue edit <number> --remove-label work-in-progress
+```
+
+If an issue is too broad, split it before adding `good first issue`.
+
+## Maintainer Release And Triage Commands
+
+Use these only when maintaining the queue or preparing a release:
+
+```bash
+gh issue list --label triage:requests --state open
+gh issue list --label "good first issue" --state open
+gh issue list --label v0.3.0 --state open
+cargo xtask release-prep-guard --version X.Y.Z
+cargo xtask release-guard --tag vX.Y.Z
+```
+
+The full release execution layer remains
+[Release Runbook](../../method/release-runbook.md). The label contract remains
+[Issue Triage](./triage.md).
+
+## Related
+
+- [Contributing](../../../CONTRIBUTING.md)
+- [Plain Wesley](../plain-wesley.md)
+- [Docs Orientation](../docs-orientation.md)
+- [Docs Maintenance](../docs-maintenance.md)
+- [Releases](../releases.md)

--- a/docs/topics/contributing/first-pr.md
+++ b/docs/topics/contributing/first-pr.md
@@ -54,12 +54,13 @@ unless the issue explicitly says it is scoped for a first PR.
 
 ## Fast Paths
 
-| Path            | Typical Files                                        | Local Command                                     | Good First Shape                                      |
-| --------------- | ---------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
-| Docs-only PR    | `docs/topics/*.md`, `docs/guides/*.md`, `README.md`  | `cargo xtask docs-check`                          | Clarify one page, fix one route, or add one example.  |
-| Fixture-only PR | `test/fixtures/**/*.graphql`, related golden fixture | Issue-named test command                          | Add one domain-free schema shape and its expectation. |
-| Emitter-test PR | `crates/wesley-emit-rust/src/lib.rs` or TypeScript   | `cargo test -p wesley-emit-rust` or issue command | Add one schema case and assert generated type shape.  |
-| CLI bug PR      | `crates/wesley-cli/tests/cli.rs`                     | `cargo test -p wesley-cli --test cli <filter>`    | Reproduce one command failure with a clear assertion. |
+| Path            | Typical Files                                        | Local Command                                           | Good First Shape                                      |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------- |
+| Docs-only PR    | `docs/topics/*.md`, `docs/guides/*.md`, `README.md`  | `cargo xtask docs-check`                                | Clarify one page, fix one route, or add one example.  |
+| Fixture-only PR | `test/fixtures/**/*.graphql`, related golden fixture | Issue-named test command                                | Add one domain-free schema shape and its expectation. |
+| Rust emitter PR | `crates/wesley-emit-rust/src/lib.rs`                 | `cargo test -p wesley-emit-rust` or issue command       | Add one schema case and assert generated type shape.  |
+| TS emitter PR   | `crates/wesley-emit-typescript/src/lib.rs`           | `cargo test -p wesley-emit-typescript` or issue command | Add one schema case and assert generated type shape.  |
+| CLI bug PR      | `crates/wesley-cli/tests/cli.rs`                     | `cargo test -p wesley-cli --test cli <filter>`          | Reproduce one command failure with a clear assertion. |
 
 Do not start by refactoring shared architecture. A first PR should leave a
 reviewer able to answer: issue, file, command, result.

--- a/docs/topics/contributing/first-pr.md
+++ b/docs/topics/contributing/first-pr.md
@@ -90,7 +90,8 @@ context:
 - acceptance criteria include exactly one required local command
 - labels include exactly one scheduling state: either one `triage:*` label or
   one `vX.Y.Z` label
-- scheduled starter issues use a `vX.Y.Z` label instead of `triage:*`
+- scheduled starter issues use a `vX.Y.Z` label instead of `triage:*` and
+  belong to a `Goalpost: ...` milestone
 - no advanced Wesley term appears without a plain-English alias
 
 Useful commands:

--- a/docs/topics/docs-orientation.md
+++ b/docs/topics/docs-orientation.md
@@ -14,6 +14,7 @@ surface, then follow that surface's authority links.
 | -------------------------------------- | ---------------------------------------------------------------------- |
 | Understand what Wesley is.             | [README](../../README.md)                                              |
 | Complete the first-hour compiler path. | [Plain Wesley](./plain-wesley.md)                                      |
+| Make a first small PR.                 | [First PR](./contributing/first-pr.md)                                 |
 | Find a task-specific path.             | [Topics Index](./README.md)                                            |
 | Orient across all docs signposts.      | [Docs Entrance](../README.md)                                          |
 | Understand the current architecture.   | [Architecture](../ARCHITECTURE.md)                                     |

--- a/docs/topics/security-tooling.md
+++ b/docs/topics/security-tooling.md
@@ -1,0 +1,84 @@
+# Security Tooling
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Use this topic when evaluating a security scanner, advisory gate, or workflow
+hardening change for Wesley.
+
+Wesley is currently a compiler and tooling repository. It does not ship a hosted
+HTTP service, browser application, database runtime, or long-lived daemon. The
+security tooling posture therefore focuses on the compiler surface:
+
+- dependency and supply-chain advisories,
+- generated-source safety,
+- artifact and path handling,
+- GitHub Actions permissions and egress visibility,
+- domain-empty boundary regressions.
+
+Security tooling in this repo should not claim that Wesley has proved
+downstream runtime, database, product, or target-module security semantics.
+Those claims belong to the owning target module or sibling repository.
+
+## Current Baseline
+
+| Surface                                   | Current Gate                                                                                                 | Status                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| JavaScript and TypeScript static analysis | `.github/workflows/codeql.yml` runs CodeQL with `security-and-quality` queries.                              | Active on `main`, PRs into `main`, and weekly schedule.                    |
+| Pull-request dependency changes           | `.github/workflows/dependency-review.yml` runs Dependency Review.                                            | Active on PRs into `main`; fails on high severity.                         |
+| Repository supply-chain posture           | `.github/workflows/scorecards.yml` runs OpenSSF Scorecard and uploads SARIF.                                 | Active on `main`, weekly schedule, and manual dispatch.                    |
+| Workflow egress visibility                | GitHub Actions jobs use `step-security/harden-runner` in audit mode.                                         | Active as visibility, not a blocking egress policy.                        |
+| JavaScript advisory audit                 | `cargo xtask preflight` runs `pnpm audit --prod=false --json`.                                               | Active in the strict local gate.                                           |
+| Rust advisory audit                       | `cargo xtask release-guard` and release workflows run `cargo audit`.                                         | Active for release readiness and publication.                              |
+| Rust product quality                      | `cargo xtask preflight` runs formatting, Clippy, workspace tests, docs checks, and a native CLI smoke test.  | Active in the strict local gate.                                           |
+| Domain-empty regression checks            | `test/domain-empty-boundary.bats` guards core source vocabulary.                                             | Active in repository validation.                                           |
+| Emitter source-safety regressions         | Emitter tests parse or compile generated output and include source-level guards where a printer rule exists. | Active for covered emitters and expected to grow with risky printer paths. |
+
+## Evaluation Matrix
+
+| Candidate                     | Decision                           | Rationale                                                                                                                                                                                                                             |
+| ----------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OWASP ZAP or other DAST       | Do not add now.                    | Wesley has no hosted runtime surface to crawl. Add DAST only if a future Wesley-owned web/API surface ships in this repo.                                                                                                             |
+| Semgrep with broad auto rules | Do not add as a blocking gate now. | Broad rule packs are likely to create high review cost for a compiler repo. Prefer repo-owned rules with focused fixtures.                                                                                                            |
+| Repo-specific Semgrep rules   | Candidate.                         | Useful fits are unsafe source interpolation in emitters, path traversal in artifact readers, and accidental domain semantics in core. Each rule needs a local reproducer and a documented false-positive policy before it blocks PRs. |
+| `cargo-deny`                  | Candidate.                         | Useful for license, advisory, duplicate, and ban policy once `deny.toml` exists and ownership is clear. Start advisory or scheduled before making it required.                                                                        |
+| Harden-runner blocking egress | Defer.                             | Audit mode provides evidence today. Blocking egress should wait until the workflow egress inventory is stable enough that normal release work is not noisy.                                                                           |
+
+## Gate Admission Rules
+
+A new security gate belongs in Wesley only when all of these are true:
+
+1. It protects a Wesley-owned compiler, CLI, artifact, docs, CI, or release
+   surface.
+2. It has a local command or focused fixture so contributors can reproduce the
+   failure without guessing at GitHub Actions state.
+3. It has a clear owner and a documented exception format.
+4. It does not duplicate an existing gate without adding a distinct signal.
+5. It starts as advisory or scheduled when the false-positive rate is unknown.
+6. It documents what the gate proves and what it does not prove.
+
+When a gate fails because of an advisory that is not exploitable in Wesley's
+actual product surface, document the package path, exposure analysis, temporary
+mitigation, and expiration or revisit date.
+
+## Near-Term Fits
+
+The most useful next gates are narrow and repo-specific:
+
+- emitter printer rules that catch direct interpolation of schema, law, or
+  directive strings into generated source,
+- artifact-reader rules that reject path escape regressions,
+- source-boundary rules that keep database, runtime, and product semantics out
+  of `wesley-core`,
+- an advisory `cargo-deny` policy once license and ban ownership is written
+  down.
+
+Keep DAST and hosted-application scanners out of Wesley until Wesley owns a
+hosted application surface.
+
+## Related Authority
+
+- [Security Policy](../../SECURITY.md)
+- [CI Workflows](./ci-workflows.md)
+- [Validation](./validation.md)
+- [Compiler Boundary](./compiler-boundary.md)
+- [Release Policy](../governance/RELEASE_POLICY.md)

--- a/docs/topics/validation.md
+++ b/docs/topics/validation.md
@@ -28,6 +28,7 @@ workspace tests, and a native CLI smoke test.
 | Domain-empty boundary                 | `BATS_LIB_PATH=test/vendor bats -t test/domain-empty-boundary.bats`                               |
 | HOLMES PR comments or reports         | `node --test packages/wesley-holmes/test/pr-comment.test.mjs`                                     |
 | JavaScript package or lockfile policy | `cargo xtask legacy-preflight`, `pnpm lint`                                                       |
+| Security-tooling policy or docs       | `cargo xtask docs-check`, `git diff --check`                                                      |
 
 The pre-push hook may select relevant checks, but do not use the hook as the
 only plan for a risky change. Choose checks deliberately and record the
@@ -43,4 +44,5 @@ Release validation is stricter than PR validation. Use
 
 - [`docs/governance/RELEASE_POLICY.md`](../governance/RELEASE_POLICY.md)
 - [`docs/governance/DOCUMENTATION_STANDARD.md`](../governance/DOCUMENTATION_STANDARD.md)
+- [`docs/topics/security-tooling.md`](./security-tooling.md)
 - [`docs/reference/cli.md`](../reference/cli.md)

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -242,6 +242,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/contributing/first-pr.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/method/release.md",
       "status": "current",
       "owner": "@flyingrobots"

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -217,6 +217,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/security-tooling.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/topics/validation.md",
       "status": "current",
       "owner": "@flyingrobots"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -134,14 +134,10 @@ fn run_preflight() -> Result<(), Error> {
 
 fn run_bench_ir(args: &[OsString]) -> Result<(), Error> {
     let options = BenchIrOptions::parse(args)?;
-    build_wesley_for_bench(options.json)?;
 
     let root = env::current_dir()
         .map_err(|source| Error::Usage(format!("failed to resolve current directory: {source}")))?;
-    let wesley_bin = root
-        .join("target")
-        .join("debug")
-        .join(format!("wesley{}", env::consts::EXE_SUFFIX));
+    let wesley_bin = build_wesley_for_bench(&root, options.json)?;
     let bench_root = env::temp_dir().join(format!(
         "wesley-bench-ir-{}-{}",
         std::process::id(),
@@ -259,12 +255,27 @@ fn run_bench_ir(args: &[OsString]) -> Result<(), Error> {
     Ok(())
 }
 
-fn build_wesley_for_bench(json_output: bool) -> Result<(), Error> {
+fn build_wesley_for_bench(root: &Path, json_output: bool) -> Result<PathBuf, Error> {
     if json_output {
-        run_command_no_label("cargo", &["build", "--quiet", "--bin", "wesley"])
+        run_command_no_label("cargo", &["build", "--quiet", "--bin", "wesley"])?;
     } else {
-        run_command("cargo", &["build", "--bin", "wesley"])
+        run_command("cargo", &["build", "--bin", "wesley"])?;
     }
+
+    Ok(bench_wesley_binary_path(
+        root,
+        env::var_os("CARGO_TARGET_DIR"),
+    ))
+}
+
+fn bench_wesley_binary_path(root: &Path, cargo_target_dir: Option<OsString>) -> PathBuf {
+    let target_dir = cargo_target_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| root.join("target"));
+
+    target_dir
+        .join("debug")
+        .join(format!("wesley{}", env::consts::EXE_SUFFIX))
 }
 
 fn run_wesley_schema_lower(wesley_bin: &Path, schema_path: &Path) -> Result<Vec<u8>, Error> {
@@ -3589,6 +3600,23 @@ mod tests {
             BenchIrOptions::parse(&args),
             Err(Error::Usage(message)) if message == "bench-ir --iterations must be greater than zero"
         ));
+    }
+
+    #[test]
+    fn bench_ir_binary_path_honors_cargo_target_dir() {
+        let root = Path::new("/workspace/wesley");
+        let expected_binary = format!("wesley{}", env::consts::EXE_SUFFIX);
+
+        assert_eq!(
+            bench_wesley_binary_path(root, Some(OsString::from("/tmp/wesley-target"))),
+            PathBuf::from("/tmp/wesley-target")
+                .join("debug")
+                .join(&expected_binary)
+        );
+        assert_eq!(
+            bench_wesley_binary_path(root, None),
+            root.join("target").join("debug").join(expected_binary)
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const EXIT_OK: u8 = 0;
 const EXIT_FAILURE: u8 = 1;
@@ -93,6 +93,7 @@ fn run(args: Vec<OsString>) -> Result<(), Error> {
             Ok(())
         }
         "test" => run_command("cargo", &["test", "--workspace"]),
+        "bench-ir" => run_bench_ir(&args[1..]),
         "preflight" | "strict-preflight" => run_preflight(),
         "docs-check" => run_docs_check(),
         "package-crates" => run_package_crates(&args[1..]),
@@ -129,6 +130,368 @@ fn run_preflight() -> Result<(), Error> {
     run_docs_check()?;
     run_command("cargo", &["test", "--workspace"])?;
     run_command("cargo", &["run", "--bin", "wesley", "--", "--help"])
+}
+
+fn run_bench_ir(args: &[OsString]) -> Result<(), Error> {
+    let options = BenchIrOptions::parse(args)?;
+    build_wesley_for_bench(options.json)?;
+
+    let root = env::current_dir()
+        .map_err(|source| Error::Usage(format!("failed to resolve current directory: {source}")))?;
+    let wesley_bin = root
+        .join("target")
+        .join("debug")
+        .join(format!("wesley{}", env::consts::EXE_SUFFIX));
+    let bench_root = env::temp_dir().join(format!(
+        "wesley-bench-ir-{}-{}",
+        std::process::id(),
+        git_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|_| "unknown".to_string())
+    ));
+    if bench_root.exists() {
+        fs::remove_dir_all(&bench_root).map_err(|source| {
+            Error::Usage(format!(
+                "failed to remove stale benchmark dir `{}`: {source}",
+                bench_root.display()
+            ))
+        })?;
+    }
+    fs::create_dir_all(&bench_root).map_err(|source| {
+        Error::Usage(format!(
+            "failed to create benchmark dir `{}`: {source}",
+            bench_root.display()
+        ))
+    })?;
+
+    let mut fixture_reports = Vec::new();
+    for fixture in bench_ir_fixtures() {
+        let schema_path = bench_root.join(format!("{}.graphql", fixture.name));
+        fs::write(&schema_path, &fixture.schema).map_err(|source| {
+            Error::Usage(format!(
+                "failed to write benchmark fixture `{}`: {source}",
+                schema_path.display()
+            ))
+        })?;
+
+        for _ in 0..options.warmups {
+            run_wesley_schema_lower(&wesley_bin, &schema_path)?;
+        }
+
+        let mut output_bytes = 0usize;
+        let mut counts = IrMetricCounts::default();
+        let mut samples_ms = Vec::new();
+        for _ in 0..options.iterations {
+            let start = Instant::now();
+            let output = run_wesley_schema_lower(&wesley_bin, &schema_path)?;
+            let elapsed = start.elapsed();
+            output_bytes = output.len();
+            let ir: serde_json::Value = serde_json::from_slice(&output).map_err(|source| {
+                Error::Usage(format!(
+                    "benchmark output for `{}` is not valid JSON: {source}",
+                    fixture.name
+                ))
+            })?;
+            counts = ir_metric_counts(&ir);
+            samples_ms.push(duration_ms(elapsed));
+        }
+
+        let summary = sample_summary(&samples_ms);
+        fixture_reports.push(serde_json::json!({
+            "name": fixture.name,
+            "schemaBytes": fixture.schema.len(),
+            "outputBytes": output_bytes,
+            "typeCount": counts.type_count,
+            "fieldCount": counts.field_count,
+            "directiveCount": counts.directive_count,
+            "operationCount": counts.operation_count,
+            "samplesMs": samples_ms,
+            "minMs": summary.min,
+            "medianMs": summary.median,
+            "meanMs": summary.mean,
+            "maxMs": summary.max
+        }));
+    }
+
+    let _ = fs::remove_dir_all(&bench_root);
+
+    let report = serde_json::json!({
+        "apiVersion": "wesley.ir-benchmark/v1",
+        "advisory": true,
+        "gitHead": git_output(&["rev-parse", "HEAD"]).unwrap_or_else(|_| "unknown".to_string()),
+        "command": "cargo xtask bench-ir",
+        "lowerer": display_path(&root, &wesley_bin),
+        "warmups": options.warmups,
+        "iterations": options.iterations,
+        "memory": {
+            "peakRss": "not-captured"
+        },
+        "fixtures": fixture_reports
+    });
+
+    if let Some(output_path) = &options.output {
+        if let Some(parent) = output_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|source| {
+                Error::Usage(format!(
+                    "failed to create benchmark output dir `{}`: {source}",
+                    parent.display()
+                ))
+            })?;
+        }
+        fs::write(output_path, serde_json::to_vec_pretty(&report).unwrap()).map_err(|source| {
+            Error::Usage(format!(
+                "failed to write benchmark report `{}`: {source}",
+                output_path.display()
+            ))
+        })?;
+    }
+
+    if options.json {
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+    } else {
+        print_bench_ir_summary(&report);
+        if let Some(output_path) = &options.output {
+            println!("report: {}", output_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn build_wesley_for_bench(json_output: bool) -> Result<(), Error> {
+    if json_output {
+        run_command_no_label("cargo", &["build", "--quiet", "--bin", "wesley"])
+    } else {
+        run_command("cargo", &["build", "--bin", "wesley"])
+    }
+}
+
+fn run_wesley_schema_lower(wesley_bin: &Path, schema_path: &Path) -> Result<Vec<u8>, Error> {
+    let output = Command::new(wesley_bin)
+        .args(["schema", "lower", "--schema"])
+        .arg(schema_path)
+        .arg("--json")
+        .output()
+        .map_err(|source| {
+            Error::Usage(format!(
+                "failed to spawn `{}` schema lower: {source}",
+                wesley_bin.display()
+            ))
+        })?;
+
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(Error::Usage(format!(
+            "benchmark lower failed for `{}`\nstderr:\n{}",
+            schema_path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+fn print_bench_ir_summary(report: &serde_json::Value) {
+    println!("Wesley IR benchmark advisory report");
+    println!(
+        "apiVersion: {}",
+        report["apiVersion"].as_str().unwrap_or("")
+    );
+    println!("memory.peakRss: not-captured");
+    println!();
+    println!(
+        "{:<28} {:>7} {:>7} {:>7} {:>7} {:>9} {:>9}",
+        "fixture", "types", "fields", "dirs", "ops", "median", "output"
+    );
+    for fixture in report["fixtures"].as_array().into_iter().flatten() {
+        println!(
+            "{:<28} {:>7} {:>7} {:>7} {:>7} {:>8.3}ms {:>9}",
+            fixture["name"].as_str().unwrap_or(""),
+            fixture["typeCount"].as_u64().unwrap_or(0),
+            fixture["fieldCount"].as_u64().unwrap_or(0),
+            fixture["directiveCount"].as_u64().unwrap_or(0),
+            fixture["operationCount"].as_u64().unwrap_or(0),
+            fixture["medianMs"].as_f64().unwrap_or(0.0),
+            fixture["outputBytes"].as_u64().unwrap_or(0)
+        );
+    }
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn sample_summary(samples: &[f64]) -> SampleSummary {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let sum: f64 = sorted.iter().sum();
+    let median = match sorted.len() {
+        0 => 0.0,
+        len if len % 2 == 1 => sorted[len / 2],
+        len => (sorted[(len / 2) - 1] + sorted[len / 2]) / 2.0,
+    };
+    SampleSummary {
+        min: sorted.first().copied().unwrap_or(0.0),
+        median,
+        mean: if sorted.is_empty() {
+            0.0
+        } else {
+            sum / sorted.len() as f64
+        },
+        max: sorted.last().copied().unwrap_or(0.0),
+    }
+}
+
+fn ir_metric_counts(ir: &serde_json::Value) -> IrMetricCounts {
+    let mut counts = IrMetricCounts::default();
+    let Some(types) = ir.get("types").and_then(serde_json::Value::as_array) else {
+        return counts;
+    };
+
+    counts.type_count = types.len();
+    for type_def in types {
+        counts.directive_count += directive_count(type_def);
+        let fields = type_def
+            .get("fields")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        counts.field_count += fields.len();
+
+        let type_name = type_def
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if matches!(type_name, "Query" | "Mutation" | "Subscription") {
+            counts.operation_count += fields.len();
+        }
+
+        for field in fields {
+            counts.directive_count += directive_count(field);
+            for argument in field
+                .get("arguments")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or(&[])
+            {
+                counts.directive_count += directive_count(argument);
+            }
+        }
+    }
+
+    counts
+}
+
+fn directive_count(value: &serde_json::Value) -> usize {
+    value
+        .get("directives")
+        .and_then(serde_json::Value::as_object)
+        .map(|directives| {
+            directives
+                .values()
+                .map(|directive| directive.as_array().map(Vec::len).unwrap_or(1))
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+fn bench_ir_fixtures() -> Vec<BenchIrFixture> {
+    vec![
+        BenchIrFixture {
+            name: "wide-schema",
+            schema: wide_schema_fixture(),
+        },
+        BenchIrFixture {
+            name: "deep-input-schema",
+            schema: deep_input_schema_fixture(),
+        },
+        BenchIrFixture {
+            name: "directive-heavy-schema",
+            schema: directive_heavy_schema_fixture(),
+        },
+        BenchIrFixture {
+            name: "operation-heavy-schema",
+            schema: operation_heavy_schema_fixture(),
+        },
+        BenchIrFixture {
+            name: "extension-folding-schema",
+            schema: extension_folding_schema_fixture(),
+        },
+    ]
+}
+
+fn wide_schema_fixture() -> String {
+    let mut sdl = String::new();
+    sdl.push_str("type Query {\n");
+    for index in 0..75 {
+        sdl.push_str(&format!("  item{index}(id: ID!): Item{index}\n"));
+    }
+    sdl.push_str("}\n\n");
+    for index in 0..75 {
+        sdl.push_str(&format!("type Item{index} {{\n"));
+        sdl.push_str("  id: ID!\n");
+        for field in 0..8 {
+            sdl.push_str(&format!("  field{field}: String\n"));
+        }
+        sdl.push_str("}\n\n");
+    }
+    sdl
+}
+
+fn deep_input_schema_fixture() -> String {
+    let mut sdl = String::from("type Query {\n  search(input: Input0): String\n}\n\n");
+    for index in 0..32 {
+        sdl.push_str(&format!("input Input{index} {{\n"));
+        sdl.push_str("  value: String\n");
+        if index < 31 {
+            sdl.push_str(&format!("  next: Input{}\n", index + 1));
+        }
+        sdl.push_str("}\n\n");
+    }
+    sdl
+}
+
+fn directive_heavy_schema_fixture() -> String {
+    let mut sdl = String::from(
+        "directive @tag(value: String) repeatable on OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION\n\n",
+    );
+    sdl.push_str("type Query @tag(value: \"root\") {\n");
+    for index in 0..120 {
+        sdl.push_str(&format!(
+            "  field{index}(arg: String @tag(value: \"arg{index}\")): String @tag(value: \"field{index}\")\n"
+        ));
+    }
+    sdl.push_str("}\n");
+    sdl
+}
+
+fn operation_heavy_schema_fixture() -> String {
+    let mut sdl = String::from("type Query {\n");
+    for index in 0..160 {
+        sdl.push_str(&format!(
+            "  queryOp{index}(id: ID!, filter: String): String\n"
+        ));
+    }
+    sdl.push_str("}\n\n");
+    sdl.push_str("type Mutation {\n");
+    for index in 0..80 {
+        sdl.push_str(&format!("  mutationOp{index}(input: String!): Boolean!\n"));
+    }
+    sdl.push_str("}\n");
+    sdl
+}
+
+fn extension_folding_schema_fixture() -> String {
+    let mut sdl =
+        String::from("directive @tag(value: String) repeatable on OBJECT | FIELD_DEFINITION\n\n");
+    sdl.push_str("type Query {\n  thing: Thing\n}\n\n");
+    sdl.push_str("type Thing @tag(value: \"base\") {\n  id: ID!\n}\n\n");
+    for index in 0..90 {
+        sdl.push_str(&format!(
+            "extend type Thing {{\n  extField{index}: String @tag(value: \"ext{index}\")\n}}\n\n"
+        ));
+    }
+    sdl
 }
 
 fn run_release_artifact_check() -> Result<(), Error> {
@@ -2760,6 +3123,11 @@ fn run_command(program: &str, args: &[&str]) -> Result<(), Error> {
     let label = command_label(program, args);
     println!("xtask: {label}");
 
+    run_command_no_label(program, args)
+}
+
+fn run_command_no_label(program: &str, args: &[&str]) -> Result<(), Error> {
+    let label = command_label(program, args);
     let status = Command::new(program)
         .args(args)
         .status()
@@ -2792,6 +3160,7 @@ Usage:
 
 Commands:
   test              Run Rust workspace tests
+  bench-ir          Run advisory Rust-native IR lowering benchmarks
   docs-check        Run Rust-native documentation hygiene checks
   preflight         Run the strict pre-PR/release quality gate
   strict-preflight  Alias for preflight
@@ -2809,6 +3178,8 @@ Publish options:
   cargo xtask publish-alpha --execute          CI tag-only compatibility publish path
   cargo xtask package-crates --tag vX.Y.Z      Check release package file sets
   cargo xtask package-crates --version X.Y.Z   Check pre-tag release package file sets
+  cargo xtask bench-ir --iterations 5 --warmups 1 --json
+  cargo xtask bench-ir --output out/ir-benchmark.json
   cargo xtask publish-crates --tag vX.Y.Z      Print tag-derived plan and run safe dry-runs
   cargo xtask publish-crates --tag vX.Y.Z --execute  Publish in GitHub Actions only
   cargo xtask release-prep-guard --version X.Y.Z
@@ -2826,6 +3197,122 @@ struct CargoVersionSource {
     name: &'static str,
     path: &'static str,
     publish: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BenchIrOptions {
+    iterations: usize,
+    warmups: usize,
+    json: bool,
+    output: Option<PathBuf>,
+}
+
+impl BenchIrOptions {
+    fn parse(args: &[OsString]) -> Result<Self, Error> {
+        let mut options = Self {
+            iterations: 5,
+            warmups: 1,
+            json: false,
+            output: None,
+        };
+
+        let mut index = 0;
+        while index < args.len() {
+            let Some(arg) = args[index].to_str() else {
+                return Err(Error::Usage("bench-ir options must be UTF-8".to_string()));
+            };
+
+            match arg {
+                "--json" => options.json = true,
+                "--iterations" => {
+                    index += 1;
+                    let value = args
+                        .get(index)
+                        .and_then(|arg| arg.to_str())
+                        .ok_or_else(|| {
+                            Error::Usage("bench-ir --iterations requires a UTF-8 value".to_string())
+                        })?;
+                    options.iterations = parse_positive_usize("bench-ir --iterations", value)?;
+                }
+                value if value.starts_with("--iterations=") => {
+                    let value = value.trim_start_matches("--iterations=");
+                    options.iterations = parse_positive_usize("bench-ir --iterations", value)?;
+                }
+                "--warmups" => {
+                    index += 1;
+                    let value = args
+                        .get(index)
+                        .and_then(|arg| arg.to_str())
+                        .ok_or_else(|| {
+                            Error::Usage("bench-ir --warmups requires a UTF-8 value".to_string())
+                        })?;
+                    options.warmups = parse_usize("bench-ir --warmups", value)?;
+                }
+                value if value.starts_with("--warmups=") => {
+                    let value = value.trim_start_matches("--warmups=");
+                    options.warmups = parse_usize("bench-ir --warmups", value)?;
+                }
+                "--output" => {
+                    index += 1;
+                    let value = args.get(index).ok_or_else(|| {
+                        Error::Usage("bench-ir --output requires a path value".to_string())
+                    })?;
+                    options.output = Some(PathBuf::from(value));
+                }
+                value if value.starts_with("--output=") => {
+                    options.output = Some(PathBuf::from(value.trim_start_matches("--output=")));
+                }
+                "--help" | "-h" => {
+                    print_help();
+                    return Err(Error::Usage(
+                        "bench-ir help requested; see usage above".to_string(),
+                    ));
+                }
+                other => {
+                    return Err(Error::Usage(format!("unknown bench-ir option `{other}`")));
+                }
+            }
+
+            index += 1;
+        }
+
+        Ok(options)
+    }
+}
+
+struct BenchIrFixture {
+    name: &'static str,
+    schema: String,
+}
+
+#[derive(Default)]
+struct IrMetricCounts {
+    type_count: usize,
+    field_count: usize,
+    directive_count: usize,
+    operation_count: usize,
+}
+
+struct SampleSummary {
+    min: f64,
+    median: f64,
+    mean: f64,
+    max: f64,
+}
+
+fn parse_positive_usize(label: &str, value: &str) -> Result<usize, Error> {
+    let parsed = parse_usize(label, value)?;
+    if parsed == 0 {
+        Err(Error::Usage(format!("{label} must be greater than zero")))
+    } else {
+        Ok(parsed)
+    }
+}
+
+fn parse_usize(label: &str, value: &str) -> Result<usize, Error> {
+    value
+        .parse::<usize>()
+        .map_err(|source| Error::Usage(format!("{label} must be an integer: {source}")))
 }
 
 #[derive(Default)]
@@ -3054,6 +3541,127 @@ enum Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn os_args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn bench_ir_options_use_advisory_defaults() {
+        assert_eq!(
+            BenchIrOptions::parse(&[]).unwrap(),
+            BenchIrOptions {
+                iterations: 5,
+                warmups: 1,
+                json: false,
+                output: None
+            }
+        );
+    }
+
+    #[test]
+    fn bench_ir_options_parse_report_flags() {
+        let args = os_args(&[
+            "--json",
+            "--iterations=7",
+            "--warmups",
+            "0",
+            "--output",
+            "out/bench.json",
+        ]);
+
+        assert_eq!(
+            BenchIrOptions::parse(&args).unwrap(),
+            BenchIrOptions {
+                iterations: 7,
+                warmups: 0,
+                json: true,
+                output: Some(PathBuf::from("out/bench.json"))
+            }
+        );
+    }
+
+    #[test]
+    fn bench_ir_options_reject_zero_iterations() {
+        let args = os_args(&["--iterations", "0"]);
+
+        assert!(matches!(
+            BenchIrOptions::parse(&args),
+            Err(Error::Usage(message)) if message == "bench-ir --iterations must be greater than zero"
+        ));
+    }
+
+    #[test]
+    fn bench_ir_fixture_corpus_covers_scale_shapes() {
+        let fixtures = bench_ir_fixtures();
+        let names = fixtures
+            .iter()
+            .map(|fixture| fixture.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                "wide-schema",
+                "deep-input-schema",
+                "directive-heavy-schema",
+                "operation-heavy-schema",
+                "extension-folding-schema"
+            ]
+        );
+        assert!(fixtures
+            .iter()
+            .any(|fixture| fixture.schema.contains("extend type Thing")));
+        assert!(fixtures
+            .iter()
+            .any(|fixture| fixture.schema.contains("directive @tag")));
+    }
+
+    #[test]
+    fn ir_metric_counts_include_fields_directives_and_operations() {
+        let ir = serde_json::json!({
+            "types": [
+                {
+                    "name": "Query",
+                    "directives": { "tag": {} },
+                    "fields": [
+                        {
+                            "name": "user",
+                            "directives": { "cache": {} },
+                            "arguments": [
+                                { "name": "id", "directives": { "arg": {} } }
+                            ]
+                        },
+                        { "name": "search" }
+                    ]
+                },
+                {
+                    "name": "User",
+                    "directives": { "tag": [{}, {}] },
+                    "fields": [
+                        { "name": "id", "directives": { "id": {} } }
+                    ]
+                }
+            ]
+        });
+
+        let counts = ir_metric_counts(&ir);
+
+        assert_eq!(counts.type_count, 2);
+        assert_eq!(counts.field_count, 3);
+        assert_eq!(counts.directive_count, 6);
+        assert_eq!(counts.operation_count, 2);
+    }
+
+    #[test]
+    fn sample_summary_uses_true_even_sample_median() {
+        let summary = sample_summary(&[12.0, 2.0, 6.0, 4.0]);
+
+        assert_eq!(summary.min, 2.0);
+        assert_eq!(summary.median, 5.0);
+        assert_eq!(summary.mean, 6.0);
+        assert_eq!(summary.max, 12.0);
+    }
 
     #[test]
     fn official_dry_run_reports_missing_internal_dependency_as_failure() {


### PR DESCRIPTION
## Summary

- Add `cargo xtask bench-ir` as a Rust-native advisory IR lowering benchmark.
- Generate scale fixtures for wide schemas, deep input nesting, directive-heavy schemas, operation-heavy schemas, and extension folding.
- Emit table or JSON reports with structural counters, timing samples, summary timings, and explicit `memory.peakRss: "not-captured"` posture.
- Update active performance evidence docs so current guidance points at `cargo xtask bench-ir` instead of retired `pnpm perf:ir` scripts.

## Validation

- `cargo test -p xtask -- --nocapture`
- `cargo --quiet xtask bench-ir --json --iterations 1 --warmups 0`
- `cargo xtask bench-ir --iterations 1 --warmups 0 --output out/rust-ir-performance-baseline.json`
- `cargo xtask help`
- `cargo xtask docs-check`
- `pnpm run preflight`
- pre-push Rust product preflight

Closes #681