### PR TITLE
fix(core): reject duplicate nonrepeatable directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Rejected duplicate non-repeatable custom directives during SDL lowering,
+  including duplicates split across type definitions and extensions, while
+  preserving ordered arrays for directives declared `repeatable`.
 - Escaped law-backed Rust validator error messages before emission so hostile
   case values containing quotes, backslashes, or control characters cannot break
   generated Rust source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   summaries, and can write JSON release evidence.
 - Added a first-PR contributor path with docs-only, fixture-only, emitter-test,
   and CLI bug fast lanes plus maintainer starter-issue checks.
+- Added a security-tooling posture topic that records Wesley's current scanner
+  baseline, rejects DAST for the current compiler-only surface, and gates future
+  Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,9 @@ artifacts through generic emitters and external modules.
 
 - Keep dependency updates reviewable and run repository preflight before
   release.
+- Scope security scanners to Wesley's compiler and tooling surface. The current
+  baseline and candidate-gate decisions live in
+  [`docs/topics/security-tooling.md`](docs/topics/security-tooling.md).
 - Prefer deterministic inputs, injected clocks, and explicit host permissions
   for portable capability work.
 - Do not grant portable modules ambient filesystem, network, process, or clock
@@ -94,5 +97,6 @@ artifacts through generic emitters and external modules.
 - Domain-empty compiler boundary that keeps target security policy out of core
 - Hash-linked evidence and artifact review surfaces
 - Dependency and documentation preflight checks
+- Documented scanner-fit posture for advisory and static-analysis gates
 - Explicit external-module responsibility for database, runtime, and product
   security behavior

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -130,6 +130,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
     }
 
     let doc = cst.document();
+    let repeatable_directives = repeatable_directive_names_from_document(&doc)?;
     let mut root_types = RootTypes::default();
     for def in doc.definitions() {
         match def {
@@ -151,6 +152,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
                     node.name(),
                     node.fields_definition(),
                     &root_types,
+                    &repeatable_directives,
                     &mut operations,
                 )?;
             }
@@ -159,6 +161,7 @@ pub fn list_schema_operations_sdl(schema_sdl: &str) -> Result<Vec<SchemaOperatio
                     node.name(),
                     node.fields_definition(),
                     &root_types,
+                    &repeatable_directives,
                     &mut operations,
                 )?;
             }
