### PR TITLE
docs: add project manifest reference starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added CLI regression coverage for missing schema file diagnostics.
 - Added Rust emitter coverage for single-list GraphQL nullability shapes such
   as `[String]!` and `[String!]`.
+- Added a docs/site starter example for the current `wesley.config.json`
+  project manifest path.
 
 ### Changed
 

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -7,6 +7,7 @@ title: Reference Links
 - Project README: https://github.com/flyingrobots/wesley/blob/main/README.md
 - CLI Reference: https://github.com/flyingrobots/wesley/blob/main/docs/reference/cli.md
 - Directive Truth Table: https://github.com/flyingrobots/wesley/blob/main/docs/reference/directives.md
+- Project Manifest: https://github.com/flyingrobots/wesley/blob/main/docs/reference/project-manifest.md
 - BEARING: https://github.com/flyingrobots/wesley/blob/main/docs/BEARING.md
 - VISION: https://github.com/flyingrobots/wesley/blob/main/docs/VISION.md
 - METHOD Process: https://github.com/flyingrobots/wesley/blob/main/docs/method/process.md
@@ -16,3 +17,26 @@ title: Reference Links
 - Contribution Guide: https://github.com/flyingrobots/wesley/blob/main/CONTRIBUTING.md
 - SECURITY Policy: https://github.com/flyingrobots/wesley/blob/main/SECURITY.md
 - Labels taxonomy: https://github.com/flyingrobots/wesley/blob/main/docs/governance/labels.md
+
+## Project Manifest Starter
+
+Use `wesley.config.json` for the current JSON manifest path. The manifest names
+GraphQL schema inputs and generic evidence/output locations; it does not define
+database behavior, runtime policy, or downstream target semantics.
+
+```json
+{
+  "apiVersion": "wesley.project-manifest/v1",
+  "schemaPaths": ["schema.graphql"]
+}
+```
+
+Validate the manifest with the native CLI:
+
+```bash
+wesley config validate --config wesley.config.json --json
+```
+
+For YAML and multi-schema examples, see the
+[Project Manifest](https://github.com/flyingrobots/wesley/blob/main/docs/reference/project-manifest.md)
+reference.


### PR DESCRIPTION
## Summary

- Link `docs/site/reference.md` to the project manifest reference
- Add a domain-free `wesley.config.json` starter example and validation command
- Record the docs/site starter in the changelog

Closes #647

## Validation

- `pnpm exec prettier --check docs/site/reference.md CHANGELOG.md`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight