### PR TITLE
ci: align Dependabot action labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,7 @@ updates:
       include: 'scope'
     labels:
       - 'dependencies'
-      - 'github-actions'
+      - 'ci'
     groups:
       github-actions:
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Aligned Dependabot GitHub Actions update PR labels with existing repository
+  labels.
 - Required PR bodies to reference at least one GitHub Issue and to use GitHub
   closing keywords for every fully resolved issue.
 


### PR DESCRIPTION
## Branch / Issue-Title Check

Branch `ci/dependabot-actions-labels` and title `ci: align Dependabot action labels` match the scoped issue and do not use reserved prefixes.

## Why

`.github/dependabot.yml` assigned GitHub Actions update PRs the `github-actions` label, but that label did not exist in the repository. That made Dependabot label assignment inconsistent with the current label taxonomy.

## Changes

- Replace the missing `github-actions` Dependabot PR label with the existing `ci` label
- Keep the `dependencies` label on GitHub Actions update PRs
- Record the label-taxonomy cleanup in the changelog

Closes #702

## Risk

Low. The change only affects labels applied to future GitHub Actions Dependabot PRs. It does not change update cadence, grouping, target branch, or dependency resolution.

## Backout

Revert commit `a815c946` to restore the prior Dependabot label list.

## Testing

- `pnpm exec prettier --check .github/dependabot.yml CHANGELOG.md`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight
- pre-push Bats smoke suite