### PR TITLE
fix: run pre-push checks without shell strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Replaced pre-push sanity shell-string execution with argv-based command
+  spawning while preserving dry-run command display.
 - Repaired tracker-deletion follow-up docs so pending audit reports point at a
   concrete release gate, historical witness transcripts no longer show
   impossible Method queue output, and design packets no longer claim deleted

--- a/scripts/pre-push-sanity.mjs
+++ b/scripts/pre-push-sanity.mjs
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = resolve(__dirname, '..');
@@ -44,14 +44,14 @@ function main() {
   for (const command of commands) {
     console.log(`  - ${command.label}`);
     if (dryRun) {
-      console.log(`    $ ${command.command}`);
+      console.log(`    $ ${formatCommand(command)}`);
     }
   }
 
   if (dryRun) return;
 
   for (const command of commands) {
-    runCommand(command.label, command.command);
+    runCommand(command);
   }
 }
 
@@ -61,10 +61,10 @@ function buildCommands(changedFiles) {
   const packages = loadPackageTests();
   const touchedPackages = new Set();
 
-  const addCommand = (key, label, command) => {
+  const addCommand = (key, label, cmd, args) => {
     if (seen.has(key)) return;
     seen.add(key);
-    commands.push({ key, label, command });
+    commands.push({ key, label, cmd, args });
   };
 
   for (const file of changedFiles) {
@@ -73,23 +73,28 @@ function buildCommands(changedFiles) {
   }
 
   if (needsPreflight(changedFiles)) {
-    addCommand('preflight', 'Rust product preflight', 'cargo xtask preflight');
+    addCommand('preflight', 'Rust product preflight', 'cargo', ['xtask', 'preflight']);
   }
 
   if (needsLegacyPreflight(changedFiles)) {
-    addCommand('legacy-preflight', 'JavaScript package preflight', 'cargo xtask legacy-preflight');
+    addCommand('legacy-preflight', 'JavaScript package preflight', 'cargo', [
+      'xtask',
+      'legacy-preflight'
+    ]);
   }
 
   if (needsRepoBats(changedFiles)) {
-    addCommand('repo-bats', 'Repo Bats smoke suite', 'bash scripts/smoke/repo-bats-prepush.sh');
+    addCommand('repo-bats', 'Repo Bats smoke suite', 'bash', [
+      'scripts/smoke/repo-bats-prepush.sh'
+    ]);
   }
 
   for (const packageName of [...touchedPackages].sort()) {
-    addCommand(
-      `package:${packageName}`,
-      `${packageName} tests`,
-      `pnpm --filter ${shellQuote(packageName)} test`
-    );
+    addCommand(`package:${packageName}`, `${packageName} tests`, 'pnpm', [
+      '--filter',
+      packageName,
+      'test'
+    ]);
   }
 
   return commands;
@@ -222,12 +227,13 @@ function gitText(args, options = {}) {
   return result.stdout;
 }
 
-function runCommand(label, command) {
-  console.log(`[pre-push] Running ${label}`);
-  const result = spawnSync('/bin/bash', ['-lc', command], {
+function runCommand(command) {
+  console.log(`[pre-push] Running ${command.label}`);
+  const result = spawnSync(command.cmd, command.args, {
     cwd: ROOT_DIR,
     stdio: 'inherit',
-    env: buildGitDiscoveryEnv(process.env)
+    env: buildGitDiscoveryEnv(process.env),
+    shell: false
   });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
@@ -242,8 +248,16 @@ function readStdin() {
   }
 }
 
-function shellQuote(value) {
-  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+function formatCommand(command) {
+  return [command.cmd, ...command.args].map(formatCommandArg).join(' ');
+}
+
+function formatCommandArg(value) {
+  const raw = String(value);
+  if (raw.length > 0 && /^[A-Za-z0-9_./:=@%+,-]+$/.test(raw)) {
+    return raw;
+  }
+  return `'${raw.replaceAll("'", "'\"'\"'")}'`;
 }
 
 function buildGitDiscoveryEnv(env) {
@@ -253,4 +267,13 @@ function buildGitDiscoveryEnv(env) {
   };
 }
 
-main();
+function isDirectInvocation() {
+  const entry = process.argv[1];
+  return Boolean(entry) && import.meta.url === pathToFileURL(resolve(entry)).href;
+}
+
+if (isDirectInvocation()) {
+  main();
+}
+
+export { buildCommands, formatCommand };

--- a/scripts/pre-push-sanity.mjs
+++ b/scripts/pre-push-sanity.mjs
@@ -229,12 +229,17 @@ function gitText(args, options = {}) {
 
 function runCommand(command) {
   console.log(`[pre-push] Running ${command.label}`);
-  const result = spawnSync(command.cmd, command.args, {
+  const resolvedCommand = resolveCommand(command);
+  const result = spawnSync(resolvedCommand.cmd, resolvedCommand.args, {
     cwd: ROOT_DIR,
     stdio: 'inherit',
     env: buildGitDiscoveryEnv(process.env),
     shell: false
   });
+  if (result.error) {
+    console.error(formatSpawnFailure(command, result.error));
+    process.exit(1);
+  }
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
@@ -250,6 +255,23 @@ function readStdin() {
 
 function formatCommand(command) {
   return [command.cmd, ...command.args].map(formatCommandArg).join(' ');
+}
+
+function resolveCommand(command, { platform = process.platform, env = process.env } = {}) {
+  if (platform === 'win32' && command.cmd === 'pnpm') {
+    return {
+      cmd: env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', command.cmd, ...command.args]
+    };
+  }
+  return command;
+}
+
+function formatSpawnFailure(command, error) {
+  return [
+    `[pre-push] Failed to start ${command.label}: ${formatCommand(command)}`,
+    `[pre-push] ${error?.message ?? 'unknown spawn error'}`
+  ].join('\n');
 }
 
 function formatCommandArg(value) {
@@ -276,4 +298,4 @@ if (isDirectInvocation()) {
   main();
 }
 
-export { buildCommands, formatCommand };
+export { buildCommands, formatCommand, formatSpawnFailure, resolveCommand };

--- a/scripts/pre-push-sanity.test.mjs
+++ b/scripts/pre-push-sanity.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildCommands, formatCommand } from './pre-push-sanity.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), '..');
+
+test('pre-push sanity builds argv commands for selected checks', () => {
+  const commands = buildCommands([
+    'crates/wesley-cli/src/main.rs',
+    'scripts/pre-push-sanity.mjs',
+    'packages/wesley-holmes/src/cli.mjs'
+  ]);
+
+  assert.deepEqual(commandByKey(commands, 'preflight'), {
+    key: 'preflight',
+    label: 'Rust product preflight',
+    cmd: 'cargo',
+    args: ['xtask', 'preflight']
+  });
+  assert.deepEqual(commandByKey(commands, 'legacy-preflight'), {
+    key: 'legacy-preflight',
+    label: 'JavaScript package preflight',
+    cmd: 'cargo',
+    args: ['xtask', 'legacy-preflight']
+  });
+  assert.deepEqual(commandByKey(commands, 'repo-bats'), {
+    key: 'repo-bats',
+    label: 'Repo Bats smoke suite',
+    cmd: 'bash',
+    args: ['scripts/smoke/repo-bats-prepush.sh']
+  });
+  assert.deepEqual(commandByKey(commands, 'package:@wesley/holmes'), {
+    key: 'package:@wesley/holmes',
+    label: '@wesley/holmes tests',
+    cmd: 'pnpm',
+    args: ['--filter', '@wesley/holmes', 'test']
+  });
+});
+
+test('pre-push sanity formats dry-run commands without making them executable input', () => {
+  assert.equal(
+    formatCommand({
+      cmd: 'pnpm',
+      args: ['--filter', '@wesley/holmes', 'test']
+    }),
+    'pnpm --filter @wesley/holmes test'
+  );
+  assert.equal(
+    formatCommand({
+      cmd: 'tool',
+      args: ['value with spaces', "quote'value"]
+    }),
+    "tool 'value with spaces' 'quote'\"'\"'value'"
+  );
+});
+
+test('pre-push sanity does not execute selected checks through a shell', () => {
+  const source = readFileSync(resolve(repoRoot, 'scripts/pre-push-sanity.mjs'), 'utf8');
+
+  assert.doesNotMatch(source, /spawnSync\(['"]\/bin\/bash['"],\s*\[\s*['"]-lc['"]/);
+  assert.doesNotMatch(source, /function shellQuote\b/);
+});
+
+function commandByKey(commands, key) {
+  return commands.find((command) => command.key === key);
+}

--- a/scripts/pre-push-sanity.test.mjs
+++ b/scripts/pre-push-sanity.test.mjs
@@ -4,7 +4,12 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { buildCommands, formatCommand } from './pre-push-sanity.mjs';
+import {
+  buildCommands,
+  formatCommand,
+  formatSpawnFailure,
+  resolveCommand
+} from './pre-push-sanity.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), '..');
@@ -56,6 +61,42 @@ test('pre-push sanity formats dry-run commands without making them executable in
       args: ['value with spaces', "quote'value"]
     }),
     "tool 'value with spaces' 'quote'\"'\"'value'"
+  );
+});
+
+test('pre-push sanity resolves pnpm through cmd on Windows only', () => {
+  const command = {
+    cmd: 'pnpm',
+    args: ['--filter', '@wesley/holmes', 'test']
+  };
+
+  assert.deepEqual(resolveCommand(command, { platform: 'linux' }), command);
+  assert.deepEqual(
+    resolveCommand(command, {
+      platform: 'win32',
+      env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' }
+    }),
+    {
+      cmd: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'pnpm', '--filter', '@wesley/holmes', 'test']
+    }
+  );
+});
+
+test('pre-push sanity reports command startup errors with actionable context', () => {
+  assert.equal(
+    formatSpawnFailure(
+      {
+        label: 'JavaScript package preflight',
+        cmd: 'pnpm',
+        args: ['--filter', '@wesley/holmes', 'test']
+      },
+      new Error('spawn pnpm ENOENT')
+    ),
+    [
+      '[pre-push] Failed to start JavaScript package preflight: pnpm --filter @wesley/holmes test',
+      '[pre-push] spawn pnpm ENOENT'
+    ].join('\n')
   );
 });
 


### PR DESCRIPTION
## Linked Issue

Closes #718

## Why

The pre-push sanity hook previously stored selected checks as shell command strings and executed them through `/bin/bash -lc`. Current inputs were narrow, but that pattern made future file/path-driven checks easier to turn into shell-injection or quoting bugs.

## Changes

- Replace shell-string command storage with structured `cmd`/`args` checks.
- Run selected checks with direct `spawnSync(cmd, args, { shell: false })` on Unix-like platforms.
- Preserve Windows package-check behavior by dispatching `pnpm` through `cmd.exe /d /s /c` when `process.platform === 'win32'`.
- Keep dry-run output readable with a display-only formatter.
- Emit a deterministic startup diagnostic when `spawnSync` cannot start a command.
- Add script unit tests covering command construction, dry-run formatting, Windows pnpm resolution, startup-error diagnostics, and the no-`/bin/bash -lc` invariant.

## Risk

Low. The selected check set and command arguments are intended to stay behaviorally equivalent. The main risk is platform-specific command dispatch, covered by unit tests for Unix and Windows command resolution.

## Backout

Revert this PR to return to the previous shell-string execution behavior. No data migration or generated artifacts are involved.

## Testing

- `node --test scripts/pre-push-sanity.test.mjs`
- `node scripts/pre-push-sanity.mjs --dry-run --files scripts/pre-push-sanity.mjs packages/wesley-holmes/src/cli.mjs`
- `node --test scripts/*.test.mjs`
- `pnpm exec prettier --check CHANGELOG.md scripts/pre-push-sanity.mjs scripts/pre-push-sanity.test.mjs`
- `git diff --check`
- `pnpm run preflight`
- `pnpm run legacy-preflight`
- pre-push hook on `git push` reran Rust product preflight and repo Bats successfully

## Checklist

- [x] PR references and closes a GitHub issue.
- [x] Tests cover the changed behavior.
- [x] Changelog updated.
- [x] No draft PR.