### PR TITLE
docs: fix tracker deletion review fallout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Repaired tracker-deletion follow-up docs so pending audit reports point at a
+  concrete release gate, historical witness transcripts no longer show
+  impossible Method queue output, and design packets no longer claim deleted
+  files remain in the current checkout.
 - Rejected duplicate non-repeatable custom directives during SDL lowering,
   including duplicates split across type definitions and extensions, while
   preserving ordered arrays for directives declared `repeatable`.

--- a/docs/audit/2026-05-04_code-quality.md
+++ b/docs/audit/2026-05-04_code-quality.md
@@ -29,7 +29,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-04-11-CODE-QUALITY'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: CODE QUALITY (2026-05-04)

--- a/docs/audit/2026-05-04_documentation-quality.md
+++ b/docs/audit/2026-05-04_documentation-quality.md
@@ -29,7 +29,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-04-11-DOCUMENTATION-QUALITY'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: DOCUMENTATION QUALITY (2026-05-04)

--- a/docs/audit/2026-05-04_ship-readiness.md
+++ b/docs/audit/2026-05-04_ship-readiness.md
@@ -29,7 +29,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-04-11-SHIP-READINESS'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: READY-TO-SHIP ASSESSMENT (2026-05-04)

--- a/docs/audit/2026-05-05_code-quality.md
+++ b/docs/audit/2026-05-05_code-quality.md
@@ -29,7 +29,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-05-04-CQ01'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: CODE QUALITY (2026-05-05)

--- a/docs/audit/2026-05-05_documentation-quality.md
+++ b/docs/audit/2026-05-05_documentation-quality.md
@@ -35,7 +35,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-05-04-DQ01'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: DOCUMENTATION QUALITY (2026-05-05)

--- a/docs/audit/2026-05-05_ship-readiness.md
+++ b/docs/audit/2026-05-05_ship-readiness.md
@@ -29,7 +29,7 @@ summary:
   remediation_status: 'Pending'
 related_reports:
   previous_audit: 'AUD-2026-05-04-SR01'
-  tracking_ticket: 'GitHub Issues'
+  tracking_ticket: 'https://github.com/flyingrobots/wesley/issues/634'
 ---
 
 # AUDIT: READY-TO-SHIP ASSESSMENT (2026-05-05)

--- a/docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md
+++ b/docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md
@@ -116,8 +116,8 @@ This slice:
 - removes the lane from the current tree
 - updates docs signposts that previously presented the lane as active release
   carry-over
-- preserves the files as historical extraction context for Continuum-era design
-  references and future repo-specific coordination
+- records that the deleted lane is recoverable only through git history for
+  Continuum-era design references and future repo-specific coordination
 
 ## Product-Era Docs Slice
 

--- a/docs/method/retro/0003-continuum-contract-compiler/witness/playback.md
+++ b/docs/method/retro/0003-continuum-contract-compiler/witness/playback.md
@@ -64,5 +64,5 @@ The cycle lands useful scaffolding and doctrine:
 - current-state witness command
 - sharper signposts and METHOD closeout surface
 
-That is enough for an honest `partial` closeout. The remaining proof work stays
-alive in the Continuum `asap/` queue.
+That is enough for an honest `partial` closeout. Remaining proof work now lives
+in GitHub Issues and owning-repo follow-up, not in a repo-local Method queue.

--- a/docs/method/retro/0003-continuum-contract-compiler/witness/verification.md
+++ b/docs/method/retro/0003-continuum-contract-compiler/witness/verification.md
@@ -36,17 +36,6 @@ $ jq '{success, result: {kind, scope, status, outputPath, summary}}' /tmp/wesley
 
 $ jq -e '.success == true and .result.kind == "wesley.continuum.conformance.v1" and .result.scope == "current-minimum-shared-surface" and .result.status == "pass" and .result.outputPath == ".wesley-cache/continuum/local-inspect/witness/conformance.json" and (.result.summary | has("totalChecks") and has("passed") and has("failed"))' /tmp/wesley-witness-continuum.json >/dev/null
 
-$ gh issue list --state open --limit 20
-# ASAP
-
-Items here should be pulled soon. They are closer to commitment than `up-next/`
-or `inbox/`.
-
-Current pull order for the Continuum cluster:
-
-1. `SOURCE_continuum-ownership-map-for-shared-nouns.md`
-2. `RUNTIME_continuum-local-compile-and-inspect-surface.md`
-3. `EVIDENCE_continuum-conformance-and-roundtrip-witness.md`
 ```
 
 ## Interpretation
@@ -55,5 +44,7 @@ Current pull order for the Continuum cluster:
   chosen-family lane exists.
 - The current inspect and witness path is real and re-runnable for the present
   minimum surface.
-- The remaining proof work is still explicitly queued in `asap/`, so the cycle
-  can close honestly as `partial` without losing the carry-over.
+- The remaining proof work is no longer represented by a repo-local queue. Live
+  carry-over belongs in GitHub Issues and owning repos, so the cycle can close
+  honestly as `partial` without preserving deleted tracker files in the current
+  checkout.

--- a/test/docs-planning-boundary.bats
+++ b/test/docs-planning-boundary.bats
@@ -82,6 +82,11 @@ load 'bats-plugins/bats-assert/load'
   assert_output ""
 }
 
+@test "retired Method tracker references do not survive in closeout evidence" {
+  run rg -n 'tracking_ticket: ['"'"'"]GitHub Issues['"'"'"]|# ASAP|asap/|preserves the files as historical extraction context' docs/audit docs/method/retro docs/design/0012-product-leftover-cleanup --glob '*.md'
+  assert_failure
+}
+
 @test "front-door signposts route task readers through docs topics" {
   run grep -F "[Topics](./docs/topics/README.md)" README.md
   assert_success

--- a/test/docs-planning-boundary.bats
+++ b/test/docs-planning-boundary.bats
@@ -83,8 +83,14 @@ load 'bats-plugins/bats-assert/load'
 }
 
 @test "retired Method tracker references do not survive in closeout evidence" {
-  run rg -n 'tracking_ticket: ['"'"'"]GitHub Issues['"'"'"]|# ASAP|asap/|preserves the files as historical extraction context' docs/audit docs/method/retro docs/design/0012-product-leftover-cleanup --glob '*.md'
-  assert_failure
+  run rg -n \
+    'tracking_ticket: ['"'"'"]GitHub Issues['"'"'"]|# ASAP|asap/|preserves the files as historical extraction context' \
+    docs/audit \
+    docs/method/retro \
+    docs/design/0012-product-leftover-cleanup \
+    --glob '*.md'
+  assert_equal "$status" 1
+  assert_output ""
 }
 
 @test "front-door signposts route task readers through docs topics" {


### PR DESCRIPTION
## Summary

- replaces vague pending audit `tracking_ticket` values with the concrete v0.3 release gate issue
- removes stale Method queue transcript/output from historical witness closeout docs
- clarifies deleted tracker files are recoverable through git history, not preserved in the current checkout
- adds a Bats guard preventing this tracker-deletion residue from returning

Closes #716.
Addresses review fallout from #715.

## Validation

- RED: `bats test/docs-planning-boundary.bats --filter 'retired Method tracker references'` failed before the fix on stale Method tracker residue
- GREEN: `bats test/docs-planning-boundary.bats --filter 'retired Method tracker references'`
- `bats test/docs-planning-boundary.bats test/domain-empty-boundary.bats`
- `cargo xtask docs-check`
- `pnpm prettier --check CHANGELOG.md docs/audit/2026-05-04_code-quality.md docs/audit/2026-05-04_documentation-quality.md docs/audit/2026-05-04_ship-readiness.md docs/audit/2026-05-05_code-quality.md docs/audit/2026-05-05_documentation-quality.md docs/audit/2026-05-05_ship-readiness.md docs/design/0012-product-leftover-cleanup/product-leftover-cleanup.md docs/method/retro/0003-continuum-contract-compiler/witness/playback.md docs/method/retro/0003-continuum-contract-compiler/witness/verification.md`
- `git diff --check`
- `pnpm run preflight`
- pre-push Rust product preflight
- pre-push repo Bats smoke suite
