### PR TITLE
test: add hello external target fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   executing target code.
 - Added JSON Schemas for the external target descriptor, request, response,
   diagnostic, and artifact manifest protocol envelopes.
+- Added a `hello-wesley-target` external target conformance fixture with
+  descriptor, request, diagnostic, response, artifact manifest, and artifact
+  hash validation.
 
 ### Changed
 

--- a/crates/wesley-core/tests/generated_json_artifacts.rs
+++ b/crates/wesley-core/tests/generated_json_artifacts.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use yaml_rust2::{Yaml, YamlLoader};
 
 use wesley_core::{
@@ -21,6 +22,14 @@ fn read_text(path: &str) -> String {
 
 fn read_json(path: &str) -> serde_json::Value {
     serde_json::from_str(&read_text(path)).expect("JSON should parse")
+}
+
+fn read_bytes(path: &str) -> Vec<u8> {
+    fs::read(repo_path(path)).expect("fixture should be readable")
+}
+
+fn sha256_prefixed(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
 }
 
 fn schema_json(path: &str) -> serde_json::Value {
@@ -631,4 +640,69 @@ fn external_target_protocol_artifacts_satisfy_declared_schemas() {
         "representative target response",
         &target_response,
     );
+}
+
+#[test]
+fn hello_external_target_fixture_satisfies_protocol_schemas() {
+    let fixture = "test/fixtures/external-targets/hello-wesley-target";
+    let descriptor = read_json(&format!("{fixture}/target-descriptor.json"));
+    assert_schema_valid(
+        "schemas/wesley-target-descriptor-v1.schema.json",
+        "hello target descriptor fixture",
+        &descriptor,
+    );
+
+    let schema_sdl = read_text(&format!("{fixture}/schema.graphql"));
+    let ir = lower_schema_sdl(&schema_sdl).expect("hello schema should lower");
+    let ir_json = serde_json::to_value(&ir).expect("hello IR should serialize");
+    let operations =
+        list_schema_operations_sdl(&schema_sdl).expect("hello schema operations should list");
+    let operations_json =
+        serde_json::to_value(&operations).expect("hello operations should serialize");
+    let schema_hash = format!(
+        "sha256:{}",
+        compute_registry_hash(&ir).expect("hello schema hash should compute")
+    );
+
+    let request = read_json(&format!("{fixture}/request.json"));
+    assert_schema_valid(
+        "schemas/wesley-target-request-v1.schema.json",
+        "hello target request fixture",
+        &request,
+    );
+    assert_eq!(request.pointer("/schema/hash"), Some(&json!(schema_hash)));
+    assert_eq!(request.pointer("/ir/json"), Some(&ir_json));
+    assert_eq!(request.pointer("/operations/items"), Some(&operations_json));
+
+    let diagnostic = read_json(&format!("{fixture}/diagnostic.json"));
+    assert_schema_valid(
+        "schemas/wesley-target-diagnostic-v1.schema.json",
+        "hello target diagnostic fixture",
+        &diagnostic,
+    );
+
+    let artifact_manifest = read_json(&format!("{fixture}/artifact-manifest.json"));
+    assert_schema_valid(
+        "schemas/wesley-target-artifact-manifest-v1.schema.json",
+        "hello target artifact manifest fixture",
+        &artifact_manifest,
+    );
+
+    let artifact_path = artifact_manifest
+        .pointer("/items/0/path")
+        .and_then(serde_json::Value::as_str)
+        .expect("hello artifact path should be present");
+    let artifact_bytes = read_bytes(&format!("{fixture}/artifacts/{artifact_path}"));
+    assert_eq!(
+        artifact_manifest.pointer("/items/0/sha256"),
+        Some(&json!(sha256_prefixed(&artifact_bytes)))
+    );
+
+    let response = read_json(&format!("{fixture}/response.json"));
+    assert_schema_valid(
+        "schemas/wesley-target-response-v1.schema.json",
+        "hello target response fixture",
+        &response,
+    );
+    assert_eq!(response.pointer("/artifacts"), Some(&artifact_manifest));
 }

--- a/crates/wesley-core/tests/generated_json_artifacts.rs
+++ b/crates/wesley-core/tests/generated_json_artifacts.rs
@@ -673,6 +673,11 @@ fn hello_external_target_fixture_satisfies_protocol_schemas() {
     assert_eq!(request.pointer("/schema/hash"), Some(&json!(schema_hash)));
     assert_eq!(request.pointer("/ir/json"), Some(&ir_json));
     assert_eq!(request.pointer("/operations/items"), Some(&operations_json));
+    assert_eq!(request.pointer("/target/name"), descriptor.pointer("/name"));
+    assert_eq!(
+        request.pointer("/target/outputDir"),
+        descriptor.pointer("/outputs/defaultOutDir")
+    );
 
     let diagnostic = read_json(&format!("{fixture}/diagnostic.json"));
     assert_schema_valid(
@@ -704,5 +709,10 @@ fn hello_external_target_fixture_satisfies_protocol_schemas() {
         "hello target response fixture",
         &response,
     );
+    assert_eq!(
+        response.pointer("/requestId"),
+        request.pointer("/requestId")
+    );
+    assert_eq!(response.pointer("/diagnostics/0"), Some(&diagnostic));
     assert_eq!(response.pointer("/artifacts"), Some(&artifact_manifest));
 }

--- a/docs/reference/external-target-protocol.md
+++ b/docs/reference/external-target-protocol.md
@@ -285,18 +285,25 @@ argv values.
 
 ## `hello-wesley-target` Template
 
-The first SDK template should contain:
+The repo-local conformance template lives at
+[`test/fixtures/external-targets/hello-wesley-target`](../../test/fixtures/external-targets/hello-wesley-target).
+It contains:
 
-- `schema.graphql`: a minimal GraphQL schema using `User` and `Query`.
-- `target-descriptor.json`: the descriptor envelope above.
-- `fixtures/request.json`: a request envelope generated from the schema.
-- `expected/model.txt`: one deterministic emitted artifact.
-- `expected/artifacts.json`: the artifact manifest.
-- one conformance test that runs the target process and compares the response
-  and artifact bytes.
+- `schema.graphql`: a minimal GraphQL schema with one generic `Query` field.
+- `target-descriptor.json`: a descriptor envelope that validates without
+  execution.
+- `request.json`: a request envelope generated from the schema's L1 IR and
+  schema operation metadata.
+- `diagnostic.json`: one standalone machine-readable diagnostic example.
+- `artifact-manifest.json`: the artifact manifest with a checked SHA-256
+  digest.
+- `response.json`: an `ok` response envelope carrying the artifact manifest.
+- `artifacts/generated/hello/model.txt`: one deterministic emitted artifact.
 
-The template must not mention Postgres, Echo, Continuum, auth, routing,
-deployment, or product runtime behavior.
+The template is not executable target loading and does not add `wesley target
+run`. Its conformance test validates the descriptor, request, diagnostic,
+response, artifact manifest, and artifact hash. It must not mention Postgres,
+Echo, Continuum, auth, routing, deployment, or product runtime behavior.
 
 ## Required Conformance Fixtures
 

--- a/test/fixtures/external-targets/README.md
+++ b/test/fixtures/external-targets/README.md
@@ -1,0 +1,8 @@
+# External Target Fixtures
+
+External target fixtures are conformance examples for Wesley's
+external-process target protocol.
+
+They are not executable target loaders. Each fixture keeps the boundary
+domain-empty by showing only protocol envelopes, deterministic artifacts, and
+schema validation evidence.

--- a/test/fixtures/external-targets/hello-wesley-target/README.md
+++ b/test/fixtures/external-targets/hello-wesley-target/README.md
@@ -1,0 +1,14 @@
+# Hello Wesley Target
+
+This fixture is a minimal external-process target conformance template.
+
+It demonstrates:
+
+- a generic GraphQL schema
+- a target descriptor that can be validated without execution
+- a request envelope containing L1 IR and schema operation metadata
+- a response envelope containing diagnostics and an artifact manifest
+- a deterministic emitted artifact with a checked SHA-256 digest
+
+The fixture does not execute target code. It exists so target authors can copy
+one complete, domain-empty envelope set before `wesley target run` exists.

--- a/test/fixtures/external-targets/hello-wesley-target/artifact-manifest.json
+++ b/test/fixtures/external-targets/hello-wesley-target/artifact-manifest.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "wesley.target-artifact-manifest/v1",
+  "items": [
+    {
+      "path": "generated/hello/model.txt",
+      "kind": "text",
+      "sha256": "sha256:045b61e78729e77f18f0eead41e5324e41f6d3a28eb3f37a6f4d4b17677f9f0e"
+    }
+  ]
+}

--- a/test/fixtures/external-targets/hello-wesley-target/artifacts/generated/hello/model.txt
+++ b/test/fixtures/external-targets/hello-wesley-target/artifacts/generated/hello/model.txt
@@ -1,0 +1,4 @@
+hello-wesley-target artifact
+
+schema: hello
+output: generated/hello/model.txt

--- a/test/fixtures/external-targets/hello-wesley-target/diagnostic.json
+++ b/test/fixtures/external-targets/hello-wesley-target/diagnostic.json
@@ -1,0 +1,6 @@
+{
+  "severity": "info",
+  "code": "target.fixture.ready",
+  "message": "hello external target fixture is ready for conformance validation",
+  "subject": "hello-wesley-target"
+}

--- a/test/fixtures/external-targets/hello-wesley-target/request.json
+++ b/test/fixtures/external-targets/hello-wesley-target/request.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "wesley.target-request/v1",
+  "requestId": "hello-request-0001",
+  "workspaceRoot": "/workspace",
+  "schema": {
+    "id": "hello",
+    "path": "test/fixtures/external-targets/hello-wesley-target/schema.graphql",
+    "hash": "sha256:d1f0871163ea0edc001202821c3e07d457d472623971c61323fc7c97850f5128"
+  },
+  "ir": {
+    "apiVersion": "wesley.l1-ir/v1",
+    "json": {
+      "version": "1.0.0",
+      "types": [
+        {
+          "name": "Query",
+          "kind": "OBJECT",
+          "directives": {},
+          "fields": [
+            {
+              "name": "hello",
+              "type": {
+                "base": "String",
+                "nullable": false,
+                "isList": false
+              },
+              "directives": {}
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "operations": {
+    "apiVersion": "wesley.schema-operations/v1",
+    "items": [
+      {
+        "operationType": "QUERY",
+        "rootTypeName": "Query",
+        "fieldName": "hello",
+        "arguments": [],
+        "resultType": {
+          "base": "String",
+          "nullable": false,
+          "isList": false
+        },
+        "directives": {}
+      }
+    ]
+  },
+  "target": {
+    "name": "hello-wesley-target",
+    "module": "example.hello",
+    "outputDir": "generated/hello"
+  },
+  "capabilityContext": {
+    "network": "denied",
+    "ambientFilesystem": "denied",
+    "allowedOutputDirs": ["generated/hello"],
+    "stagingOutputRoot": "/tmp/wesley-target-runs/hello-request-0001/out"
+  }
+}

--- a/test/fixtures/external-targets/hello-wesley-target/response.json
+++ b/test/fixtures/external-targets/hello-wesley-target/response.json
@@ -2,7 +2,14 @@
   "apiVersion": "wesley.target-response/v1",
   "requestId": "hello-request-0001",
   "status": "ok",
-  "diagnostics": [],
+  "diagnostics": [
+    {
+      "severity": "info",
+      "code": "target.fixture.ready",
+      "message": "hello external target fixture is ready for conformance validation",
+      "subject": "hello-wesley-target"
+    }
+  ],
   "artifacts": {
     "apiVersion": "wesley.target-artifact-manifest/v1",
     "items": [

--- a/test/fixtures/external-targets/hello-wesley-target/response.json
+++ b/test/fixtures/external-targets/hello-wesley-target/response.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "wesley.target-response/v1",
+  "requestId": "hello-request-0001",
+  "status": "ok",
+  "diagnostics": [],
+  "artifacts": {
+    "apiVersion": "wesley.target-artifact-manifest/v1",
+    "items": [
+      {
+        "path": "generated/hello/model.txt",
+        "kind": "text",
+        "sha256": "sha256:045b61e78729e77f18f0eead41e5324e41f6d3a28eb3f37a6f4d4b17677f9f0e"
+      }
+    ]
+  }
+}

--- a/test/fixtures/external-targets/hello-wesley-target/schema.graphql
+++ b/test/fixtures/external-targets/hello-wesley-target/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String!
+}

--- a/test/fixtures/external-targets/hello-wesley-target/target-descriptor.json
+++ b/test/fixtures/external-targets/hello-wesley-target/target-descriptor.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "wesley.target-descriptor/v1",
+  "name": "hello-wesley-target",
+  "protocol": {
+    "kind": "external-process",
+    "version": "wesley.target-process/v1"
+  },
+  "command": {
+    "program": "./bin/hello-wesley-target",
+    "args": ["--request-stdin"]
+  },
+  "execution": {
+    "timeoutMs": 30000
+  },
+  "capabilities": {
+    "inputs": ["wesley.l1-ir/v1", "wesley.schema-operations/v1"],
+    "outputs": ["wesley.target-artifact-manifest/v1"],
+    "requiresNetwork": false,
+    "requiresAmbientFilesystem": false
+  },
+  "outputs": {
+    "defaultOutDir": "generated/hello"
+  }
+}


### PR DESCRIPTION
## Summary

- Add a domain-empty `hello-wesley-target` external target conformance fixture.
- Validate descriptor, request, diagnostic, response, and artifact manifest files against the published target protocol schemas.
- Verify the checked artifact manifest hash against the fixture artifact bytes and document the template path.

## Verification

- RED: `cargo test -p wesley-core --test generated_json_artifacts hello_external_target_fixture_satisfies_protocol_schemas -- --nocapture` failed before the fixture files existed.
- GREEN: `cargo test -p wesley-core --test generated_json_artifacts hello_external_target_fixture_satisfies_protocol_schemas -- --nocapture`
- GREEN: `cargo test -p wesley-core --test generated_json_artifacts`
- GREEN: `cargo fmt --check`
- GREEN: `pnpm exec prettier --check CHANGELOG.md docs/reference/external-target-protocol.md 'test/fixtures/external-targets/**/*.md' 'test/fixtures/external-targets/**/*.json'`
- GREEN: `cargo xtask docs-check`
- GREEN: `git diff --check`
- GREEN: `pnpm run preflight`
- GREEN: pre-push Rust product preflight and repo Bats smoke suite

Closes #710
Related to #680
