### PR TITLE
test: cover Rust emitter list nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added a security-tooling posture topic that records Wesley's current scanner
   baseline, rejects DAST for the current compiler-only surface, and gates future
   Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
+- Added Rust emitter coverage for single-list GraphQL nullability shapes such
+  as `[String]!` and `[String!]`.
 
 ### Changed
 

--- a/crates/wesley-emit-rust/src/lib.rs
+++ b/crates/wesley-emit-rust/src/lib.rs
@@ -970,6 +970,29 @@ pub struct UserFilter {
     }
 
     #[test]
+    fn emits_single_list_nullability_shapes() {
+        let ir = lower_schema_sdl(
+            r#"
+            type ListShape {
+              requiredListNullableItems: [String]!
+              nullableListRequiredItems: [String!]
+            }
+            "#,
+        )
+        .expect("schema should lower");
+
+        let actual = emit_rust(&ir);
+
+        syn::parse_file(&actual).expect("generated Rust should parse");
+        assert!(actual.contains(
+            "#[serde(rename = \"requiredListNullableItems\")]\n    pub required_list_nullable_items: Vec<Option<String>>,"
+        ));
+        assert!(actual.contains(
+            "#[serde(rename = \"nullableListRequiredItems\")]\n    pub nullable_list_required_items: Option<Vec<String>>,"
+        ));
+    }
+
+    #[test]
     fn emits_jedit_shaped_hot_text_fixture() {
         let ir = lower_schema_sdl(include_str!(
             "../../../test/fixtures/consumer-models/jedit-hot-text-core.graphql"


### PR DESCRIPTION
## Summary

- Add focused Rust emitter coverage for `[String]!` and `[String!]` shapes
- Assert generated Rust preserves list nullability as `Vec<Option<String>>` and `Option<Vec<String>>`
- Record the regression coverage in the changelog

Closes #690

## Validation

- `cargo test -p wesley-emit-rust emits_single_list_nullability_shapes`
- `cargo test -p wesley-emit-rust`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight