### PR TITLE
test: cover missing schema path diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added a security-tooling posture topic that records Wesley's current scanner
   baseline, rejects DAST for the current compiler-only surface, and gates future
   Semgrep or `cargo-deny` adoption on low-noise repo-owned policies.
+- Added CLI regression coverage for missing schema file diagnostics.
 
 ### Changed
 

--- a/crates/wesley-cli/tests/cli.rs
+++ b/crates/wesley-cli/tests/cli.rs
@@ -203,6 +203,28 @@ fn schema_commands_discover_single_schema_manifest_when_schema_flag_is_omitted()
 }
 
 #[test]
+fn schema_lower_reports_missing_schema_path() {
+    let dir = temp_dir("missing-schema-path");
+    let missing_schema = dir.join("missing-schema.graphql");
+
+    let output = wesley()
+        .args(["schema", "lower", "--schema"])
+        .arg(&missing_schema)
+        .arg("--json")
+        .output()
+        .expect("wesley should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("failed to access schema"));
+    assert!(stderr.contains("missing-schema.graphql"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn removed_footprint_checker_is_not_a_wesley_command() {
     let output = wesley()
         .arg("check-footprint")


### PR DESCRIPTION
## Summary

- Add a CLI integration regression for `wesley schema lower --schema <missing>`
- Assert nonzero exit, empty stdout, and a clear missing schema diagnostic
- Record the diagnostic coverage in the changelog

Closes #691

## Validation

- `cargo test -p wesley-cli --test cli schema_lower_reports_missing_schema_path`
- `cargo test -p wesley-cli --test cli schema`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight