### PR TITLE
docs: add extension fixture walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   project manifest path.
 - Added CLI integration coverage for YAML project manifests in changed-schema
   selection.
+- Added a quick-start walkthrough for descriptor-only extension fixture groups.
 
 ### Changed
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -63,6 +63,26 @@ Validate it:
 cargo wesley config validate --json
 ```
 
+## Inspect extension examples
+
+Wesley keeps extension examples as descriptor-only test fixtures under
+`test/fixtures/extensions/fixture-zoo`. These files are examples for docs and
+tests, not executable modules.
+
+Start with the fixture zoo README, then inspect the three groups:
+
+- `compiler-heavy`: compiler-focused descriptors for schema lowering, operation
+  metadata, and generic emitters.
+- `evidence-heavy`: evidence-focused descriptors for artifact citations,
+  coverage summaries, and judgment summaries.
+- `blade-heavy`: BLADE-focused descriptors for release-readiness scenario
+  metadata.
+
+Each descriptor shows which generic facts Wesley core may validate and which
+meaning stays outside the core. Runtime execution, product behavior, storage,
+operator policy, and other domain choices belong to the owning external module
+or sibling repo.
+
 ## Diff a schema change
 
 Copy the file, make a change, and compare the two SDL states:


### PR DESCRIPTION
## Summary

- Add a quick-start section for `test/fixtures/extensions/fixture-zoo`
- Explain the compiler-focused, evidence-focused, and BLADE-focused descriptor groups in plain language
- Clarify that fixture descriptors are examples for docs/tests, not executable modules, and that Wesley core remains domain-free

Closes #649

## Validation

- `pnpm exec prettier --check docs/guides/quick-start.md CHANGELOG.md`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`