### PR TITLE
cli: add target descriptor verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added CLI integration coverage for YAML project manifests in changed-schema
   selection.
 - Added a quick-start walkthrough for descriptor-only extension fixture groups.
+- Added `wesley target verify` for external target descriptor validation without
+  executing target code.
 
 ### Changed
 

--- a/crates/wesley-cli/src/main.rs
+++ b/crates/wesley-cli/src/main.rs
@@ -1485,6 +1485,7 @@ fn is_path_safe_name(value: &str) -> bool {
         && !trimmed.contains("..")
         && !trimmed.contains('/')
         && !trimmed.contains('\\')
+        && !trimmed.contains(':')
         && !trimmed.contains('\0')
 }
 
@@ -1492,12 +1493,17 @@ fn is_bare_program_name(value: &str) -> bool {
     !value.is_empty()
         && !value.contains('/')
         && !value.contains('\\')
+        && !value.contains(':')
         && !value.contains('\0')
         && !Path::new(value).is_absolute()
 }
 
 fn is_safe_relative_path(value: &str, require_nested: bool) -> bool {
-    if value.trim().is_empty() || value.contains('\\') || value.contains('\0') {
+    if value.trim().is_empty()
+        || value.contains('\\')
+        || value.contains(':')
+        || value.contains('\0')
+    {
         return false;
     }
 

--- a/crates/wesley-cli/src/main.rs
+++ b/crates/wesley-cli/src/main.rs
@@ -32,6 +32,11 @@ const EXIT_OK: u8 = 0;
 const EXIT_FAILURE: u8 = 1;
 const EXIT_USAGE: u8 = 2;
 const RUST_NATIVE_EXECUTION_MODE: &str = "rust-native";
+const TARGET_DESCRIPTOR_API_VERSION: &str = "wesley.target-descriptor/v1";
+const TARGET_PROCESS_PROTOCOL_VERSION: &str = "wesley.target-process/v1";
+const REQUIRED_TARGET_INPUT_IR: &str = "wesley.l1-ir/v1";
+const REQUIRED_TARGET_OUTPUT_MANIFEST: &str = "wesley.target-artifact-manifest/v1";
+const TARGET_VERIFY_MAX_TIMEOUT_MS: u64 = 300_000;
 
 fn main() -> ExitCode {
     let args = env::args().skip(1).collect::<Vec<_>>();
@@ -62,6 +67,7 @@ fn run(args: Vec<String>) -> Result<u8, CliError> {
         }
         Some("doctor") => run_doctor_command(&args[1..]),
         Some("config") => run_config_command(&args[1..]),
+        Some("target") => run_target_command(&args[1..]),
         Some("init-law") if wants_help(&args[1..]) => {
             print_init_law_help();
             Ok(EXIT_OK)
@@ -481,6 +487,69 @@ fn run_config_command(args: &[String]) -> Result<u8, CliError> {
         Some(command) => Err(CliError::usage(format!(
             "unknown config command '{command}'"
         ))),
+    }
+}
+
+fn run_target_command(args: &[String]) -> Result<u8, CliError> {
+    match args.first().map(String::as_str) {
+        None | Some("--help") | Some("-h") => {
+            print_target_help();
+            Ok(EXIT_OK)
+        }
+        Some("verify") if wants_help(&args[1..]) => {
+            print_target_help();
+            Ok(EXIT_OK)
+        }
+        Some("verify") => run_target_verify_command(&args[1..]),
+        Some(command) => Err(CliError::usage(format!(
+            "unknown target command '{command}'"
+        ))),
+    }
+}
+
+fn run_target_verify_command(args: &[String]) -> Result<u8, CliError> {
+    let (descriptor_path, json) = parse_target_verify_args(args)?;
+    let descriptor_source = read_file(&descriptor_path, "target descriptor")?;
+    let descriptor =
+        serde_json::from_str::<ExternalTargetDescriptor>(&descriptor_source).map_err(|source| {
+            CliError::JsonInput {
+                label: "target descriptor".to_string(),
+                path: descriptor_path.clone(),
+                source: source.to_string(),
+            }
+        })?;
+    let diagnostics = validate_external_target_descriptor(&descriptor);
+    let valid = diagnostics.is_empty();
+    let report = TargetVerifyReport {
+        valid,
+        descriptor_path: descriptor_path.display().to_string(),
+        descriptor: TargetDescriptorIdentity {
+            api_version: descriptor.api_version.clone(),
+            name: descriptor.name.clone(),
+            protocol: descriptor.protocol.version.clone(),
+        },
+        diagnostics,
+    };
+
+    if json {
+        print_json(&report)?;
+    } else if valid {
+        println!("Target descriptor valid: {}", report.descriptor.name);
+    } else {
+        eprintln!("Target descriptor invalid: {}", descriptor_path.display());
+        for diagnostic in &report.diagnostics {
+            if let Some(subject) = diagnostic.subject.as_deref() {
+                eprintln!("{}: {} ({subject})", diagnostic.code, diagnostic.message);
+            } else {
+                eprintln!("{}: {}", diagnostic.code, diagnostic.message);
+            }
+        }
+    }
+
+    if valid {
+        Ok(EXIT_OK)
+    } else {
+        Ok(EXIT_FAILURE)
     }
 }
 
@@ -1207,6 +1276,37 @@ fn parse_options(args: &[String], command: &str) -> Result<ParsedOptions, CliErr
     Ok(options)
 }
 
+fn parse_target_verify_args(args: &[String]) -> Result<(PathBuf, bool), CliError> {
+    let mut descriptor_path = None;
+    let mut json = false;
+
+    for argument in args {
+        match argument.as_str() {
+            "--json" => json = true,
+            value if value.starts_with('-') => {
+                return Err(CliError::usage(format!(
+                    "unknown option '{value}' for `target verify`"
+                )));
+            }
+            value => {
+                if descriptor_path.replace(PathBuf::from(value)).is_some() {
+                    return Err(CliError::usage(
+                        "pass exactly one descriptor path to `target verify`",
+                    ));
+                }
+            }
+        }
+    }
+
+    let Some(descriptor_path) = descriptor_path else {
+        return Err(CliError::usage(
+            "missing descriptor path for `target verify`",
+        ));
+    };
+
+    Ok((descriptor_path, json))
+}
+
 fn wants_help(args: &[String]) -> bool {
     args.iter()
         .any(|argument| argument == "--help" || argument == "-h")
@@ -1222,6 +1322,202 @@ fn required_value(args: &[String], index: usize, option: &str) -> Result<String,
     }
 
     Ok(value.clone())
+}
+
+fn validate_external_target_descriptor(
+    descriptor: &ExternalTargetDescriptor,
+) -> Vec<TargetVerifyDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if descriptor.api_version != TARGET_DESCRIPTOR_API_VERSION {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.api_version.unsupported",
+            "target descriptor apiVersion is unsupported",
+            Some(&descriptor.api_version),
+        );
+    }
+
+    if !is_path_safe_name(&descriptor.name) {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.name.path_unsafe",
+            "target descriptor name must be non-empty and path-safe",
+            Some(&descriptor.name),
+        );
+    }
+
+    if descriptor.protocol.kind != "external-process" {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.protocol.kind_unsupported",
+            "target protocol kind must be external-process",
+            Some(&descriptor.protocol.kind),
+        );
+    }
+
+    if descriptor.protocol.version != TARGET_PROCESS_PROTOCOL_VERSION {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.protocol.version_unsupported",
+            "target process protocol version is unsupported",
+            Some(&descriptor.protocol.version),
+        );
+    }
+
+    if !is_safe_relative_path(&descriptor.command.program, true) {
+        let code = if is_bare_program_name(&descriptor.command.program) {
+            "target.command.program_bare"
+        } else {
+            "target.command.program_unsafe"
+        };
+        push_target_diagnostic(
+            &mut diagnostics,
+            code,
+            "target command program must be a descriptor-relative path without traversal",
+            Some(&descriptor.command.program),
+        );
+    }
+
+    if descriptor
+        .command
+        .args
+        .iter()
+        .any(|argument| argument.contains('\0'))
+    {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.command.arg_nul",
+            "target command args must not contain NUL bytes",
+            None,
+        );
+    }
+
+    if descriptor.execution.timeout_ms == 0
+        || descriptor.execution.timeout_ms > TARGET_VERIFY_MAX_TIMEOUT_MS
+    {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.execution.timeout_out_of_range",
+            "target execution timeout must be between 1 and the host maximum",
+            Some(&descriptor.execution.timeout_ms.to_string()),
+        );
+    }
+
+    if !descriptor
+        .capabilities
+        .inputs
+        .iter()
+        .any(|input| input == REQUIRED_TARGET_INPUT_IR)
+    {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.capability.input_missing",
+            "target descriptor must request the Wesley L1 IR input capability",
+            Some(REQUIRED_TARGET_INPUT_IR),
+        );
+    }
+
+    if !descriptor
+        .capabilities
+        .outputs
+        .iter()
+        .any(|output| output == REQUIRED_TARGET_OUTPUT_MANIFEST)
+    {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.capability.output_missing",
+            "target descriptor must declare the artifact manifest output capability",
+            Some(REQUIRED_TARGET_OUTPUT_MANIFEST),
+        );
+    }
+
+    if descriptor.capabilities.requires_network {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.capability.network_denied",
+            "target verify does not grant network capability",
+            None,
+        );
+    }
+
+    if descriptor.capabilities.requires_ambient_filesystem {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.capability.ambient_filesystem_denied",
+            "target verify does not grant ambient filesystem capability",
+            None,
+        );
+    }
+
+    if !is_safe_relative_path(&descriptor.outputs.default_out_dir, false) {
+        push_target_diagnostic(
+            &mut diagnostics,
+            "target.output.default_dir_unsafe",
+            "default output directory must be workspace-relative without traversal",
+            Some(&descriptor.outputs.default_out_dir),
+        );
+    }
+
+    diagnostics
+}
+
+fn push_target_diagnostic(
+    diagnostics: &mut Vec<TargetVerifyDiagnostic>,
+    code: &str,
+    message: &str,
+    subject: Option<&str>,
+) {
+    diagnostics.push(TargetVerifyDiagnostic {
+        severity: "error".to_string(),
+        code: code.to_string(),
+        message: message.to_string(),
+        subject: subject.map(ToOwned::to_owned),
+    });
+}
+
+fn is_path_safe_name(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed == value
+        && trimmed != "."
+        && trimmed != ".."
+        && !trimmed.contains("..")
+        && !trimmed.contains('/')
+        && !trimmed.contains('\\')
+        && !trimmed.contains('\0')
+}
+
+fn is_bare_program_name(value: &str) -> bool {
+    !value.is_empty()
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.contains('\0')
+        && !Path::new(value).is_absolute()
+}
+
+fn is_safe_relative_path(value: &str, require_nested: bool) -> bool {
+    if value.trim().is_empty() || value.contains('\\') || value.contains('\0') {
+        return false;
+    }
+
+    let path = Path::new(value);
+    if path.is_absolute() {
+        return false;
+    }
+
+    let mut normal_components = 0;
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(_) => normal_components += 1,
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => return false,
+        }
+    }
+
+    normal_components > 0 && (!require_nested || value.contains('/'))
 }
 
 fn read_file(path: &PathBuf, label: &str) -> Result<String, CliError> {
@@ -1564,6 +1860,85 @@ fn print_json(value: &impl serde::Serialize) -> Result<(), CliError> {
     let json = serde_json::to_string_pretty(value)?;
     println!("{json}");
     Ok(())
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetDescriptor {
+    api_version: String,
+    name: String,
+    protocol: ExternalTargetProtocol,
+    command: ExternalTargetCommand,
+    execution: ExternalTargetExecution,
+    capabilities: ExternalTargetCapabilities,
+    outputs: ExternalTargetOutputs,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetProtocol {
+    kind: String,
+    version: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetCommand {
+    program: String,
+    #[serde(default)]
+    args: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetExecution {
+    timeout_ms: u64,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetCapabilities {
+    #[serde(default)]
+    inputs: Vec<String>,
+    #[serde(default)]
+    outputs: Vec<String>,
+    #[serde(default)]
+    requires_network: bool,
+    #[serde(default)]
+    requires_ambient_filesystem: bool,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExternalTargetOutputs {
+    default_out_dir: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetVerifyReport {
+    valid: bool,
+    descriptor_path: String,
+    descriptor: TargetDescriptorIdentity,
+    diagnostics: Vec<TargetVerifyDiagnostic>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetDescriptorIdentity {
+    api_version: String,
+    name: String,
+    protocol: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetVerifyDiagnostic {
+    severity: String,
+    code: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subject: Option<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -2328,6 +2703,7 @@ Commands:
   config validate          Validate a Wesley project manifest
   config inspect           Print resolved manifest schema paths and targets
   config changed-schemas   Select schema sets affected by changed files
+  target verify            Validate an external target descriptor
   schema lower              Lower GraphQL SDL to Wesley L1 IR JSON
   schema hash               Print the Wesley L1 registry hash for GraphQL SDL
   schema operations         List Query/Mutation/Subscription root operations
@@ -2408,6 +2784,22 @@ Options:
   --changed <path>       Changed file path; may be passed more than once
   --changed-file <path>  Newline-delimited changed file list
   --json                 Emit JSON output"
+    );
+}
+
+fn print_target_help() {
+    println!(
+        "\
+Wesley target commands
+
+External target commands validate descriptor metadata without assigning product
+or runtime meaning to Wesley core.
+
+Usage:
+  wesley target verify <descriptor> [--json]
+
+Options:
+  --json  Emit JSON output"
     );
 }
 
@@ -2526,6 +2918,11 @@ enum CliError {
     Config(ProjectManifestError),
     Git(String),
     Json(String),
+    JsonInput {
+        label: String,
+        path: PathBuf,
+        source: String,
+    },
 }
 
 impl CliError {
@@ -2541,7 +2938,8 @@ impl CliError {
             | Self::Law(_)
             | Self::Config(_)
             | Self::Git(_)
-            | Self::Json(_) => EXIT_FAILURE,
+            | Self::Json(_)
+            | Self::JsonInput { .. } => EXIT_FAILURE,
         }
     }
 }
@@ -2573,6 +2971,15 @@ impl std::fmt::Display for CliError {
             Self::Config(error) => write!(formatter, "{error}"),
             Self::Git(error) => write!(formatter, "git error: {error}"),
             Self::Json(error) => write!(formatter, "failed to serialize JSON output: {error}"),
+            Self::JsonInput {
+                label,
+                path,
+                source,
+            } => write!(
+                formatter,
+                "failed to parse {label} `{}`: {source}",
+                path.display()
+            ),
         }
     }
 }

--- a/crates/wesley-cli/tests/cli.rs
+++ b/crates/wesley-cli/tests/cli.rs
@@ -15,6 +15,7 @@ fn help_exits_zero_without_footprint_command() {
     assert!(stdout.contains("schema diff"));
     assert!(stdout.contains("config validate"));
     assert!(stdout.contains("config changed-schemas"));
+    assert!(stdout.contains("target verify"));
     assert!(stdout.contains("law validate"));
     assert!(stdout.contains("law lint"));
     assert!(stdout.contains("law diff"));
@@ -28,6 +29,169 @@ fn help_exits_zero_without_footprint_command() {
     assert!(stdout.contains("emit le-binary-typescript"));
     assert!(stdout.contains("operation selections"));
     assert!(!stdout.contains("check-footprint"));
+}
+
+#[test]
+fn target_verify_accepts_descriptor_without_execution() {
+    let dir = temp_dir("target-verify-valid");
+    let descriptor = dir.join("target-descriptor.json");
+    std::fs::write(
+        &descriptor,
+        valid_target_descriptor_json("./bin/hello-wesley-target"),
+    )
+    .expect("descriptor should write");
+
+    let output = wesley()
+        .current_dir(&dir)
+        .args(["target", "verify"])
+        .arg("target-descriptor.json")
+        .arg("--json")
+        .output()
+        .expect("wesley should run");
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["descriptor"]["name"], "hello-wesley-target");
+    assert_eq!(
+        report["descriptor"]["apiVersion"],
+        "wesley.target-descriptor/v1"
+    );
+    assert_eq!(report["diagnostics"].as_array().unwrap().len(), 0);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn target_verify_does_not_execute_descriptor_program() {
+    let dir = temp_dir("target-verify-no-exec");
+    let bin_dir = dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("bin dir should create");
+    let marker = dir.join("should-not-exist");
+    let program = bin_dir.join("hello-wesley-target");
+    std::fs::write(&program, format!("#!/bin/sh\ntouch {}\n", marker.display()))
+        .expect("program should write");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(&program)
+            .expect("program metadata should read")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&program, permissions).expect("program mode should update");
+    }
+    let descriptor = dir.join("target-descriptor.json");
+    std::fs::write(
+        &descriptor,
+        valid_target_descriptor_json("./bin/hello-wesley-target"),
+    )
+    .expect("descriptor should write");
+
+    let output = wesley()
+        .current_dir(&dir)
+        .args(["target", "verify", "target-descriptor.json"])
+        .output()
+        .expect("wesley should run");
+
+    assert_success(&output);
+    assert!(
+        !marker.exists(),
+        "target verify must not execute descriptor command programs"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn target_verify_reports_deterministic_diagnostics_for_unsafe_descriptor() {
+    let dir = temp_dir("target-verify-unsafe");
+    let descriptor = dir.join("target-descriptor.json");
+    std::fs::write(
+        &descriptor,
+        r#"
+{
+  "apiVersion": "wesley.target-descriptor/v1",
+  "name": "../not-safe",
+  "protocol": {
+    "kind": "shell",
+    "version": "wesley.target-process/v2"
+  },
+  "command": {
+    "program": "hello-wesley-target",
+    "args": ["--request-stdin"]
+  },
+  "execution": {
+    "timeoutMs": 0
+  },
+  "capabilities": {
+    "inputs": [],
+    "outputs": [],
+    "requiresNetwork": true,
+    "requiresAmbientFilesystem": true
+  },
+  "outputs": {
+    "defaultOutDir": "../generated"
+  }
+}
+"#,
+    )
+    .expect("descriptor should write");
+
+    let output = wesley()
+        .current_dir(&dir)
+        .args(["target", "verify", "target-descriptor.json", "--json"])
+        .output()
+        .expect("wesley should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be json");
+    assert_eq!(report["valid"], false);
+    let codes = report["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array")
+        .iter()
+        .map(|diagnostic| diagnostic["code"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"target.name.path_unsafe"));
+    assert!(codes.contains(&"target.protocol.kind_unsupported"));
+    assert!(codes.contains(&"target.protocol.version_unsupported"));
+    assert!(codes.contains(&"target.command.program_bare"));
+    assert!(codes.contains(&"target.execution.timeout_out_of_range"));
+    assert!(codes.contains(&"target.capability.input_missing"));
+    assert!(codes.contains(&"target.capability.output_missing"));
+    assert!(codes.contains(&"target.capability.network_denied"));
+    assert!(codes.contains(&"target.capability.ambient_filesystem_denied"));
+    assert!(codes.contains(&"target.output.default_dir_unsafe"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn target_verify_reports_descriptor_parse_errors() {
+    let dir = temp_dir("target-verify-malformed");
+    let descriptor = dir.join("target-descriptor.json");
+    std::fs::write(&descriptor, "{").expect("descriptor should write");
+
+    let output = wesley()
+        .current_dir(&dir)
+        .args(["target", "verify", "target-descriptor.json", "--json"])
+        .output()
+        .expect("wesley should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        output.stdout.is_empty(),
+        "malformed descriptor input must not emit a validation report"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("failed to parse target descriptor"));
+    assert!(stderr.contains("target-descriptor.json"));
+    assert!(!stderr.contains("failed to serialize JSON output"));
+
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
@@ -1823,6 +1987,36 @@ fn temp_dir(name: &str) -> std::path::PathBuf {
     ));
     std::fs::create_dir_all(&path).expect("temp directory should create");
     path
+}
+
+fn valid_target_descriptor_json(program: &str) -> String {
+    format!(
+        r#"{{
+  "apiVersion": "wesley.target-descriptor/v1",
+  "name": "hello-wesley-target",
+  "protocol": {{
+    "kind": "external-process",
+    "version": "wesley.target-process/v1"
+  }},
+  "command": {{
+    "program": "{program}",
+    "args": ["--request-stdin"]
+  }},
+  "execution": {{
+    "timeoutMs": 30000
+  }},
+  "capabilities": {{
+    "inputs": ["wesley.l1-ir/v1", "wesley.schema-operations/v1"],
+    "outputs": ["wesley.target-artifact-manifest/v1"],
+    "requiresNetwork": false,
+    "requiresAmbientFilesystem": false
+  }},
+  "outputs": {{
+    "defaultOutDir": "generated/hello"
+  }}
+}}
+"#
+    )
 }
 
 fn generated_hash_literal(generated: &str, constant: &str) -> serde_json::Value {

--- a/crates/wesley-cli/tests/cli.rs
+++ b/crates/wesley-cli/tests/cli.rs
@@ -170,6 +170,63 @@ fn target_verify_reports_deterministic_diagnostics_for_unsafe_descriptor() {
 }
 
 #[test]
+fn target_verify_rejects_windows_drive_like_paths() {
+    let dir = temp_dir("target-verify-windows-drive");
+    let descriptor = dir.join("target-descriptor.json");
+    std::fs::write(
+        &descriptor,
+        r#"
+{
+  "apiVersion": "wesley.target-descriptor/v1",
+  "name": "hello:target",
+  "protocol": {
+    "kind": "external-process",
+    "version": "wesley.target-process/v1"
+  },
+  "command": {
+    "program": "C:/tools/hello-wesley-target",
+    "args": ["--request-stdin"]
+  },
+  "execution": {
+    "timeoutMs": 30000
+  },
+  "capabilities": {
+    "inputs": ["wesley.l1-ir/v1"],
+    "outputs": ["wesley.target-artifact-manifest/v1"],
+    "requiresNetwork": false,
+    "requiresAmbientFilesystem": false
+  },
+  "outputs": {
+    "defaultOutDir": "C:/generated"
+  }
+}
+"#,
+    )
+    .expect("descriptor should write");
+
+    let output = wesley()
+        .current_dir(&dir)
+        .args(["target", "verify", "target-descriptor.json", "--json"])
+        .output()
+        .expect("wesley should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be json");
+    let codes = report["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array")
+        .iter()
+        .map(|diagnostic| diagnostic["code"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"target.name.path_unsafe"));
+    assert!(codes.contains(&"target.command.program_unsafe"));
+    assert!(codes.contains(&"target.output.default_dir_unsafe"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn target_verify_reports_descriptor_parse_errors() {
     let dir = temp_dir("target-verify-malformed");
     let descriptor = dir.join("target-descriptor.json");

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,6 +32,7 @@ Commands:
 | `config validate`           | Validate a Wesley project manifest                           |
 | `config inspect`            | Print resolved manifest schema paths and targets             |
 | `config changed-schemas`    | Select schema sets affected by changed files                 |
+| `target verify`             | Validate an external target descriptor without execution     |
 | `schema lower`              | Lower GraphQL SDL to Wesley L1 IR JSON                       |
 | `schema hash`               | Print the Wesley L1 registry hash for GraphQL SDL            |
 | `schema operations`         | List Query/Mutation/Subscription root operations             |
@@ -76,10 +77,10 @@ pnpm, config modules, or plugin packages.
 
 Options:
 
-| Option         | Meaning          |
-| -------------- | ---------------- | ------------- |
-| `--json`       | Emit JSON output |
-| `--format text | json`            | Output format |
+| Option                | Meaning          |
+| --------------------- | ---------------- |
+| `--json`              | Emit JSON output |
+| `--format text\|json` | Output format    |
 
 ## Init Law
 
@@ -122,6 +123,27 @@ Options:
 
 The project manifest is documented in
 [Project Manifest](./project-manifest.md).
+
+## Target
+
+```text
+wesley target verify <descriptor> [--json]
+```
+
+`target verify` validates a `wesley.target-descriptor/v1` descriptor without
+executing the descriptor command. It checks the protocol version, path-safe
+target name, descriptor-relative command path, bounded timeout, required input
+and output capabilities, denied network and ambient filesystem requests, and
+workspace-relative output directory.
+
+Options:
+
+| Option   | Meaning          |
+| -------- | ---------------- |
+| `--json` | Emit JSON output |
+
+`target verify` is descriptor validation only. Wesley still does not ship
+`target run`, process sandboxing, artifact copy-out, or target SDK execution.
 
 ## Schema
 

--- a/docs/reference/external-target-protocol.md
+++ b/docs/reference/external-target-protocol.md
@@ -9,10 +9,11 @@ Wesley target authors:
 Wesley compiler facts -> external process -> artifact manifest and diagnostics
 ```
 
-Status: protocol MVP specification. The current `v0.2.0` native CLI does not
-ship `wesley target verify` or `wesley target run` yet. Until those commands
-exist with tests and release evidence, project manifests and fixture descriptors
-remain metadata surfaces.
+Status: protocol MVP specification. The native CLI ships
+`wesley target verify` for descriptor validation without execution. It does not
+ship `wesley target run` yet. Until `target run` exists with tests and release
+evidence, project manifests and fixture descriptors remain metadata surfaces
+for execution.
 
 ## Goals
 
@@ -86,6 +87,7 @@ Descriptor rules:
 - `apiVersion` must be exactly `wesley.target-descriptor/v1` for this MVP.
 - `name` must be stable, non-empty, and path-safe.
 - `protocol.kind` must be `external-process`.
+- `protocol.version` must be exactly `wesley.target-process/v1`.
 - `command.program` must be a descriptor-relative executable path, not a shell
   string, bare program name, or `PATH` lookup. It must not be absolute or
   contain `..`, and the host must reject symlink or canonicalization escapes
@@ -93,6 +95,10 @@ Descriptor rules:
   only if it preserves deterministic resolution.
 - `command.args` must be argv elements, not a shell command.
 - `execution.timeoutMs` must be finite and bounded by the host maximum.
+- target capabilities must request `wesley.l1-ir/v1` input and
+  `wesley.target-artifact-manifest/v1` output.
+- network and ambient filesystem capability requests are denied by the MVP
+  verifier.
 - output directories must be workspace-relative.
 - descriptors must not contain product semantics; examples should use names
   like `hello`, `model`, or `artifact`.

--- a/docs/reference/external-target-protocol.md
+++ b/docs/reference/external-target-protocol.md
@@ -85,21 +85,24 @@ The descriptor is plain JSON. It is safe to validate without execution.
 Descriptor rules:
 
 - `apiVersion` must be exactly `wesley.target-descriptor/v1` for this MVP.
-- `name` must be stable, non-empty, and path-safe.
+- `name` must be stable, non-empty, and path-safe: no `.`, `..`, slashes,
+  backslashes, colons, or traversal-like `..` substrings.
 - `protocol.kind` must be `external-process`.
 - `protocol.version` must be exactly `wesley.target-process/v1`.
 - `command.program` must be a descriptor-relative executable path, not a shell
   string, bare program name, or `PATH` lookup. It must not be absolute or
-  contain `..`, and the host must reject symlink or canonicalization escapes
-  before launch. A future package or digest-backed binary reference may be added
-  only if it preserves deterministic resolution.
+  contain `..`, a Windows drive-like `:` prefix, or backslashes, and the host
+  must reject symlink or canonicalization escapes before launch. A future
+  package or digest-backed binary reference may be added only if it preserves
+  deterministic resolution.
 - `command.args` must be argv elements, not a shell command.
 - `execution.timeoutMs` must be finite and bounded by the host maximum.
 - target capabilities must request `wesley.l1-ir/v1` input and
   `wesley.target-artifact-manifest/v1` output.
 - network and ambient filesystem capability requests are denied by the MVP
   verifier.
-- output directories must be workspace-relative.
+- output directories must be workspace-relative and must not contain `..`,
+  Windows drive-like `:` prefixes, or backslashes.
 - descriptors must not contain product semantics; examples should use names
   like `hello`, `model`, or `artifact`.
 


### PR DESCRIPTION
## Branch / Issue-Title Check

Branch `cli/target-descriptor-verify` and title `cli: add target descriptor verification` match #705 and use no reserved prefixes.

## Why

#680 named `wesley target verify` in the external-process protocol docs, but the native CLI did not ship a descriptor verifier. Third-party target authors need a non-executing validation surface before any target runner exists.

## Changes

- Add `wesley target verify <descriptor> [--json]`.
- Validate descriptor API/protocol versions, path-safe names, descriptor-relative command paths, bounded timeouts, required capabilities, denied network/ambient filesystem requests, and safe output directories.
- Reject Windows drive-like colon paths so descriptor validation stays deterministic across hosts.
- Add CLI tests for valid descriptors, non-execution, deterministic unsafe-descriptor diagnostics, malformed descriptor parse errors, and drive-like path rejection.
- Update CLI/protocol docs and the changelog.

Closes #705
Related to #680

## Risk

Medium-low. This adds a validation-only CLI command. It does not execute target code, add `target run`, perform process sandboxing, or copy artifacts.

## Backout

Revert `ac2f95c0` and `9368f48c` to remove the `target` command and reference docs.

## Testing

- `cargo test -p wesley-cli --test cli target_verify_reports_descriptor_parse_errors` (RED before fix, GREEN after fix)
- `cargo test -p wesley-cli --test cli target_verify_rejects_windows_drive_like_paths` (RED before fix, GREEN after fix)
- `cargo test -p wesley-cli --test cli target_verify`
- `cargo test -p wesley-cli --test cli`
- `cargo fmt --check`
- `pnpm exec prettier --check docs/reference/cli.md docs/reference/external-target-protocol.md CHANGELOG.md`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight
