### PR TITLE
docs: document security tooling posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   summaries, and can write JSON release evidence.
 - Added a first-PR contributor path with docs-only, fixture-only, emitter-test,
   and CLI bug fast lanes plus maintainer starter-issue checks.
+- Added a security-tooling posture topic that records Wesley's current scanner
+  baseline, rejects DAST for the current compiler-only surface, and gates future
+  Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,9 @@ artifacts through generic emitters and external modules.
 
 - Keep dependency updates reviewable and run repository preflight before
   release.
+- Scope security scanners to Wesley's compiler and tooling surface. The current
+  baseline and candidate-gate decisions live in
+  [`docs/topics/security-tooling.md`](docs/topics/security-tooling.md).
 - Prefer deterministic inputs, injected clocks, and explicit host permissions
   for portable capability work.
 - Do not grant portable modules ambient filesystem, network, process, or clock
@@ -94,5 +97,6 @@ artifacts through generic emitters and external modules.
 - Domain-empty compiler boundary that keeps target security policy out of core
 - Hash-linked evidence and artifact review surfaces
 - Dependency and documentation preflight checks
+- Documented scanner-fit posture for advisory and static-analysis gates
 - Explicit external-module responsibility for database, runtime, and product
   security behavior

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -39,6 +39,7 @@ short path to the authoritative surface.
 | ------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Choose local checks before a PR or release. | [Validation](./validation.md)                 | `cargo xtask preflight`, `docs/governance/RELEASE_POLICY.md`                       |
 | Interpret GitHub Actions checks.            | [CI Workflows](./ci-workflows.md)             | `docs/ci.md`, `.github/workflows/`                                                 |
+| Evaluate security scanners and gates.       | [Security Tooling](./security-tooling.md)     | `SECURITY.md`, `.github/workflows/`, `docs/governance/RELEASE_POLICY.md`           |
 | Understand HOLMES CI and PR comments.       | [HOLMES CI](./holmes-ci.md)                   | `.github/workflows/wesley-holmes.yml`, `docs/architecture/`                        |
 | Work with assurance evidence and policies.  | [Assurance Evidence](./assurance-evidence.md) | `docs/reference/assurance-capability-matrix.md`, `docs/holmes-policy-spec.md`      |
 | Prepare or judge a release.                 | [Releases](./releases.md)                     | `.continuum/release.yml`, `docs/method/release.md`, `docs/governance/`             |

--- a/docs/topics/ci-workflows.md
+++ b/docs/topics/ci-workflows.md
@@ -17,6 +17,7 @@ diff or running focused checks before a PR.
 | Compatibility smoke          | Workspace compatibility and Rust product smoke.    |
 | CodeQL / analysis            | Static analysis for supported languages.           |
 | Dependency review            | Dependency risk in PRs.                            |
+| Security posture             | Advisory gates, scanner fit, and false positives.  |
 | HOLMES workflow              | Schema-selected assurance reports and PR comments. |
 | SHIPME certificate           | Post-merge evidence for the landed `main` SHA.     |
 
@@ -54,6 +55,7 @@ BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 ## Related Authority
 
 - [Continuous Integration](../ci.md)
+- [Security Tooling](./security-tooling.md)
 - [HOLMES CI](./holmes-ci.md)
 - [Validation](./validation.md)
 - [Release Workflow](./releases.md)

--- a/docs/topics/security-tooling.md
+++ b/docs/topics/security-tooling.md
@@ -1,0 +1,84 @@
+# Security Tooling
+
+<!-- docs-truth: status=current owner=@flyingrobots -->
+
+Use this topic when evaluating a security scanner, advisory gate, or workflow
+hardening change for Wesley.
+
+Wesley is currently a compiler and tooling repository. It does not ship a hosted
+HTTP service, browser application, database runtime, or long-lived daemon. The
+security tooling posture therefore focuses on the compiler surface:
+
+- dependency and supply-chain advisories,
+- generated-source safety,
+- artifact and path handling,
+- GitHub Actions permissions and egress visibility,
+- domain-empty boundary regressions.
+
+Security tooling in this repo should not claim that Wesley has proved
+downstream runtime, database, product, or target-module security semantics.
+Those claims belong to the owning target module or sibling repository.
+
+## Current Baseline
+
+| Surface                                   | Current Gate                                                                                                 | Status                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| JavaScript and TypeScript static analysis | `.github/workflows/codeql.yml` runs CodeQL with `security-and-quality` queries.                              | Active on `main`, PRs into `main`, and weekly schedule.                    |
+| Pull-request dependency changes           | `.github/workflows/dependency-review.yml` runs Dependency Review.                                            | Active on PRs into `main`; fails on high severity.                         |
+| Repository supply-chain posture           | `.github/workflows/scorecards.yml` runs OpenSSF Scorecard and uploads SARIF.                                 | Active on `main`, weekly schedule, and manual dispatch.                    |
+| Workflow egress visibility                | GitHub Actions jobs use `step-security/harden-runner` in audit mode.                                         | Active as visibility, not a blocking egress policy.                        |
+| JavaScript advisory audit                 | `cargo xtask preflight` runs `pnpm audit --prod=false --json`.                                               | Active in the strict local gate.                                           |
+| Rust advisory audit                       | `cargo xtask release-guard` and release workflows run `cargo audit`.                                         | Active for release readiness and publication.                              |
+| Rust product quality                      | `cargo xtask preflight` runs formatting, Clippy, workspace tests, docs checks, and a native CLI smoke test.  | Active in the strict local gate.                                           |
+| Domain-empty regression checks            | `test/domain-empty-boundary.bats` guards core source vocabulary.                                             | Active in repository validation.                                           |
+| Emitter source-safety regressions         | Emitter tests parse or compile generated output and include source-level guards where a printer rule exists. | Active for covered emitters and expected to grow with risky printer paths. |
+
+## Evaluation Matrix
+
+| Candidate                     | Decision                           | Rationale                                                                                                                                                                                                                             |
+| ----------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OWASP ZAP or other DAST       | Do not add now.                    | Wesley has no hosted runtime surface to crawl. Add DAST only if a future Wesley-owned web/API surface ships in this repo.                                                                                                             |
+| Semgrep with broad auto rules | Do not add as a blocking gate now. | Broad rule packs are likely to create high review cost for a compiler repo. Prefer repo-owned rules with focused fixtures.                                                                                                            |
+| Repo-specific Semgrep rules   | Candidate.                         | Useful fits are unsafe source interpolation in emitters, path traversal in artifact readers, and accidental domain semantics in core. Each rule needs a local reproducer and a documented false-positive policy before it blocks PRs. |
+| `cargo-deny`                  | Candidate.                         | Useful for license, advisory, duplicate, and ban policy once `deny.toml` exists and ownership is clear. Start advisory or scheduled before making it required.                                                                        |
+| Harden-runner blocking egress | Defer.                             | Audit mode provides evidence today. Blocking egress should wait until the workflow egress inventory is stable enough that normal release work is not noisy.                                                                           |
+
+## Gate Admission Rules
+
+A new security gate belongs in Wesley only when all of these are true:
+
+1. It protects a Wesley-owned compiler, CLI, artifact, docs, CI, or release
+   surface.
+2. It has a local command or focused fixture so contributors can reproduce the
+   failure without guessing at GitHub Actions state.
+3. It has a clear owner and a documented exception format.
+4. It does not duplicate an existing gate without adding a distinct signal.
+5. It starts as advisory or scheduled when the false-positive rate is unknown.
+6. It documents what the gate proves and what it does not prove.
+
+When a gate fails because of an advisory that is not exploitable in Wesley's
+actual product surface, document the package path, exposure analysis, temporary
+mitigation, and expiration or revisit date.
+
+## Near-Term Fits
+
+The most useful next gates are narrow and repo-specific:
+
+- emitter printer rules that catch direct interpolation of schema, law, or
+  directive strings into generated source,
+- artifact-reader rules that reject path escape regressions,
+- source-boundary rules that keep database, runtime, and product semantics out
+  of `wesley-core`,
+- an advisory `cargo-deny` policy once license and ban ownership is written
+  down.
+
+Keep DAST and hosted-application scanners out of Wesley until Wesley owns a
+hosted application surface.
+
+## Related Authority
+
+- [Security Policy](../../SECURITY.md)
+- [CI Workflows](./ci-workflows.md)
+- [Validation](./validation.md)
+- [Compiler Boundary](./compiler-boundary.md)
+- [Release Policy](../governance/RELEASE_POLICY.md)

--- a/docs/topics/validation.md
+++ b/docs/topics/validation.md
@@ -28,6 +28,7 @@ workspace tests, and a native CLI smoke test.
 | Domain-empty boundary                 | `BATS_LIB_PATH=test/vendor bats -t test/domain-empty-boundary.bats`                               |
 | HOLMES PR comments or reports         | `node --test packages/wesley-holmes/test/pr-comment.test.mjs`                                     |
 | JavaScript package or lockfile policy | `cargo xtask legacy-preflight`, `pnpm lint`                                                       |
+| Security-tooling policy or docs       | `cargo xtask docs-check`, `git diff --check`                                                      |
 
 The pre-push hook may select relevant checks, but do not use the hook as the
 only plan for a risky change. Choose checks deliberately and record the
@@ -43,4 +44,5 @@ Release validation is stricter than PR validation. Use
 
 - [`docs/governance/RELEASE_POLICY.md`](../governance/RELEASE_POLICY.md)
 - [`docs/governance/DOCUMENTATION_STANDARD.md`](../governance/DOCUMENTATION_STANDARD.md)
+- [`docs/topics/security-tooling.md`](./security-tooling.md)
 - [`docs/reference/cli.md`](../reference/cli.md)

--- a/docs/truth-manifest.json
+++ b/docs/truth-manifest.json
@@ -217,6 +217,11 @@
       "owner": "@flyingrobots"
     },
     {
+      "path": "docs/topics/security-tooling.md",
+      "status": "current",
+      "owner": "@flyingrobots"
+    },
+    {
       "path": "docs/topics/validation.md",
       "status": "current",
       "owner": "@flyingrobots"


### PR DESCRIPTION
## Summary

- adds a current Security Tooling topic that records Wesley's existing security baseline
- documents scanner-fit decisions: no DAST for the current compiler-only surface, no broad auto Semgrep gate, and `cargo-deny` only after a repo-owned policy exists
- wires the topic into `SECURITY.md`, the topic map, CI workflow guidance, validation guidance, the truth manifest, and the changelog

## Validation

- `pnpm exec prettier --write CHANGELOG.md SECURITY.md docs/topics/README.md docs/topics/ci-workflows.md docs/topics/validation.md docs/topics/security-tooling.md`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight

Closes #684