@@ -175,6 +178,15 @@ struct TypeAggregate {
     kind: TypeKind,
     definitions: Vec<TypeDefinitionNode>,
     extensions: Vec<TypeExtensionNode>,
+}
+
+#[derive(Default)]
+struct TypeBuildAccumulator {
+    directives: IndexMap<String, serde_json::Value>,
+    implements: Vec<String>,
+    fields: Vec<Field>,
+    enum_values: Vec<String>,
+    union_members: Vec<String>,
 }
 
 enum TypeDefinitionNode {
@@ -244,6 +256,7 @@ impl ApolloLoweringAdapter {
         }
 
         let doc = cst.document();
+        let repeatable_directives = repeatable_directive_names_from_document(&doc)?;
         let mut aggregates: BTreeMap<String, TypeAggregate> = BTreeMap::new();
 
         for def in doc.definitions() {
@@ -314,7 +327,7 @@ impl ApolloLoweringAdapter {
 
         let mut types = Vec::new();
         for agg in aggregates.values() {
-            types.push(self.build_type_from_aggregate(agg)?);
+            types.push(self.build_type_from_aggregate(agg, &repeatable_directives)?);
         }
 
         Ok(WesleyIR {
@@ -351,110 +364,114 @@ impl ApolloLoweringAdapter {
     fn build_type_from_aggregate(
         &self,
         agg: &TypeAggregate,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<TypeDefinition, WesleyError> {
-        let mut directives = IndexMap::new();
-        let mut implements = Vec::new();
-        let mut fields = Vec::new();
-        let mut enum_values = Vec::new();
-        let mut union_members = Vec::new();
+        let mut acc = TypeBuildAccumulator::default();
         let mut description = None;
 
         for def in &agg.definitions {
             if description.is_none() {
                 description = description_from(def.description());
             }
-            self.merge_definition(
-                def,
-                &mut directives,
-                &mut implements,
-                &mut fields,
-                &mut enum_values,
-                &mut union_members,
-            )?;
+            self.merge_definition(def, &mut acc, repeatable_directives)?;
         }
 
         for ext in &agg.extensions {
-            self.merge_extension(
-                ext,
-                &mut directives,
-                &mut implements,
-                &mut fields,
-                &mut enum_values,
-                &mut union_members,
-            )?;
+            self.merge_extension(ext, &mut acc, repeatable_directives)?;
         }
 
         Ok(TypeDefinition {
             name: agg.name.clone(),
             kind: agg.kind,
             description,
-            directives,
-            implements,
-            fields,
-            enum_values,
-            union_members,
+            directives: acc.directives,
+            implements: acc.implements,
+            fields: acc.fields,
+            enum_values: acc.enum_values,
+            union_members: acc.union_members,
         })
     }
 
     fn merge_definition(
         &self,
         def: &TypeDefinitionNode,
-        directives: &mut IndexMap<String, serde_json::Value>,
-        implements: &mut Vec<String>,
-        fields: &mut Vec<Field>,
-        enum_values: &mut Vec<String>,
-        union_members: &mut Vec<String>,
+        acc: &mut TypeBuildAccumulator,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         match def {
             TypeDefinitionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
             }
             TypeDefinitionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeDefinitionNode::Interface(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeDefinitionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(member_types) = node.union_member_types() {
-                    collect_union_members(member_types, union_members)?;
+                    collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeDefinitionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(values_def) = node.enum_values_definition() {
-                    collect_enum_values(values_def, enum_values)?;
+                    collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeDefinitionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.input_fields_definition() {
-                    self.collect_input_fields(fields_def, fields)?;
+                    self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
         }
@@ -465,62 +482,83 @@ impl ApolloLoweringAdapter {
     fn merge_extension(
         &self,
         ext: &TypeExtensionNode,
-        directives: &mut IndexMap<String, serde_json::Value>,
-        implements: &mut Vec<String>,
-        fields: &mut Vec<Field>,
-        enum_values: &mut Vec<String>,
-        union_members: &mut Vec<String>,
+        acc: &mut TypeBuildAccumulator,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         match ext {
             TypeExtensionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
             }
             TypeExtensionNode::Object(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeExtensionNode::Interface(node) => {
                 if let Some(interfaces) = node.implements_interfaces() {
-                    collect_implements(interfaces, implements)?;
+                    collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.fields_definition() {
-                    self.collect_fields(fields_def, fields)?;
+                    self.collect_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
             TypeExtensionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(member_types) = node.union_member_types() {
-                    collect_union_members(member_types, union_members)?;
+                    collect_union_members(member_types, &mut acc.union_members)?;
                 }
             }
             TypeExtensionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(values_def) = node.enum_values_definition() {
-                    collect_enum_values(values_def, enum_values)?;
+                    collect_enum_values(values_def, &mut acc.enum_values)?;
                 }
             }
             TypeExtensionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives(dirs, directives)?;
+                    self.extract_directives_with_repeatability(
+                        dirs,
+                        &mut acc.directives,
+                        repeatable_directives,
+                    )?;
                 }
                 if let Some(fields_def) = node.input_fields_definition() {
-                    self.collect_input_fields(fields_def, fields)?;
+                    self.collect_input_fields(fields_def, &mut acc.fields, repeatable_directives)?;
                 }
             }
         }
@@ -528,10 +566,11 @@ impl ApolloLoweringAdapter {
         Ok(())
     }
 
-    fn extract_directives(
+    fn extract_directives_with_repeatability(
         &self,
         dirs: cst::Directives,
         map: &mut IndexMap<String, serde_json::Value>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for dir in dirs.directives() {
             let dir_name = dir
@@ -568,7 +607,8 @@ impl ApolloLoweringAdapter {
                 ));
             }
 
-            insert_directive_value(map, canonical_name, val);
+            let repeatable = core_name.is_none() && repeatable_directives.contains(&canonical_name);
+            insert_directive_value(map, canonical_name, val, repeatable)?;
         }
         Ok(())
     }
@@ -577,9 +617,10 @@ impl ApolloLoweringAdapter {
         &self,
         fields_def: cst::FieldsDefinition,
         fields: &mut Vec<Field>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for field_def in fields_def.field_definitions() {
-            fields.push(self.build_field(field_def)?);
+            fields.push(self.build_field(field_def, repeatable_directives)?);
         }
 
         Ok(())
@@ -589,15 +630,20 @@ impl ApolloLoweringAdapter {
         &self,
         fields_def: cst::InputFieldsDefinition,
         fields: &mut Vec<Field>,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<(), WesleyError> {
         for field_def in fields_def.input_value_definitions() {
-            fields.push(self.build_input_field(field_def)?);
+            fields.push(self.build_input_field(field_def, repeatable_directives)?);
         }
 
         Ok(())
     }
 
-    fn build_field(&self, field_def: cst::FieldDefinition) -> Result<Field, WesleyError> {
+    fn build_field(
+        &self,
+        field_def: cst::FieldDefinition,
+        repeatable_directives: &BTreeSet<String>,
+    ) -> Result<Field, WesleyError> {
         let name = field_def
             .name()
             .ok_or(WesleyError::LoweringError {
@@ -614,13 +660,20 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives(dirs, &mut field_directives)?;
+            self.extract_directives_with_repeatability(
+                dirs,
+                &mut field_directives,
+                repeatable_directives,
+            )?;
         }
 
         Ok(Field {
             name,
             r#type: self.build_type_reference(type_node)?,
-            arguments: field_arguments_from_definition(field_def.arguments_definition())?,
+            arguments: field_arguments_from_definition(
+                field_def.arguments_definition(),
+                repeatable_directives,
+            )?,
             default_value: None,
             directives: field_directives,
             description: description_from(field_def.description()),
@@ -630,6 +683,7 @@ impl ApolloLoweringAdapter {
     fn build_input_field(
         &self,
         field_def: cst::InputValueDefinition,
+        repeatable_directives: &BTreeSet<String>,
     ) -> Result<Field, WesleyError> {
         let name = field_def
             .name()
@@ -647,7 +701,11 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives(dirs, &mut field_directives)?;
+            self.extract_directives_with_repeatability(
+                dirs,
+                &mut field_directives,
+                repeatable_directives,
+            )?;
         }
         let default_value = field_def
             .default_value()
@@ -869,6 +927,7 @@ fn type_reference_shape_from_type(
 
 fn field_arguments_from_definition(
     arguments_definition: Option<cst::ArgumentsDefinition>,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<Vec<FieldArgument>, WesleyError> {
     let Some(arguments_definition) = arguments_definition else {
         return Ok(Vec::new());
@@ -876,12 +935,13 @@ fn field_arguments_from_definition(
 
     arguments_definition
         .input_value_definitions()
-        .map(field_argument_from_input_value)
+        .map(|input_value| field_argument_from_input_value(input_value, repeatable_directives))
         .collect()
 }
 
 fn field_argument_from_input_value(
     input_value: cst::InputValueDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<FieldArgument, WesleyError> {
     let name = input_value
         .name()
@@ -903,7 +963,11 @@ fn field_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(FieldArgument {
@@ -1056,12 +1120,46 @@ fn canonical_core_directive_name(name: &str) -> Option<&str> {
     }
 }
 
+fn repeatable_directive_names_from_document(
+    doc: &cst::Document,
+) -> Result<BTreeSet<String>, WesleyError> {
+    let mut repeatable = BTreeSet::new();
+    for definition in doc.definitions() {
+        let cst::Definition::DirectiveDefinition(directive) = definition else {
+            continue;
+        };
+        if directive.repeatable_token().is_none() {
+            continue;
+        }
+
+        let name = directive
+            .name()
+            .map(|name| name.text().to_string())
+            .ok_or_else(|| {
+                lowering_error_value("directive", "Directive definition missing name".to_string())
+            })?;
+        let canonical_name = canonical_core_directive_name(&name)
+            .unwrap_or(name.as_str())
+            .to_string();
+        repeatable.insert(canonical_name);
+    }
+
+    Ok(repeatable)
+}
+
 fn insert_directive_value(
     map: &mut IndexMap<String, serde_json::Value>,
     name: String,
     value: serde_json::Value,
-) {
+    repeatable: bool,
+) -> Result<(), WesleyError> {
     match map.get_mut(&name) {
+        Some(_) if !repeatable => {
+            return Err(lowering_error_value(
+                "directive",
+                format!("Duplicate non-repeatable directive '@{name}'"),
+            ));
+        }
         Some(serde_json::Value::Array(values)) => values.push(value),
         Some(existing) => {
             let first = std::mem::take(existing);
@@ -1071,6 +1169,8 @@ fn insert_directive_value(
             map.insert(name, value);
         }
     }
+
+    Ok(())
 }
 
 /// Resolves response-path field selections from a single GraphQL operation.
@@ -3468,6 +3568,7 @@ fn collect_schema_operations_from_object(
     name: Option<cst::Name>,
     fields_definition: Option<cst::FieldsDefinition>,
     root_types: &RootTypes,
+    repeatable_directives: &BTreeSet<String>,
     operations: &mut Vec<SchemaOperation>,
 ) -> Result<(), WesleyError> {
     let type_name = type_node_name(name, "Object type missing name")?;
@@ -3486,6 +3587,7 @@ fn collect_schema_operations_from_object(
                 *operation_type,
                 &type_name,
                 field_def.clone(),
+                repeatable_directives,
             )?);
         }
     }
@@ -3497,6 +3599,7 @@ fn schema_operation_from_field(
     operation_type: OperationType,
     root_type_name: &str,
     field_def: cst::FieldDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<SchemaOperation, WesleyError> {
     let field_name = field_def
         .name()
@@ -3513,14 +3616,21 @@ fn schema_operation_from_field(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = field_def.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(SchemaOperation {
         operation_type,
         root_type_name: root_type_name.to_string(),
         field_name,
-        arguments: operation_arguments_from_definition(field_def.arguments_definition())?,
+        arguments: operation_arguments_from_definition(
+            field_def.arguments_definition(),
+            repeatable_directives,
+        )?,
         result_type: type_reference_from_type(result_type, true)?,
         directives,
     })
@@ -3528,6 +3638,7 @@ fn schema_operation_from_field(
 
 fn operation_arguments_from_definition(
     arguments_definition: Option<cst::ArgumentsDefinition>,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<Vec<OperationArgument>, WesleyError> {
     let Some(arguments_definition) = arguments_definition else {
         return Ok(Vec::new());
@@ -3535,12 +3646,13 @@ fn operation_arguments_from_definition(
 
     arguments_definition
         .input_value_definitions()
-        .map(operation_argument_from_input_value)
+        .map(|input_value| operation_argument_from_input_value(input_value, repeatable_directives))
         .collect()
 }
 
 fn operation_argument_from_input_value(
     input_value: cst::InputValueDefinition,
+    repeatable_directives: &BTreeSet<String>,
 ) -> Result<OperationArgument, WesleyError> {
     let name = input_value
         .name()
@@ -3562,7 +3674,11 @@ fn operation_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives(dirs, &mut directives)?;
+        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+            dirs,
+            &mut directives,
+            repeatable_directives,
+        )?;
     }
 
     Ok(OperationArgument {

--- a/crates/wesley-core/src/adapters/apollo.rs
+++ b/crates/wesley-core/src/adapters/apollo.rs
@@ -401,7 +401,7 @@ impl ApolloLoweringAdapter {
         match def {
             TypeDefinitionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -413,7 +413,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -428,7 +428,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -440,7 +440,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -452,7 +452,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -464,7 +464,7 @@ impl ApolloLoweringAdapter {
             }
             TypeDefinitionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -488,7 +488,7 @@ impl ApolloLoweringAdapter {
         match ext {
             TypeExtensionNode::Scalar(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -500,7 +500,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -515,7 +515,7 @@ impl ApolloLoweringAdapter {
                     collect_implements(interfaces, &mut acc.implements)?;
                 }
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -527,7 +527,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::Union(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -539,7 +539,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::Enum(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -551,7 +551,7 @@ impl ApolloLoweringAdapter {
             }
             TypeExtensionNode::InputObject(node) => {
                 if let Some(dirs) = node.directives() {
-                    self.extract_directives_with_repeatability(
+                    Self::extract_directives_with_repeatability(
                         dirs,
                         &mut acc.directives,
                         repeatable_directives,
@@ -567,7 +567,6 @@ impl ApolloLoweringAdapter {
     }
 
     fn extract_directives_with_repeatability(
-        &self,
         dirs: cst::Directives,
         map: &mut IndexMap<String, serde_json::Value>,
         repeatable_directives: &BTreeSet<String>,
@@ -660,7 +659,7 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives_with_repeatability(
+            Self::extract_directives_with_repeatability(
                 dirs,
                 &mut field_directives,
                 repeatable_directives,
@@ -701,7 +700,7 @@ impl ApolloLoweringAdapter {
 
         let mut field_directives = IndexMap::new();
         if let Some(dirs) = field_def.directives() {
-            self.extract_directives_with_repeatability(
+            Self::extract_directives_with_repeatability(
                 dirs,
                 &mut field_directives,
                 repeatable_directives,
@@ -963,7 +962,7 @@ fn field_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,
@@ -3616,7 +3615,7 @@ fn schema_operation_from_field(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = field_def.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,
@@ -3674,7 +3673,7 @@ fn operation_argument_from_input_value(
 
     let mut directives = IndexMap::new();
     if let Some(dirs) = input_value.directives() {
-        ApolloLoweringAdapter::new(0).extract_directives_with_repeatability(
+        ApolloLoweringAdapter::extract_directives_with_repeatability(
             dirs,
             &mut directives,
             repeatable_directives,

--- a/crates/wesley-core/tests/lowering_validation.rs
+++ b/crates/wesley-core/tests/lowering_validation.rs
@@ -290,6 +290,143 @@ async fn preserves_repeated_custom_directives_as_ordered_values() {
 }
 
 #[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_on_same_location() {
+    let sdl = r#"
+        directive @tag(name: String!) on FIELD_DEFINITION
+
+        type Thing {
+          name: String @tag(name: "alpha") @tag(name: "beta")
+        }
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("non-repeatable custom directive duplicates should fail");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_across_base_and_extension() {
+    let sdl = r#"
+        directive @tag(name: String!) on OBJECT
+
+        type Thing @tag(name: "base") {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "extension")
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("base and extension non-repeatable custom directives should collide");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_non_repeatable_custom_directives_across_extensions() {
+    let sdl = r#"
+        directive @tag(name: String!) on OBJECT
+
+        type Thing {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "first")
+        extend type Thing @tag(name: "second")
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("extension non-repeatable custom directives should collide");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@tag'"
+    );
+}
+
+#[tokio::test]
+async fn preserves_repeatable_custom_directives_across_extensions() {
+    let sdl = r#"
+        directive @tag(name: String!) repeatable on OBJECT
+
+        type Thing @tag(name: "base") {
+          id: ID!
+        }
+
+        extend type Thing @tag(name: "first")
+        extend type Thing @tag(name: "second")
+    "#;
+
+    let adapter = create_adapter();
+    let ir = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect("repeatable custom directives should accumulate across extensions");
+    let thing = find_type(&ir.types, "Thing");
+    let tag_values = thing.directives["tag"]
+        .as_array()
+        .expect("repeatable type directives should be preserved as an array");
+
+    assert_eq!(tag_values.len(), 3);
+    assert_eq!(
+        tag_values[0]["name"],
+        serde_json::Value::String("base".into())
+    );
+    assert_eq!(
+        tag_values[1]["name"],
+        serde_json::Value::String("first".into())
+    );
+    assert_eq!(
+        tag_values[2]["name"],
+        serde_json::Value::String("second".into())
+    );
+}
+
+#[tokio::test]
+async fn rejects_duplicate_undefined_custom_directives() {
+    let sdl = r#"
+        type Thing {
+          name: String @externalTag(name: "alpha") @externalTag(name: "beta")
+        }
+    "#;
+
+    let adapter = create_adapter();
+    let err = adapter
+        .lower_sdl(sdl)
+        .await
+        .expect_err("undefined custom directive duplicates should not become arrays");
+    let diagnostic = err.diagnostic();
+
+    assert_eq!(diagnostic.code, "WESLEY_LOWERING_ERROR");
+    assert_eq!(
+        diagnostic.message,
+        "Duplicate non-repeatable directive '@externalTag'"
+    );
+}
+
+#[tokio::test]
 async fn lowers_graphql_type_families_into_l1_ir() {
     let sdl = r#"
         scalar DateTime @specifiedBy(url: "https://example.com/datetime")

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -43,11 +43,11 @@ lowering, hashing, diffing, and emitter flows.
 Directive values in L1 IR follow GraphQL repeatability:
 
 - non-repeatable directives lower to a single directive value
-- duplicate non-repeatable directives fail lowering, including duplicates split
-  across a base definition and extensions
+- custom directives are non-repeatable unless their SDL directive definition
+  is marked `repeatable`
+- duplicate non-repeatable directives fail lowering across base definitions
+  and any extensions, including extension-to-extension collisions
 - directives declared with `repeatable` lower to ordered arrays when repeated
-- unknown custom directives are treated as non-repeatable unless the SDL
-  declares them `repeatable`
 
 Canonical Wesley directive aliases, such as `@table` and `@wes_table`, still
 collide as their canonical `@wes_*` directive and are rejected when repeated.

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -27,16 +27,30 @@ directives by what that path truly parses and lowers today.
 These directives are the stable SDL surface for the current Rust-native schema
 lowering, hashing, diffing, and emitter flows.
 
-| Directive                      | Status    | Current lowering                            | Aliases accepted by current parser | Notes                                                                                                                  |
-| ------------------------------ | --------- | ------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `@wes_table`                   | `current` | Admits an object type to structured IR      | `@wesley_table`, `@table`          | Historical name; downstream modules decide whether that structure becomes SQL, models, validators, or something else. |
-| `@wes_pk`                      | `current` | Marks the primary identity field            | `@wesley_pk`, `@pk`, `@primaryKey` | Current lowering enforces at most one primary identity field and requires it to be non-null.                           |
-| `@wes_fk(ref: "Type.field")`   | `current` | Lowers structured reference metadata        | `@wesley_fk`, `@fk`, `@foreignKey` | Main path validates the `Type.field` format and target existence.                                                      |
-| `@wes_unique`                  | `current` | Lowers a uniqueness marker                  | `@wesley_unique`, `@unique`        | Preserved in IR for downstream emitters and external targets.                                                          |
-| `@wes_index`                   | `current` | Lowers an index marker                      | `@wesley_index`, `@index`          | Field-level indexing metadata is current; target-specific index semantics are downstream-owned.                        |
-| `@wes_tenant(by: "...")`       | `current` | Lowers tenant metadata on the object        | `@wesley_tenant`, `@tenant`        | The `by` field must exist on the same type.                                                                            |
-| `@wes_default(value: "...")`   | `current` | Lowers a default expression/value marker    | `@wesley_default`, `@default`      | Canonical argument is `value`; the parser still accepts legacy `expr` on the hot path.                                 |
-| `@wes_rls`                     | `current` | Preserves an RLS marker                     | `@wesley_rls`, `@rls`              | Treat this as a marker today; full policy semantics belong to downstream modules.                                      |
+| Directive                    | Status    | Current lowering                         | Aliases accepted by current parser | Notes                                                                                                                 |
+| ---------------------------- | --------- | ---------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `@wes_table`                 | `current` | Admits an object type to structured IR   | `@wesley_table`, `@table`          | Historical name; downstream modules decide whether that structure becomes SQL, models, validators, or something else. |
+| `@wes_pk`                    | `current` | Marks the primary identity field         | `@wesley_pk`, `@pk`, `@primaryKey` | Current lowering enforces at most one primary identity field and requires it to be non-null.                          |
+| `@wes_fk(ref: "Type.field")` | `current` | Lowers structured reference metadata     | `@wesley_fk`, `@fk`, `@foreignKey` | Main path validates the `Type.field` format and target existence.                                                     |
+| `@wes_unique`                | `current` | Lowers a uniqueness marker               | `@wesley_unique`, `@unique`        | Preserved in IR for downstream emitters and external targets.                                                         |
+| `@wes_index`                 | `current` | Lowers an index marker                   | `@wesley_index`, `@index`          | Field-level indexing metadata is current; target-specific index semantics are downstream-owned.                       |
+| `@wes_tenant(by: "...")`     | `current` | Lowers tenant metadata on the object     | `@wesley_tenant`, `@tenant`        | The `by` field must exist on the same type.                                                                           |
+| `@wes_default(value: "...")` | `current` | Lowers a default expression/value marker | `@wesley_default`, `@default`      | Canonical argument is `value`; the parser still accepts legacy `expr` on the hot path.                                |
+| `@wes_rls`                   | `current` | Preserves an RLS marker                  | `@wesley_rls`, `@rls`              | Treat this as a marker today; full policy semantics belong to downstream modules.                                     |
+
+### IR Encoding Rule
+
+Directive values in L1 IR follow GraphQL repeatability:
+
+- non-repeatable directives lower to a single directive value
+- duplicate non-repeatable directives fail lowering, including duplicates split
+  across a base definition and extensions
+- directives declared with `repeatable` lower to ordered arrays when repeated
+- unknown custom directives are treated as non-repeatable unless the SDL
+  declares them `repeatable`
+
+Canonical Wesley directive aliases, such as `@table` and `@wes_table`, still
+collide as their canonical `@wes_*` directive and are rejected when repeated.
 
 ### Composition Directives
 
@@ -71,8 +85,8 @@ ships a public `compile-ttd` command or old core TTD package export.
 | Directive family                                                                                     | Status     | Current surface                                                                                                                                    |
 | ---------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@wes_channel`, `@wes_op`, `@wes_rule`, `@wes_invariant`                                             | `external` | Declared in `continuum/wesley/ttd/schemas/ttd-directives.graphql` and parsed by `continuum/wesley/ttd/directives.mjs`, not by generic Wesley core. |
-| `@wes_emission`, `@wes_footprint`, `@wes_requires`, `@wes_produces`, `@wes_emitsTo`, `@wes_mustEmit` | `external` | Current in the relocated Continuum TTD extraction/manifest path, not in generic Wesley.                                            |
-| `@wes_codec`, `@wes_version`                                                                         | `external` | Current for relocated Continuum TTD/type-registry compilation paths and related manifests, not for generic Wesley.                 |
+| `@wes_emission`, `@wes_footprint`, `@wes_requires`, `@wes_produces`, `@wes_emitsTo`, `@wes_mustEmit` | `external` | Current in the relocated Continuum TTD extraction/manifest path, not in generic Wesley.                                                            |
+| `@wes_codec`, `@wes_version`                                                                         | `external` | Current for relocated Continuum TTD/type-registry compilation paths and related manifests, not for generic Wesley.                                 |
 
 ## Deferred Or Unstable Surface
 

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -39,6 +39,7 @@ short path to the authoritative surface.
 | ------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Choose local checks before a PR or release. | [Validation](./validation.md)                 | `cargo xtask preflight`, `docs/governance/RELEASE_POLICY.md`                       |
 | Interpret GitHub Actions checks.            | [CI Workflows](./ci-workflows.md)             | `docs/ci.md`, `.github/workflows/`                                                 |
+| Evaluate security scanners and gates.       | [Security Tooling](./security-tooling.md)     | `SECURITY.md`, `.github/workflows/`, `docs/governance/RELEASE_POLICY.md`           |
 | Understand HOLMES CI and PR comments.       | [HOLMES CI](./holmes-ci.md)                   | `.github/workflows/wesley-holmes.yml`, `docs/architecture/`                        |
 | Work with assurance evidence and policies.  | [Assurance Evidence](./assurance-evidence.md) | `docs/reference/assurance-capability-matrix.md`, `docs/holmes-policy-spec.md`      |
 | Prepare or judge a release.                 | [Releases](./releases.md)                     | `.continuum/release.yml`, `docs/method/release.md`, `docs/governance/`             |

--- a/docs/topics/ci-workflows.md
+++ b/docs/topics/ci-workflows.md
@@ -17,6 +17,7 @@ diff or running focused checks before a PR.
 | Compatibility smoke          | Workspace compatibility and Rust product smoke.    |
 | CodeQL / analysis            | Static analysis for supported languages.           |
 | Dependency review            | Dependency risk in PRs.                            |
+| Security posture             | Advisory gates, scanner fit, and false positives.  |
 | HOLMES workflow              | Schema-selected assurance reports and PR comments. |
 | SHIPME certificate           | Post-merge evidence for the landed `main` SHA.     |
 
@@ -54,6 +55,7 @@ BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 ## Related Authority
 
 - [Continuous Integration](../ci.md)
+- [Security Tooling](./security-tooling.md)
 - [HOLMES CI](./holmes-ci.md)
 - [Validation](./validation.md)
 - [Release Workflow](./releases.md)

--- a/docs/topics/security-tooling.md
+++ b/docs/topics/security-tooling.md
@@ -1,0 +1,84 @@
+# Security Tooling
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Use this topic when evaluating a security scanner, advisory gate, or workflow
+hardening change for Wesley.
+
+Wesley is currently a compiler and tooling repository. It does not ship a hosted
+HTTP service, browser application, database runtime, or long-lived daemon. The
+security tooling posture therefore focuses on the compiler surface:
+
+- dependency and supply-chain advisories,
+- generated-source safety,
+- artifact and path handling,
+- GitHub Actions permissions and egress visibility,
+- domain-empty boundary regressions.
+
+Security tooling in this repo should not claim that Wesley has proved
+downstream runtime, database, product, or target-module security semantics.
+Those claims belong to the owning target module or sibling repository.
+
+## Current Baseline
+
+| Surface                                   | Current Gate                                                                                                 | Status                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| JavaScript and TypeScript static analysis | `.github/workflows/codeql.yml` runs CodeQL with `security-and-quality` queries.                              | Active on `main`, PRs into `main`, and weekly schedule.                    |
+| Pull-request dependency changes           | `.github/workflows/dependency-review.yml` runs Dependency Review.                                            | Active on PRs into `main`; fails on high severity.                         |
+| Repository supply-chain posture           | `.github/workflows/scorecards.yml` runs OpenSSF Scorecard and uploads SARIF.                                 | Active on `main`, weekly schedule, and manual dispatch.                    |
+| Workflow egress visibility                | GitHub Actions jobs use `step-security/harden-runner` in audit mode.                                         | Active as visibility, not a blocking egress policy.                        |
+| JavaScript advisory audit                 | `cargo xtask preflight` runs `pnpm audit --prod=false --json`.                                               | Active in the strict local gate.                                           |
+| Rust advisory audit                       | `cargo xtask release-guard` and release workflows run `cargo audit`.                                         | Active for release readiness and publication.                              |
+| Rust product quality                      | `cargo xtask preflight` runs formatting, Clippy, workspace tests, docs checks, and a native CLI smoke test.  | Active in the strict local gate.                                           |
+| Domain-empty regression checks            | `test/domain-empty-boundary.bats` guards core source vocabulary.                                             | Active in repository validation.                                           |
+| Emitter source-safety regressions         | Emitter tests parse or compile generated output and include source-level guards where a printer rule exists. | Active for covered emitters and expected to grow with risky printer paths. |
+
+## Evaluation Matrix
+
+| Candidate                     | Decision                           | Rationale                                                                                                                                                                                                                             |
+| ----------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OWASP ZAP or other DAST       | Do not add now.                    | Wesley has no hosted runtime surface to crawl. Add DAST only if a future Wesley-owned web/API surface ships in this repo.                                                                                                             |
+| Semgrep with broad auto rules | Do not add as a blocking gate now. | Broad rule packs are likely to create high review cost for a compiler repo. Prefer repo-owned rules with focused fixtures.                                                                                                            |
+| Repo-specific Semgrep rules   | Candidate.                         | Useful fits are unsafe source interpolation in emitters, path traversal in artifact readers, and accidental domain semantics in core. Each rule needs a local reproducer and a documented false-positive policy before it blocks PRs. |
+| `cargo-deny`                  | Candidate.                         | Useful for license, advisory, duplicate, and ban policy once `deny.toml` exists and ownership is clear. Start advisory or scheduled before making it required.                                                                        |
+| Harden-runner blocking egress | Defer.                             | Audit mode provides evidence today. Blocking egress should wait until the workflow egress inventory is stable enough that normal release work is not noisy.                                                                           |
+
+## Gate Admission Rules
+
+A new security gate belongs in Wesley only when all of these are true:
+
+1. It protects a Wesley-owned compiler, CLI, artifact, docs, CI, or release
+   surface.
+2. It has a local command or focused fixture so contributors can reproduce the
+   failure without guessing at GitHub Actions state.
+3. It has a clear owner and a documented exception format.
+4. It does not duplicate an existing gate without adding a distinct signal.
+5. It starts as advisory or scheduled when the false-positive rate is unknown.
+6. It documents what the gate proves and what it does not prove.
+
+When a gate fails because of an advisory that is not exploitable in Wesley's
+actual product surface, document the package path, exposure analysis, temporary
+mitigation, and expiration or revisit date.
+
+## Near-Term Fits
+
+The most useful next gates are narrow and repo-specific:
+
+- emitter printer rules that catch direct interpolation of schema, law, or
+  directive strings into generated source,
+- artifact-reader rules that reject path escape regressions,
+- source-boundary rules that keep database, runtime, and product semantics out
+  of `wesley-core`,
+- an advisory `cargo-deny` policy once license and ban ownership is written
+  down.
+
+Keep DAST and hosted-application scanners out of Wesley until Wesley owns a
+hosted application surface.
+
+## Related Authority
+
+- [Security Policy](../../SECURITY.md)
+- [CI Workflows](./ci-workflows.md)
+- [Validation](./validation.md)
+- [Compiler Boundary](./compiler-boundary.md)
+- [Release Policy](../governance/RELEASE_POLICY.md)

--- a/docs/topics/validation.md
+++ b/docs/topics/validation.md
@@ -28,6 +28,7 @@ workspace tests, and a native CLI smoke test.
 | Domain-empty boundary                 | `BATS_LIB_PATH=test/vendor bats -t test/domain-empty-boundary.bats`                               |
 | HOLMES PR comments or reports         | `node --test packages/wesley-holmes/test/pr-comment.test.mjs`                                     |
 | JavaScript package or lockfile policy | `cargo xtask legacy-preflight`, `pnpm lint`                                                       |
+| Security-tooling policy or docs       | `cargo xtask docs-check`, `git diff --check`                                                      |
 
 The pre-push hook may select relevant checks, but do not use the hook as the
 only plan for a risky change. Choose checks deliberately and record the
@@ -43,4 +44,5 @@ Release validation is stricter than PR validation. Use
 
 - [`docs/governance/RELEASE_POLICY.md`](../governance/RELEASE_POLICY.md)
 - [`docs/governance/DOCUMENTATION_STANDARD.md`](../governance/DOCUMENTATION_STANDARD.md)
+- [`docs/topics/security-tooling.md`](./security-tooling.md)
 - [`docs/reference/cli.md`](../reference/cli.md)

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -217,6 +217,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/security-tooling.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/topics/validation.md",
       "status": "current",
       "owner": "@flyingrobots"


### PR DESCRIPTION
## Summary

- rejects duplicate non-repeatable custom directives during GraphQL lowering, including base/extension and extension/extension collisions
- preserves ordered arrays only for directives explicitly declared `repeatable`
- documents the IR directive encoding rule and records the fix in the changelog

## Validation

- `cargo test -p wesley-core --test lowering_validation directive -- --nocapture`
- `cargo test -p wesley-core -- --nocapture`
- `cargo clippy -p wesley-core --all-targets -- -D warnings`
- `cargo xtask docs-check`
- `pnpm run preflight`
- `git diff --check`
- pre-push Rust product preflight

Closes #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeated directives so valid repeatable ones are preserved, while invalid duplicates are now rejected more consistently.

* **New Features**
  * Added clearer security-tooling guidance, including current baseline expectations and criteria for evaluating future scanners and security gates.

* **Documentation**
  * Expanded security and validation docs, refreshed directive reference tables, and added a new security-tooling topic to the documentation map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->