### PR TITLE
test: cover Holmes weights JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added a `hello-wesley-target` external target conformance fixture with
   descriptor, request, diagnostic, response, artifact manifest, and artifact
   hash validation.
+- Added Holmes CLI regression coverage for normalized `weights --json` output.
 
 ### Changed
 

--- a/packages/wesley-holmes/test/cli-options.test.mjs
+++ b/packages/wesley-holmes/test/cli-options.test.mjs
@@ -432,24 +432,33 @@ function runHolmesRunsInspect(fixture, runId, transmutation) {
 function runWeights(options = {}) {
   const tempDir = mkdtempSync(path.join(tmpdir(), 'holmes-weights-'));
   const weightsPath = path.join(tempDir, 'weights.json');
+  const jsonPath = path.join(tempDir, 'weights-output.json');
   if (options.writeWeights) {
     writeFileSync(weightsPath, JSON.stringify(options.writeWeights, null, 2));
   }
 
   const args = [cliPath, 'weights', '--file', weightsPath];
+  if (options.jsonOutput) {
+    args.push('--json', jsonPath);
+  }
   const result = spawnSync(process.execPath, args, {
     cwd: repoRoot,
     encoding: 'utf8'
   });
 
   try {
+    let jsonOutput;
     if (options.expectSuccess !== false) {
       assert.equal(result.status, 0, `weights exited with ${result.status}: ${result.stderr}`);
       assert.ok(result.stdout.includes('weights configuration valid'));
+      if (options.jsonOutput) {
+        assert.ok(existsSync(jsonPath), 'weights --json should write the requested output file');
+        jsonOutput = JSON.parse(readFileSync(jsonPath, 'utf8'));
+      }
     } else {
       assert.notEqual(result.status, 0, 'weights command should fail');
     }
-    return result;
+    return { ...result, jsonOutput };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -875,6 +884,37 @@ test('holmes CLI predict fails when requested runtime run is missing', () => {
 
 test('weights command validates custom configuration', () => {
   runWeights({ writeWeights: { default: 6, password: 12 }, expectSuccess: true });
+});
+
+test('weights command writes normalized JSON output', () => {
+  const result = runWeights({
+    writeWeights: {
+      default: 6,
+      substrings: { Email: 9 },
+      directives: { '@PrimaryKey': 11 },
+      overrides: { 'User.password': 13 }
+    },
+    jsonOutput: true,
+    expectSuccess: true
+  });
+
+  assert.deepEqual(result.jsonOutput, {
+    default: 6,
+    substrings: {
+      password: 10,
+      email: 9,
+      id: 7,
+      user: 6,
+      created: 5,
+      theme: 2
+    },
+    directives: {
+      primarykey: 11
+    },
+    overrides: {
+      'User.password': 13
+    }
+  });
 });
 
 test('weights command fails when file missing', () => {


### PR DESCRIPTION
## Linked Issue

Closes #105

## Why

The transitional Holmes CLI already supports `weights --json <file>`, but the retained package tests only covered successful validation and missing-file failure. That left the machine-readable output branch unguarded.

## Changes

- Extend the Holmes CLI test helper to request and parse `weights --json` output.
- Add a regression test proving the command writes normalized `default`, `substrings`, `directives`, and `overrides` data.
- Record the coverage addition in the changelog.

## Risk

Low. This is test coverage only; no CLI production code changes.

## Backout

Revert this PR to remove the new regression test and changelog entry. No generated artifacts or migrations are involved.

## Testing

- `node --test --test-name-pattern "weights command" packages/wesley-holmes/test/cli-options.test.mjs`
- `pnpm --filter @wesley/holmes test`
- `pnpm exec prettier --check CHANGELOG.md packages/wesley-holmes/test/cli-options.test.mjs`
- `git diff --check`
- `pnpm run preflight`
- pre-push hook ran legacy preflight and `@wesley/holmes` tests

## Checklist

- [x] PR references and closes a GitHub issue.
- [x] Tests cover the changed behavior.
- [x] Changelog updated.
- [x] No draft PR.
