### PR TITLE
schemas: publish external target protocol schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added a quick-start walkthrough for descriptor-only extension fixture groups.
 - Added `wesley target verify` for external target descriptor validation without
   executing target code.
+- Added JSON Schemas for the external target descriptor, request, response,
+  diagnostic, and artifact manifest protocol envelopes.
 
 ### Changed
 

--- a/crates/wesley-core/tests/generated_json_artifacts.rs
+++ b/crates/wesley-core/tests/generated_json_artifacts.rs
@@ -60,6 +60,12 @@ fn local_schema_ref(reference: &str) -> Option<&'static str> {
         "realm.schema.json#" => Some("schemas/realm.schema.json"),
         "runtime-event.schema.json#" => Some("schemas/runtime-event.schema.json"),
         "runtime-run.schema.json#" => Some("schemas/runtime-run.schema.json"),
+        "wesley-target-artifact-manifest-v1.schema.json#" => {
+            Some("schemas/wesley-target-artifact-manifest-v1.schema.json")
+        }
+        "wesley-target-diagnostic-v1.schema.json#" => {
+            Some("schemas/wesley-target-diagnostic-v1.schema.json")
+        }
         _ => None,
     }
 }
@@ -75,6 +81,17 @@ fn assert_schema_valid(schema_path: &str, artifact_name: &str, artifact: &serde_
     assert!(
         errors.is_empty(),
         "{artifact_name} failed {schema_path}: {errors:#?}"
+    );
+}
+
+fn assert_schema_invalid(schema_path: &str, artifact_name: &str, artifact: &serde_json::Value) {
+    let schema = schema_json(schema_path);
+    let validator = jsonschema::validator_for(&schema).expect("schema should compile");
+    let errors = validator.iter_errors(artifact).collect::<Vec<_>>();
+
+    assert!(
+        !errors.is_empty(),
+        "{artifact_name} unexpectedly satisfied {schema_path}"
     );
 }
 
@@ -375,5 +392,191 @@ fn holmes_and_shipme_artifacts_satisfy_declared_schemas() {
         "schemas/shipme.schema.json",
         "representative SHIPME certificate",
         &shipme,
+    );
+}
+
+#[test]
+fn external_target_protocol_artifacts_satisfy_declared_schemas() {
+    let artifact_hash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let descriptor = json!({
+        "apiVersion": "wesley.target-descriptor/v1",
+        "name": "hello-wesley-target",
+        "protocol": {
+            "kind": "external-process",
+            "version": "wesley.target-process/v1"
+        },
+        "command": {
+            "program": "./bin/hello-wesley-target",
+            "args": ["--request-stdin"]
+        },
+        "execution": {
+            "timeoutMs": 30000
+        },
+        "capabilities": {
+            "inputs": ["wesley.l1-ir/v1", "wesley.schema-operations/v1"],
+            "outputs": ["wesley.target-artifact-manifest/v1"],
+            "requiresNetwork": false,
+            "requiresAmbientFilesystem": false
+        },
+        "outputs": {
+            "defaultOutDir": "generated/hello"
+        }
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-descriptor-v1.schema.json",
+        "representative target descriptor",
+        &descriptor,
+    );
+
+    let unsafe_descriptor = json!({
+        "apiVersion": "wesley.target-descriptor/v1",
+        "name": "hello-wesley-target",
+        "protocol": {
+            "kind": "external-process",
+            "version": "wesley.target-process/v1"
+        },
+        "command": {
+            "program": "C:/tools/hello-wesley-target",
+            "args": []
+        },
+        "execution": {
+            "timeoutMs": 30000
+        },
+        "capabilities": {
+            "inputs": ["wesley.l1-ir/v1"],
+            "outputs": ["wesley.target-artifact-manifest/v1"],
+            "requiresNetwork": false,
+            "requiresAmbientFilesystem": false
+        },
+        "outputs": {
+            "defaultOutDir": "generated/hello"
+        }
+    });
+    assert_schema_invalid(
+        "schemas/wesley-target-descriptor-v1.schema.json",
+        "drive-like target descriptor",
+        &unsafe_descriptor,
+    );
+
+    let dot_only_descriptor = json!({
+        "apiVersion": "wesley.target-descriptor/v1",
+        "name": "hello-wesley-target",
+        "protocol": {
+            "kind": "external-process",
+            "version": "wesley.target-process/v1"
+        },
+        "command": {
+            "program": "./",
+            "args": []
+        },
+        "execution": {
+            "timeoutMs": 30000
+        },
+        "capabilities": {
+            "inputs": ["wesley.l1-ir/v1"],
+            "outputs": ["wesley.target-artifact-manifest/v1"],
+            "requiresNetwork": false,
+            "requiresAmbientFilesystem": false
+        },
+        "outputs": {
+            "defaultOutDir": "."
+        }
+    });
+    assert_schema_invalid(
+        "schemas/wesley-target-descriptor-v1.schema.json",
+        "dot-only target descriptor paths",
+        &dot_only_descriptor,
+    );
+
+    let target_request = json!({
+        "apiVersion": "wesley.target-request/v1",
+        "requestId": "request-hello-0001",
+        "workspaceRoot": "/workspace",
+        "schema": {
+            "id": "app",
+            "path": "schema.graphql",
+            "hash": artifact_hash
+        },
+        "ir": {
+            "apiVersion": "wesley.l1-ir/v1",
+            "json": {}
+        },
+        "operations": {
+            "apiVersion": "wesley.schema-operations/v1",
+            "items": []
+        },
+        "target": {
+            "name": "hello-wesley-target",
+            "module": "example.hello",
+            "outputDir": "generated/hello"
+        },
+        "capabilityContext": {
+            "network": "denied",
+            "ambientFilesystem": "denied",
+            "allowedOutputDirs": ["generated/hello"],
+            "stagingOutputRoot": "/tmp/wesley-target-runs/request-hello-0001/out"
+        }
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-request-v1.schema.json",
+        "representative target request",
+        &target_request,
+    );
+
+    let diagnostic = json!({
+        "severity": "error",
+        "code": "target.output.path_escape",
+        "message": "artifact path escapes the allowed output directory",
+        "subject": "generated/../escape.txt"
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-diagnostic-v1.schema.json",
+        "representative target diagnostic",
+        &diagnostic,
+    );
+
+    let artifact_manifest = json!({
+        "apiVersion": "wesley.target-artifact-manifest/v1",
+        "items": [
+            {
+                "path": "generated/hello/model.txt",
+                "kind": "text",
+                "sha256": artifact_hash
+            }
+        ]
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-artifact-manifest-v1.schema.json",
+        "representative target artifact manifest",
+        &artifact_manifest,
+    );
+
+    let dot_only_artifact_manifest = json!({
+        "apiVersion": "wesley.target-artifact-manifest/v1",
+        "items": [
+            {
+                "path": ".",
+                "kind": "text",
+                "sha256": artifact_hash
+            }
+        ]
+    });
+    assert_schema_invalid(
+        "schemas/wesley-target-artifact-manifest-v1.schema.json",
+        "dot-only artifact manifest path",
+        &dot_only_artifact_manifest,
+    );
+
+    let target_response = json!({
+        "apiVersion": "wesley.target-response/v1",
+        "requestId": "request-hello-0001",
+        "status": "ok",
+        "diagnostics": [],
+        "artifacts": artifact_manifest
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-response-v1.schema.json",
+        "representative target response",
+        &target_response,
     );
 }

--- a/crates/wesley-core/tests/generated_json_artifacts.rs
+++ b/crates/wesley-core/tests/generated_json_artifacts.rs
@@ -551,6 +551,58 @@ fn external_target_protocol_artifacts_satisfy_declared_schemas() {
         &artifact_manifest,
     );
 
+    let duplicate_artifact_manifest = json!({
+        "apiVersion": "wesley.target-artifact-manifest/v1",
+        "items": [
+            {
+                "path": "generated/hello/model.txt",
+                "kind": "text",
+                "sha256": artifact_hash
+            },
+            {
+                "path": "generated/hello/model.txt",
+                "kind": "text",
+                "sha256": artifact_hash
+            }
+        ]
+    });
+    assert_schema_invalid(
+        "schemas/wesley-target-artifact-manifest-v1.schema.json",
+        "exact duplicate artifact manifest entries",
+        &duplicate_artifact_manifest,
+    );
+
+    let duplicate_path_distinct_artifact_manifest = json!({
+        "apiVersion": "wesley.target-artifact-manifest/v1",
+        "items": [
+            {
+                "path": "generated/hello/model.txt",
+                "kind": "text",
+                "sha256": artifact_hash
+            },
+            {
+                "path": "generated/hello/model.txt",
+                "kind": "binary",
+                "sha256": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            }
+        ]
+    });
+    assert_schema_valid(
+        "schemas/wesley-target-artifact-manifest-v1.schema.json",
+        "duplicate artifact paths with distinct metadata require host validation",
+        &duplicate_path_distinct_artifact_manifest,
+    );
+
+    let external_target_protocol_reference =
+        include_str!("../../../docs/reference/external-target-protocol.md")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+    assert!(
+        external_target_protocol_reference.contains("same path with different metadata"),
+        "external target protocol docs must spell out duplicate path validation beyond JSON Schema"
+    );
+
     let dot_only_artifact_manifest = json!({
         "apiVersion": "wesley.target-artifact-manifest/v1",
         "items": [

--- a/docs/reference/external-target-protocol.md
+++ b/docs/reference/external-target-protocol.md
@@ -244,7 +244,9 @@ Artifact manifest rules:
   colon characters such as Windows drive prefixes, backslashes, or absolute
   path prefixes. A path of `.` alone is not valid.
 - Artifact order must be deterministic.
-- Repeated paths are invalid.
+- Repeated paths are invalid. The JSON Schema rejects exact duplicate artifact
+  objects; `target run` must additionally reject the same path with different
+  metadata before artifact copy-out.
 
 ## Host Enforcement Rules
 

--- a/docs/reference/external-target-protocol.md
+++ b/docs/reference/external-target-protocol.md
@@ -54,6 +54,8 @@ for execution.
 ## Descriptor Envelope
 
 The descriptor is plain JSON. It is safe to validate without execution.
+The machine-readable schema is
+[`schemas/wesley-target-descriptor-v1.schema.json`](../../schemas/wesley-target-descriptor-v1.schema.json).
 
 ```json
 {
@@ -91,24 +93,27 @@ Descriptor rules:
 - `protocol.version` must be exactly `wesley.target-process/v1`.
 - `command.program` must be a descriptor-relative executable path, not a shell
   string, bare program name, or `PATH` lookup. It must not be absolute or
-  contain `..`, a Windows drive-like `:` prefix, or backslashes, and the host
-  must reject symlink or canonicalization escapes before launch. A future
-  package or digest-backed binary reference may be added only if it preserves
-  deterministic resolution.
+  contain a parent-directory `..` segment, colon characters such as Windows
+  drive-like `:` prefixes, or backslashes, and the host must reject symlink or
+  canonicalization escapes before launch. A future package or digest-backed
+  binary reference may be added only if it preserves deterministic resolution.
 - `command.args` must be argv elements, not a shell command.
 - `execution.timeoutMs` must be finite and bounded by the host maximum.
 - target capabilities must request `wesley.l1-ir/v1` input and
   `wesley.target-artifact-manifest/v1` output.
 - network and ambient filesystem capability requests are denied by the MVP
   verifier.
-- output directories must be workspace-relative and must not contain `..`,
-  Windows drive-like `:` prefixes, or backslashes.
+- output directories must be workspace-relative and must not contain
+  parent-directory `..` segments, colon characters such as Windows drive-like
+  `:` prefixes, or backslashes. A directory of `.` alone is not valid.
 - descriptors must not contain product semantics; examples should use names
   like `hello`, `model`, or `artifact`.
 
 ## Request Envelope
 
 The request envelope is the only input a target needs from Wesley.
+The machine-readable schema is
+[`schemas/wesley-target-request-v1.schema.json`](../../schemas/wesley-target-request-v1.schema.json).
 
 ```json
 {
@@ -118,7 +123,7 @@ The request envelope is the only input a target needs from Wesley.
   "schema": {
     "id": "app",
     "path": "schema.graphql",
-    "hash": "sha256:..."
+    "hash": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   },
   "ir": {
     "apiVersion": "wesley.l1-ir/v1",
@@ -159,7 +164,8 @@ Request rules:
 ## Response Envelope
 
 Targets return one JSON response envelope on stdout. Human logs should go to
-stderr.
+stderr. The machine-readable schema is
+[`schemas/wesley-target-response-v1.schema.json`](../../schemas/wesley-target-response-v1.schema.json).
 
 ```json
 {
@@ -173,7 +179,7 @@ stderr.
       {
         "path": "generated/hello/model.txt",
         "kind": "text",
-        "sha256": "..."
+        "sha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       }
     ]
   }
@@ -192,6 +198,9 @@ Response rules:
   hashes are hard failures.
 
 ## Diagnostic Shape
+
+The machine-readable schema is
+[`schemas/wesley-target-diagnostic-v1.schema.json`](../../schemas/wesley-target-diagnostic-v1.schema.json).
 
 ```json
 {
@@ -212,6 +221,9 @@ Diagnostic rules:
 
 ## Artifact Manifest Shape
 
+The machine-readable schema is
+[`schemas/wesley-target-artifact-manifest-v1.schema.json`](../../schemas/wesley-target-artifact-manifest-v1.schema.json).
+
 ```json
 {
   "apiVersion": "wesley.target-artifact-manifest/v1",
@@ -219,7 +231,7 @@ Diagnostic rules:
     {
       "path": "generated/hello/model.txt",
       "kind": "text",
-      "sha256": "..."
+      "sha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   ]
 }
@@ -228,8 +240,9 @@ Diagnostic rules:
 Artifact manifest rules:
 
 - Every artifact must have a path, kind, and hash.
-- Paths must be relative and must not contain `..`, Windows drive prefixes, or
-  absolute path prefixes.
+- Paths must be relative and must not contain parent-directory `..` segments,
+  colon characters such as Windows drive prefixes, backslashes, or absolute
+  path prefixes. A path of `.` alone is not valid.
 - Artifact order must be deterministic.
 - Repeated paths are invalid.
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -12,6 +12,16 @@ This directory hosts machine-readable schemas that underpin Wesley’s generator
   Schema describing the emitted `wesley.contract-bundle-manifest/v1` shape.
 - `wesley-law-diff-v1.schema.json` – Versioned, canonical JSON Schema
   describing machine-readable `wesley.law-diff/v1` semantic law diff reports.
+- `wesley-target-descriptor-v1.schema.json` – JSON Schema for
+  `wesley.target-descriptor/v1` external target descriptors.
+- `wesley-target-request-v1.schema.json` – JSON Schema for
+  `wesley.target-request/v1` external target request envelopes.
+- `wesley-target-response-v1.schema.json` – JSON Schema for
+  `wesley.target-response/v1` external target response envelopes.
+- `wesley-target-diagnostic-v1.schema.json` – JSON Schema for machine-readable
+  target diagnostics used by the external target protocol.
+- `wesley-target-artifact-manifest-v1.schema.json` – JSON Schema for
+  `wesley.target-artifact-manifest/v1` target artifact manifests.
 - `evidence-map.schema.json` – JSON Schema for the evidence bundle map emitted by HOLMES/-SHIPME flows.
 - `scores.schema.json` – JSON Schema for holmes `scores.json` output.
 

--- a/schemas/wesley-target-artifact-manifest-v1.schema.json
+++ b/schemas/wesley-target-artifact-manifest-v1.schema.json
@@ -9,6 +9,7 @@
     "apiVersion": { "const": "wesley.target-artifact-manifest/v1" },
     "items": {
       "type": "array",
+      "description": "JSON Schema rejects exact duplicate artifact objects. Hosts must additionally reject repeated path values when metadata differs.",
       "uniqueItems": true,
       "items": { "$ref": "#/definitions/artifact" }
     }

--- a/schemas/wesley-target-artifact-manifest-v1.schema.json
+++ b/schemas/wesley-target-artifact-manifest-v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wesley.dev/schemas/wesley-target-artifact-manifest-v1.schema.json",
+  "title": "wesley.target-artifact-manifest/v1",
+  "description": "Manifest of artifacts emitted by an external Wesley target process.",
+  "type": "object",
+  "required": ["apiVersion", "items"],
+  "properties": {
+    "apiVersion": { "const": "wesley.target-artifact-manifest/v1" },
+    "items": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/artifact" }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "artifact": {
+      "type": "object",
+      "required": ["path", "kind", "sha256"],
+      "properties": {
+        "path": { "$ref": "#/definitions/workspaceRelativePath" },
+        "kind": { "$ref": "#/definitions/noNulNonEmptyString" },
+        "sha256": { "$ref": "#/definitions/sha256" }
+      },
+      "additionalProperties": false
+    },
+    "noNulNonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "workspaceRelativePath": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))(?!.*[:\\\\\\u0000])(?=.*[^./]).+"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/schemas/wesley-target-descriptor-v1.schema.json
+++ b/schemas/wesley-target-descriptor-v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wesley.dev/schemas/wesley-target-descriptor-v1.schema.json",
+  "title": "wesley.target-descriptor/v1",
+  "description": "External-process target descriptor validated before Wesley executes target code.",
+  "type": "object",
+  "required": ["apiVersion", "name", "protocol", "command", "execution", "capabilities", "outputs"],
+  "properties": {
+    "apiVersion": { "const": "wesley.target-descriptor/v1" },
+    "name": { "$ref": "#/definitions/pathSafeName" },
+    "protocol": {
+      "type": "object",
+      "required": ["kind", "version"],
+      "properties": {
+        "kind": { "const": "external-process" },
+        "version": { "const": "wesley.target-process/v1" }
+      },
+      "additionalProperties": false
+    },
+    "command": {
+      "type": "object",
+      "required": ["program"],
+      "properties": {
+        "program": { "$ref": "#/definitions/descriptorRelativeProgram" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/noNulString" },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution": {
+      "type": "object",
+      "required": ["timeoutMs"],
+      "properties": {
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300000
+        }
+      },
+      "additionalProperties": false
+    },
+    "capabilities": {
+      "type": "object",
+      "required": ["inputs", "outputs", "requiresNetwork", "requiresAmbientFilesystem"],
+      "properties": {
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/noNulString" },
+          "contains": { "const": "wesley.l1-ir/v1" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/noNulString" },
+          "contains": { "const": "wesley.target-artifact-manifest/v1" }
+        },
+        "requiresNetwork": { "const": false },
+        "requiresAmbientFilesystem": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["defaultOutDir"],
+      "properties": {
+        "defaultOutDir": { "$ref": "#/definitions/workspaceRelativePath" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "noNulString": {
+      "type": "string",
+      "pattern": "^[^\\u0000]*$"
+    },
+    "pathSafeName": {
+      "type": "string",
+      "pattern": "^(?!\\.\\.?$)(?!.*\\.\\.)(?!.*[/:\\\\\\u0000])\\S(?:.*\\S)?$"
+    },
+    "descriptorRelativeProgram": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))(?!.*[:\\\\\\u0000])(?=.*\\/)(?=.*[^./]).+"
+    },
+    "workspaceRelativePath": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))(?!.*[:\\\\\\u0000])(?=.*[^./]).+"
+    }
+  }
+}

--- a/schemas/wesley-target-diagnostic-v1.schema.json
+++ b/schemas/wesley-target-diagnostic-v1.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wesley.dev/schemas/wesley-target-diagnostic-v1.schema.json",
+  "title": "wesley.target-diagnostic/v1",
+  "description": "Machine-readable diagnostic emitted by an external Wesley target process.",
+  "type": "object",
+  "required": ["severity", "code", "message"],
+  "properties": {
+    "severity": { "enum": ["error", "warning", "info"] },
+    "code": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(\\.[a-z][a-z0-9_]*)+$"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/wesley-target-request-v1.schema.json
+++ b/schemas/wesley-target-request-v1.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wesley.dev/schemas/wesley-target-request-v1.schema.json",
+  "title": "wesley.target-request/v1",
+  "description": "Request envelope passed to an external Wesley target process.",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "requestId",
+    "workspaceRoot",
+    "schema",
+    "ir",
+    "operations",
+    "target",
+    "capabilityContext"
+  ],
+  "properties": {
+    "apiVersion": { "const": "wesley.target-request/v1" },
+    "requestId": { "$ref": "#/definitions/noNulNonEmptyString" },
+    "workspaceRoot": { "$ref": "#/definitions/noNulNonEmptyString" },
+    "schema": {
+      "type": "object",
+      "required": ["id", "path", "hash"],
+      "properties": {
+        "id": { "$ref": "#/definitions/pathSafeName" },
+        "path": { "$ref": "#/definitions/workspaceRelativePath" },
+        "hash": { "$ref": "#/definitions/sha256" }
+      },
+      "additionalProperties": false
+    },
+    "ir": {
+      "type": "object",
+      "required": ["apiVersion", "json"],
+      "properties": {
+        "apiVersion": { "const": "wesley.l1-ir/v1" },
+        "json": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "operations": {
+      "type": "object",
+      "required": ["apiVersion", "items"],
+      "properties": {
+        "apiVersion": { "const": "wesley.schema-operations/v1" },
+        "items": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "target": {
+      "type": "object",
+      "required": ["name", "outputDir"],
+      "properties": {
+        "name": { "$ref": "#/definitions/pathSafeName" },
+        "module": { "$ref": "#/definitions/noNulNonEmptyString" },
+        "outputDir": { "$ref": "#/definitions/workspaceRelativePath" }
+      },
+      "additionalProperties": false
+    },
+    "capabilityContext": {
+      "type": "object",
+      "required": ["network", "ambientFilesystem", "allowedOutputDirs", "stagingOutputRoot"],
+      "properties": {
+        "network": { "const": "denied" },
+        "ambientFilesystem": { "const": "denied" },
+        "allowedOutputDirs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/definitions/workspaceRelativePath" }
+        },
+        "stagingOutputRoot": { "$ref": "#/definitions/noNulNonEmptyString" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "noNulNonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "pathSafeName": {
+      "type": "string",
+      "pattern": "^(?!\\.\\.?$)(?!.*\\.\\.)(?!.*[/:\\\\\\u0000])\\S(?:.*\\S)?$"
+    },
+    "workspaceRelativePath": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))(?!.*[:\\\\\\u0000])(?=.*[^./]).+"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/schemas/wesley-target-response-v1.schema.json
+++ b/schemas/wesley-target-response-v1.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wesley.dev/schemas/wesley-target-response-v1.schema.json",
+  "title": "wesley.target-response/v1",
+  "description": "Response envelope returned by an external Wesley target process.",
+  "type": "object",
+  "required": ["apiVersion", "requestId", "status", "diagnostics"],
+  "properties": {
+    "apiVersion": { "const": "wesley.target-response/v1" },
+    "requestId": { "$ref": "#/definitions/noNulNonEmptyString" },
+    "status": { "enum": ["ok", "error"] },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "wesley-target-diagnostic-v1.schema.json#" }
+    },
+    "artifacts": { "$ref": "wesley-target-artifact-manifest-v1.schema.json#" }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "const": "ok" } },
+        "required": ["status"]
+      },
+      "then": { "required": ["artifacts"] }
+    }
+  ],
+  "definitions": {
+    "noNulNonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    }
+  }
+}


### PR DESCRIPTION
## Branch / Issue-Title Check

Branch `schemas/external-target-protocol` and title `schemas: publish external target protocol schemas` match #708 and use no reserved prefixes.

## Why

#680 now has an external-process protocol spec and PR #707 shipped descriptor verification, but target authors still lacked canonical JSON Schemas for the protocol envelopes.

## Changes

- Add JSON Schemas for target descriptors, requests, responses, diagnostics, and artifact manifests.
- Validate representative protocol artifacts through `generated_json_artifacts`.
- Add negative schema coverage for drive-like paths and dot-only target/artifact paths.
- Update the schema index, protocol reference, and changelog.

Closes #708
Related to #680

## Risk

Low. This publishes schema artifacts and tests only. It does not add `target run`, execute target code, sandbox processes, or copy artifacts.

## Backout

Revert `03534e38` to remove the schema files, protocol schema tests, and documentation references.

## Testing

- `cargo test -p wesley-core --test generated_json_artifacts external_target_protocol_artifacts_satisfy_declared_schemas` (RED before schemas, GREEN after schemas)
- `cargo test -p wesley-core --test generated_json_artifacts`
- `cargo fmt --check`
- `pnpm exec prettier --check schemas/README.md docs/reference/external-target-protocol.md CHANGELOG.md schemas/wesley-target-descriptor-v1.schema.json schemas/wesley-target-request-v1.schema.json schemas/wesley-target-response-v1.schema.json schemas/wesley-target-diagnostic-v1.schema.json schemas/wesley-target-artifact-manifest-v1.schema.json`
- `cargo xtask docs-check`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight
