### PR TITLE
docs: require issue-linked pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ This guide is for AI agents and human operators recovering context in the Wesley
 - **NEVER** rebase or force-push.
 - **NEVER** push to `main` without explicit permission.
 - Always use standard commits and regular pushes.
+- Every PR must name at least one GitHub Issue in the PR body.
+- Use a closing keyword such as `Closes #123`, `Fixes #123`, or
+  `Resolves #123` for every issue the PR fully resolves so GitHub auto-closes
+  it on merge.
+- If a PR only advances an issue, use a non-closing reference such as
+  `Refs #123` or `Tracks #123` and state what remains.
 
 ## Documentation & Planning Map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   baseline, rejects DAST for the current compiler-only surface, and gates future
   Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
 
+### Changed
+
+- Required PR bodies to reference at least one GitHub Issue and to use GitHub
+  closing keywords for every fully resolved issue.
+
 ### Fixed
 
 - Rejected duplicate non-repeatable custom directives during SDL lowering,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,12 @@ Starter issues must have one scheduling-state label such as `v0.3.0`, one
 validation command. If an issue still has a `triage:*` label, it is not a
 starter task until a maintainer schedules, splits, moves, or closes it.
 
+Every PR must name at least one GitHub Issue in its body. Use a closing keyword
+such as `Closes #123`, `Fixes #123`, or `Resolves #123` for every issue the PR
+fully resolves so GitHub auto-closes it on merge. If the PR only advances an
+issue, use a non-closing reference such as `Refs #123` or `Tracks #123` and
+state the remaining work explicitly.
+
 The normal first-contribution lanes are docs-only PRs, fixture-only PRs,
 emitter-test PRs, and CLI bug PRs. Advanced architecture, assurance, and
 release docs are background for these lanes, not required reading unless the


### PR DESCRIPTION
## Summary

- Require every PR body to name at least one GitHub Issue
- Require GitHub closing keywords for issues fully resolved by a PR
- Document partial-progress references with `Refs` or `Tracks`

Closes #695

## Validation

- `pnpm exec prettier --check AGENTS.md CONTRIBUTING.md CHANGELOG.md`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`