### PR TITLE
test: protect JSON schema draft policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Documented and test-protected the supported JSON Schema draft boundary for
+  canonical schema artifacts.
 - Aligned Dependabot GitHub Actions update PR labels with existing repository
   labels.
 - Required PR bodies to reference at least one GitHub Issue and to use GitHub

--- a/crates/wesley-core/tests/generated_json_artifacts.rs
+++ b/crates/wesley-core/tests/generated_json_artifacts.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -9,6 +10,9 @@ use wesley_core::{
     build_contract_bundle_manifest_v1, compute_registry_hash, diff_law_ir_v1,
     list_schema_operations_sdl, load_weslaw_yaml, lower_schema_sdl, to_canonical_law_ir_json,
 };
+
+const JSON_SCHEMA_DRAFT_07: &str = "http://json-schema.org/draft-07/schema#";
+const JSON_SCHEMA_DRAFT_2020_12: &str = "https://json-schema.org/draft/2020-12/schema";
 
 fn repo_path(path: impl AsRef<Path>) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -36,6 +40,81 @@ fn schema_json(path: &str) -> serde_json::Value {
     let mut schema = read_json(path);
     inline_local_schema_refs(&mut schema);
     schema
+}
+
+fn schema_file_paths() -> Vec<PathBuf> {
+    let mut paths = fs::read_dir(repo_path("schemas"))
+        .expect("schema directory should be readable")
+        .map(|entry| entry.expect("schema entry should be readable").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".schema.json"))
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn repo_relative_path(path: &Path) -> String {
+    path.strip_prefix(repo_path(""))
+        .expect("path should live under repo")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn schema_draft(schema_path: &str, schema: &serde_json::Value) -> String {
+    schema
+        .get("$schema")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("{schema_path} must declare $schema"))
+        .to_string()
+}
+
+fn collect_refs(value: &serde_json::Value, refs: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(serde_json::Value::String(reference)) = object.get("$ref") {
+                refs.push(reference.clone());
+            }
+            for child in object.values() {
+                collect_refs(child, refs);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                collect_refs(child, refs);
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
+    }
+}
+
+fn local_schema_reference_target(reference: &str) -> Option<String> {
+    if reference.starts_with('#') {
+        return None;
+    }
+
+    let path = reference
+        .split_once('#')
+        .map_or(reference, |(path, _fragment)| path);
+    if path.is_empty() {
+        return None;
+    }
+
+    assert!(
+        !path.contains("://"),
+        "schema $ref must not use remote schemas: {reference}"
+    );
+    assert!(
+        path.ends_with(".schema.json"),
+        "schema $ref must target a local schema file: {reference}"
+    );
+
+    Some(format!("schemas/{path}"))
 }
 
 fn inline_local_schema_refs(value: &mut serde_json::Value) {
@@ -143,6 +222,48 @@ fn yaml_to_json_value(value: &Yaml) -> serde_json::Value {
         }
         Yaml::Null => serde_json::Value::Null,
         Yaml::Alias(_) | Yaml::BadValue => panic!("unsupported YAML value in fixture"),
+    }
+}
+
+#[test]
+fn schema_family_declares_supported_draft_boundary() {
+    let readme = read_text("schemas/README.md");
+    assert!(
+        readme.contains("## JSON Schema Draft Policy"),
+        "schemas/README.md must document the supported draft boundary"
+    );
+
+    let mut drafts = BTreeMap::new();
+    for schema_path in schema_file_paths() {
+        let repo_path = repo_relative_path(&schema_path);
+        let schema = read_json(&repo_path);
+        let draft = schema_draft(&repo_path, &schema);
+        assert!(
+            matches!(
+                draft.as_str(),
+                JSON_SCHEMA_DRAFT_07 | JSON_SCHEMA_DRAFT_2020_12
+            ),
+            "{repo_path} uses unsupported JSON Schema draft {draft}"
+        );
+        drafts.insert(repo_path, draft);
+    }
+
+    for (schema_path, source_draft) in &drafts {
+        let schema = read_json(schema_path);
+        let mut refs = Vec::new();
+        collect_refs(&schema, &mut refs);
+        for reference in refs {
+            let Some(target_path) = local_schema_reference_target(&reference) else {
+                continue;
+            };
+            let Some(target_draft) = drafts.get(&target_path) else {
+                panic!("{schema_path} references missing local schema {reference}");
+            };
+            assert_eq!(
+                source_draft, target_draft,
+                "{schema_path} must not $ref {target_path} across JSON Schema drafts"
+            );
+        }
     }
 }
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -25,6 +25,21 @@ This directory hosts machine-readable schemas that underpin Wesley’s generator
 - `evidence-map.schema.json` – JSON Schema for the evidence bundle map emitted by HOLMES/-SHIPME flows.
 - `scores.schema.json` – JSON Schema for holmes `scores.json` output.
 
+## JSON Schema Draft Policy
+
+Wesley supports two JSON Schema draft families in `schemas/`:
+
+- **Draft 2020-12** for newer canonical evidence and `weslaw` artifacts whose
+  schemas are generated or published as canonical JSON.
+- **Draft-07** for retained runtime, SHIPME, L1 IR, and external-target
+  protocol artifacts that already have stable consumers.
+
+This is an explicit compatibility boundary, not an accidental mixed state.
+Schema validators must compile each file according to its declared `$schema`.
+Local `$ref` links must stay inside the same draft family. A schema may not
+reference a local schema that declares a different draft unless the boundary is
+redesigned and the validation tests are updated in the same change.
+
 > [!note]
 > When a schema evolves, update the corresponding validation logic/tests and regenerate fixtures so downstream consumers stay aligned.
 


### PR DESCRIPTION
## Linked Issue

Closes #456

## Summary

- Document the supported JSON Schema draft boundary for `schemas/`.
- Add regression coverage that every schema declares either draft-07 or 2020-12.
- Reject undocumented local `$ref` links that cross draft families.

## Why

Wesley currently has stable draft-07 consumers and newer canonical 2020-12 evidence artifacts. This PR makes that compatibility boundary explicit and executable instead of relying on tribal knowledge or validator-specific tolerance.

## Validation

- RED: `cargo test -p wesley-core --test generated_json_artifacts schema_family_declares_supported_draft_boundary -- --nocapture` failed before the policy section existed.
- GREEN: `cargo test -p wesley-core --test generated_json_artifacts schema_family_declares_supported_draft_boundary -- --nocapture`
- `cargo test -p wesley-core --test generated_json_artifacts -- --nocapture`
- `cargo xtask docs-check`
- `pnpm exec prettier --check CHANGELOG.md schemas/README.md`
- `git diff --check`
- `pnpm run preflight`

## Risk

Low. This does not rewrite schema files or artifact semantics. The new test only freezes the declared draft policy and same-draft local reference rule.

## Backout

Revert this PR. The schema files and generated artifacts themselves are unchanged.
