### PR TITLE
chore(release): prepare v0.3.0-alpha.1 (first 0.3.0-line pre-release)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -201,12 +201,13 @@ jobs:
         run: |
           set -euo pipefail
           # A SemVer pre-release (e.g. v0.3.0-alpha.1) carries a hyphen after the
-          # core version. Stable releases (v0.3.0) do not.
-          if printf '%s' "${GITHUB_REF_NAME#v}" | grep -q '-'; then
-            echo "WESLEY_PRERELEASE=true" >> "$GITHUB_ENV"
-          else
-            echo "WESLEY_PRERELEASE=false" >> "$GITHUB_ENV"
-          fi
+          # core version; stable releases (v0.3.0) do not. Use a shell glob so
+          # classification never depends on how grep treats a leading-dash
+          # pattern.
+          case "${GITHUB_REF_NAME#v}" in
+            *-*) echo "WESLEY_PRERELEASE=true" >> "$GITHUB_ENV" ;;
+            *) echo "WESLEY_PRERELEASE=false" >> "$GITHUB_ENV" ;;
+          esac
 
       - name: Create draft GitHub Release
         env:

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -200,11 +200,14 @@ jobs:
       - name: Classify release channel
         run: |
           set -euo pipefail
-          # A SemVer pre-release (e.g. v0.3.0-alpha.1) carries a hyphen after the
-          # core version; stable releases (v0.3.0) do not. Use a shell glob so
-          # classification never depends on how grep treats a leading-dash
+          # SemVer marks a pre-release with a hyphen after the core version
+          # (v0.3.0-alpha.1) and build metadata with a plus (v0.3.0+build.7).
+          # Strip any build metadata first so a `-` inside it cannot be mistaken
+          # for a pre-release, then a hyphen in what remains means a pre-release.
+          # A shell glob keeps this independent of how grep treats a leading-dash
           # pattern.
-          case "${GITHUB_REF_NAME#v}" in
+          version="${GITHUB_REF_NAME#v}"
+          case "${version%%+*}" in
             *-*) echo "WESLEY_PRERELEASE=true" >> "$GITHUB_ENV" ;;
             *) echo "WESLEY_PRERELEASE=false" >> "$GITHUB_ENV" ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1721,7 +1721,8 @@ kind` instead of being silently accepted via structural duck-typing. All
 
 - Initial public repository layout
 
-[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/wesley/compare/v0.3.0-alpha.1...HEAD
+[0.3.0-alpha.1]: https://github.com/flyingrobots/wesley/compare/v0.2.0...v0.3.0-alpha.1
 [0.2.0]: https://github.com/flyingrobots/wesley/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/flyingrobots/wesley/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/flyingrobots/wesley/compare/v0.0.5...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.3.0-alpha.1] - 2026-07-15
+
 ### Added
 
 - Added a pure `wesley-core` extension-generation contract with canonical

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-cli"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "apollo-parser",
  "async-trait",
@@ -1556,14 +1556,14 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-codec"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "wesley-core",
 ]
 
 [[package]]
 name = "wesley-emit-rust"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-emit-typescript"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "wesley-holmes"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ wesley --help
 ```
 
 Pre-release builds of the next line (for example `0.3.0-alpha.1`) are published
-to crates.io as opt-in previews; pin the exact pre-release version to install
-one. They are unstable and are not the recommended default.
+to crates.io as opt-in previews once their signed tag lands; after one is
+published, pin its exact version to install it. Pre-releases are unstable and
+are not the recommended default.
 
 From a source checkout:
 
@@ -142,9 +143,9 @@ extension consumes Wesley IR independently and emits its own artifacts.
 
 ## What's New in v0.3.0-alpha.1
 
-`0.3.0-alpha.1` is the first pre-release of the 0.3.0 line, published to
-crates.io to unblock downstream consumers that need Wesley changes landed
-since `0.2.0`. Notable changes since `0.2.0` include the extension generation
+`0.3.0-alpha.1` is the first pre-release of the 0.3.0 line, cut to unblock
+downstream consumers that need Wesley changes landed since `0.2.0`. Notable
+changes since `0.2.0` include the extension generation
 provenance contract, hardened generation input-schema validation, pre-push and
 test Git-context isolation, and a release pipeline that now publishes
 pre-release tags as GitHub pre-releases (not `latest`). As a pre-release, APIs,

--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ as release-scoped until the project declares a stable `1.0` surface.
 
 ## Quick Start
 
-After the signed `v0.2.0` tag publishes, install the native CLI:
+Install the latest stable native CLI from crates.io:
 
 ```bash
 cargo install wesley-cli --version 0.2.0
 wesley --help
 ```
+
+Pre-release builds of the next line (for example `0.3.0-alpha.1`) are published
+to crates.io as opt-in previews; pin the exact pre-release version to install
+one. They are unstable and are not the recommended default.
 
 From a source checkout:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ extension consumes Wesley IR independently and emits its own artifacts.
 | Echo          | Echo-owned integration            | Runtime law, footprints, observation semantics        |
 | Continuum     | Continuum-owned module/repo       | Deferred protocol generation                          |
 
+## What's New in v0.3.0-alpha.1
+
+`0.3.0-alpha.1` is the first pre-release of the 0.3.0 line, published to
+crates.io to unblock downstream consumers that need Wesley changes landed
+since `0.2.0`. Notable changes since `0.2.0` include the extension generation
+provenance contract, hardened generation input-schema validation, pre-push and
+test Git-context isolation, and a release pipeline that now publishes
+pre-release tags as GitHub pre-releases (not `latest`). As a pre-release, APIs,
+CLI surface, and emitted artifacts remain unstable and may change before the
+stable `0.3.0`; see the changelog for the complete list.
+
 ## What's New in v0.2.0
 
 Wesley `0.2.0` is the domain-free project-manifest platform release. It adds

--- a/crates/wesley-cli/Cargo.toml
+++ b/crates/wesley-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-cli"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 description = "Wesley native CLI"
 license = "Apache-2.0"
@@ -18,6 +18,6 @@ path = "src/main.rs"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.2.0" }
-wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.2.0" }
-wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.2.0" }
+wesley-core = { path = "../wesley-core", version = "0.3.0-alpha.1" }
+wesley-emit-rust = { path = "../wesley-emit-rust", version = "0.3.0-alpha.1" }
+wesley-emit-typescript = { path = "../wesley-emit-typescript", version = "0.3.0-alpha.1" }

--- a/crates/wesley-core/Cargo.toml
+++ b/crates/wesley-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-core"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 description = "Wesley Rust Core - Deterministic compiler kernel"
 license = "Apache-2.0"

--- a/crates/wesley-emit-codec/Cargo.toml
+++ b/crates/wesley-emit-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-codec"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Language-neutral LE-binary codec plan lowered from Wesley L1 IR, shared by the Rust and TypeScript codec emitters."
@@ -12,4 +12,4 @@ keywords = ["graphql", "compiler", "codec", "codegen"]
 categories = ["compilers"]
 
 [dependencies]
-wesley-core = { path = "../wesley-core", version = "0.2.0" }
+wesley-core = { path = "../wesley-core", version = "0.3.0-alpha.1" }

--- a/crates/wesley-emit-rust/Cargo.toml
+++ b/crates/wesley-emit-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-rust"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 description = "Rust syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.2.0" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.2.0" }
+wesley-core = { path = "../wesley-core", version = "0.3.0-alpha.1" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.3.0-alpha.1" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-emit-typescript/Cargo.toml
+++ b/crates/wesley-emit-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-emit-typescript"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 description = "TypeScript syntax-model emitter for Wesley IR"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["compilers"]
 
 [dependencies]
 serde_json = "1.0"
-wesley-core = { path = "../wesley-core", version = "0.2.0" }
-wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.2.0" }
+wesley-core = { path = "../wesley-core", version = "0.3.0-alpha.1" }
+wesley-emit-codec = { path = "../wesley-emit-codec", version = "0.3.0-alpha.1" }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/crates/wesley-holmes/Cargo.toml
+++ b/crates/wesley-holmes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wesley-holmes"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 description = "Rust Holmes law assurance foundation for Wesley semantic evidence"
 license = "MIT"

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -12,7 +12,7 @@
 This document is an end-to-end technical explanation of the Wesley repository
 as prepared for the `v0.2.0` release on June 26, 2026. The `v0.3.0-alpha.1`
 pre-release carries the same architecture; it is the first 0.3.0-line
-pre-release published to crates.io to unblock downstream consumers.
+pre-release, cut to unblock downstream consumers.
 
 It assumes no prior knowledge of Wesley, its domain, or its implementation.
 The explanation starts with the business and domain concepts, then follows the

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -10,7 +10,9 @@
 > [BEARING.md](./BEARING.md) for current direction and active tensions.
 
 This document is an end-to-end technical explanation of the Wesley repository
-as prepared for the `v0.2.0` release on June 26, 2026.
+as prepared for the `v0.2.0` release on June 26, 2026. The `v0.3.0-alpha.1`
+pre-release carries the same architecture; it is the first 0.3.0-line
+pre-release published to crates.io to unblock downstream consumers.
 
 It assumes no prior knowledge of Wesley, its domain, or its implementation.
 The explanation starts with the business and domain concepts, then follows the

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -297,12 +297,13 @@ intentionally not yet exposed as a public Holmes CLI from Rust.
 
 ### Current Tensions
 
-The README now describes `v0.2.0`, aligned with the `Cargo.toml` crate version
-declared across the workspace. The changelog's dated `0.2.0` section carries
-the post-`0.1.1` project-manifest, HOLMES schema-selection, and documentation
-coverage work. Release preparation has landed on synced `main`; the remaining
-release gate is the final pre-tag validation, signed tag, publish, and
-post-publish verification sequence.
+The README now describes `v0.3.0-alpha.1`, aligned with the `Cargo.toml` crate
+version declared across the workspace. The changelog's dated `0.3.0-alpha.1`
+section carries the post-`0.2.0` extension-generation provenance contract,
+generation input-schema hardening, pre-push and test Git-context isolation, and
+release-pipeline pre-release support. Release preparation has landed on synced
+`main`; the remaining release gate is the final pre-tag validation, signed tag,
+publish, and post-publish verification sequence.
 
 ## Package(s) Overview
 

--- a/docs/topics/ci-workflows.md
+++ b/docs/topics/ci-workflows.md
@@ -20,6 +20,7 @@ diff or running focused checks before a PR.
 | Security posture             | Advisory gates, scanner fit, and false positives.  |
 | HOLMES workflow              | Schema-selected assurance reports and PR comments. |
 | SHIPME certificate           | Post-merge evidence for the landed `main` SHA.     |
+| Crates release publishing    | Signed-tag crate publish and GitHub release cut.   |
 
 ## Local Mirrors
 
@@ -50,6 +51,12 @@ BATS_LIB_PATH=test/vendor bats -t test/ci-workflows.bats
 - Browser, Bun, and Deno host experiment workflows are retired from Wesley.
 - Required checks should name the Rust product or repository hygiene surface
   they protect.
+- The crates release workflow classifies the tag channel from its SemVer
+  suffix: pre-release tags (for example `v0.3.0-alpha.1`) publish as GitHub
+  pre-releases and are not marked `latest`; stable tags publish as `latest`.
+- Git hooks export `GIT_DIR`/`GIT_WORK_TREE` into child processes, so the
+  pre-push checks and the CLI git tests strip them to keep nested fixture
+  repositories from mutating the caller's repository.
 - Do not widen workflow permissions or secret exposure casually.
 
 ## Related Authority

--- a/docs/topics/native-cli.md
+++ b/docs/topics/native-cli.md
@@ -42,6 +42,9 @@ validating this checkout before a PR or release.
 | `law`       | `weslaw/v1` lint, validation, diff, explain, rebind, coverage. |
 | `emit`      | Rust, TypeScript, and LE-binary codec projections.             |
 | `config`    | Project manifest validation, inspection, and changed schemas.  |
+| `target`    | Verify external target descriptors without executing target code. |
+| `init-law`  | Scaffold a `weslaw/v1` authoring file.                         |
+| `normalize-sdl` | Emit canonical normalized GraphQL SDL.                     |
 | `doctor`    | Rust-native health checks for the compiler spine.              |
 
 The command help text and [CLI Reference](../reference/cli.md) are the command

--- a/docs/topics/plain-wesley.md
+++ b/docs/topics/plain-wesley.md
@@ -34,7 +34,8 @@ and toolchain terms.
 
 ## Beginner Tutorial
 
-Install the current release:
+Install the latest stable release (`0.2.0`; the `0.3.0` line is still a
+pre-release preview, so beginners should stay on stable):
 
 ```bash
 cargo install wesley-cli --version 0.2.0

--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -71,7 +71,7 @@ needed, and crates are published to crates.io for both channels.
 Pre-releases are cut the same way as stable releases — from synced `main`, under
 the same guards — but are opt-in previews whose APIs and emitted artifacts may
 change before the stable `vX.Y.Z`. `v0.3.0-alpha.1` is the first Wesley
-pre-release, published to unblock downstream consumers.
+pre-release, cut to unblock downstream consumers.
 
 ## Pre-Tag Launch Pass
 

--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -58,6 +58,21 @@ implementation slices, release milestones own release-gate issues, and concrete
 `vX.Y.Z` labels are the version scheduling axis. This is intentional because a
 GitHub issue can carry only one milestone.
 
+## Pre-Release Channels
+
+A tag whose version carries a SemVer pre-release suffix (for example
+`v0.3.0-alpha.1`, `-beta.N`, or `-rc.N`) is published as a GitHub Release marked
+`prerelease` and is not promoted to `latest`; stable `vX.Y.Z` tags publish as
+`latest`. The crates release workflow
+([`.github/workflows/release-crates.yml`](../../.github/workflows/release-crates.yml))
+classifies the channel from the tag itself, so no separate configuration is
+needed, and crates are published to crates.io for both channels.
+
+Pre-releases are cut the same way as stable releases — from synced `main`, under
+the same guards — but are opt-in previews whose APIs and emitted artifacts may
+change before the stable `vX.Y.Z`. `v0.3.0-alpha.1` is the first Wesley
+pre-release, published to unblock downstream consumers.
+
 ## Pre-Tag Launch Pass
 
 After the release-prep PR lands on `main` but before creating the signed tag,

--- a/docs/topics/validation.md
+++ b/docs/topics/validation.md
@@ -13,8 +13,9 @@ Run strict preflight before opening or updating a substantial PR:
 cargo xtask preflight
 ```
 
-The gate runs formatting, clippy, JavaScript advisory audit, docs checks,
-workspace tests, and a native CLI smoke test.
+The gate runs formatting, clippy, docs checks, workspace tests, and a native
+CLI smoke test. JavaScript dependency advisories are handled by Dependabot and
+the `dependency-review` workflow, not by preflight.
 
 ## Focused Checks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wesley",
-  "version": "0.2.0",
+  "version": "0.3.0-alpha.1",
   "private": true,
   "type": "module",
   "description": "Core GraphQL compiler and assurance toolchain. Wesley brings the compiler; external modules bring target semantics.",

--- a/test/ci-workflows.bats
+++ b/test/ci-workflows.bats
@@ -471,14 +471,18 @@ load 'vendor/bats-plugins/bats-assert/load'
 }
 
 @test "release crates workflow marks pre-release tags as pre-releases" {
-  # Classifies the release channel from the tag's SemVer pre-release suffix
-  # (e.g. v0.3.0-alpha.1) so alpha/beta/rc tags do not publish as stable.
-  run grep -F 'WESLEY_PRERELEASE' .github/workflows/release-crates.yml
+  # Assert the classification wiring, not merely that the variable is mentioned:
+  # the hyphen (pre-release) case arm must set true and the default arm false,
+  # so an inverted mapping would fail here.
+  run grep -F '*-*) echo "WESLEY_PRERELEASE=true"' .github/workflows/release-crates.yml
   assert_success
 
-  # Threads the pre-release flag into the GitHub Release create and finalize
+  run grep -F '*) echo "WESLEY_PRERELEASE=false"' .github/workflows/release-crates.yml
+  assert_success
+
+  # The pre-release flag is threaded into the GitHub Release create and finalize
   # steps so the published release is marked prerelease and not latest.
-  run bash -lc "grep -c -- '--prerelease' .github/workflows/release-crates.yml"
+  run grep -c -- '--prerelease' .github/workflows/release-crates.yml
   assert_success
   [ "$output" -ge 1 ]
 

--- a/test/ci-workflows.bats
+++ b/test/ci-workflows.bats
@@ -470,24 +470,40 @@ load 'vendor/bats-plugins/bats-assert/load'
   [ -z "$output" ]
 }
 
-@test "release crates workflow marks pre-release tags as pre-releases" {
-  # Assert the classification wiring, not merely that the variable is mentioned:
-  # the hyphen (pre-release) case arm must set true and the default arm false,
-  # so an inverted mapping would fail here.
-  run grep -F '*-*) echo "WESLEY_PRERELEASE=true"' .github/workflows/release-crates.yml
-  assert_success
+@test "release crates workflow classifies pre-release, stable, and build-metadata tags" {
+  # Exercise the workflow's own channel-classification shell across tag shapes
+  # instead of grepping for token presence (a plain '--latest' grep also matches
+  # '--latest=false' and proves nothing about the mapping). Extract the Classify
+  # step's run body and run it for each shape.
+  local snippet
+  snippet="$(awk '
+    /- name: Classify release channel/ { f = 1; next }
+    f && /^      - name: / { exit }
+    f && /run: \|/ { r = 1; next }
+    f && r { print }
+  ' .github/workflows/release-crates.yml)"
+  [ -n "$snippet" ]
 
-  run grep -F '*) echo "WESLEY_PRERELEASE=false"' .github/workflows/release-crates.yml
-  assert_success
+  classify() {
+    local env_file="$BATS_TEST_TMPDIR/gh_env"
+    : > "$env_file"
+    GITHUB_REF_NAME="$1" GITHUB_ENV="$env_file" bash -c "$snippet"
+    grep -F 'WESLEY_PRERELEASE=' "$env_file"
+  }
 
-  # The pre-release flag is threaded into the GitHub Release create and finalize
-  # steps so the published release is marked prerelease and not latest.
-  run grep -c -- '--prerelease' .github/workflows/release-crates.yml
-  assert_success
-  [ "$output" -ge 1 ]
+  [ "$(classify v0.3.0)" = "WESLEY_PRERELEASE=false" ]
+  [ "$(classify v0.3.0-alpha.1)" = "WESLEY_PRERELEASE=true" ]
+  [ "$(classify v1.0.0+build.7)" = "WESLEY_PRERELEASE=false" ]
+  [ "$(classify v0.3.0-alpha.1+build.7)" = "WESLEY_PRERELEASE=true" ]
 
-  # Stable tags still publish as the latest release.
-  run grep -F -- '--latest' .github/workflows/release-crates.yml
+  # The classified value must map to the exact publish flags: pre-release =>
+  # --prerelease --latest=false, stable => --latest. Asserting the exact array
+  # literals (not a bare '--latest' substring) proves the branch mapping.
+  run grep -F 'if [ "${WESLEY_PRERELEASE}" = "true" ]; then' .github/workflows/release-crates.yml
+  assert_success
+  run grep -F 'channel_flags=(--latest)' .github/workflows/release-crates.yml
+  assert_success
+  run grep -F 'channel_flags=(--prerelease --latest=false)' .github/workflows/release-crates.yml
   assert_success
 }
 

--- a/test/ci-workflows.bats
+++ b/test/ci-workflows.bats
@@ -470,6 +470,23 @@ load 'vendor/bats-plugins/bats-assert/load'
   [ -z "$output" ]
 }
 
+@test "release crates workflow marks pre-release tags as pre-releases" {
+  # Classifies the release channel from the tag's SemVer pre-release suffix
+  # (e.g. v0.3.0-alpha.1) so alpha/beta/rc tags do not publish as stable.
+  run grep -F 'WESLEY_PRERELEASE' .github/workflows/release-crates.yml
+  assert_success
+
+  # Threads the pre-release flag into the GitHub Release create and finalize
+  # steps so the published release is marked prerelease and not latest.
+  run bash -lc "grep -c -- '--prerelease' .github/workflows/release-crates.yml"
+  assert_success
+  [ "$output" -ge 1 ]
+
+  # Stable tags still publish as the latest release.
+  run grep -F -- '--latest' .github/workflows/release-crates.yml
+  assert_success
+}
+
 @test "pull request template preserves rollback metadata" {
   run grep -F '## Backout' .github/pull_request_template.md
   assert_success


### PR DESCRIPTION
Prepares the first pre-release of the 0.3.0 line, `v0.3.0-alpha.1`, to unblock downstream consumers (Edict, Echo) that are pinned to old published Wesley crates and need changes landed since `0.2.0`. This PR is the reversible prep only — the tag/publish is done separately after merge.

## `chore(release): prepare v0.3.0-alpha.1`
- Bumps all 5 published crate manifests + their inter-crate version pins, the unpublished `wesley-holmes` crate, the root `package.json`, and `Cargo.lock` from `0.2.0` → `0.3.0-alpha.1`. `xtask` (unpublished, not a version source) is intentionally left at `0.1.0`.
- Adds a dated `## [0.3.0-alpha.1] - 2026-07-15` changelog section, a `## What's New in v0.3.0-alpha.1` README section, and a TECHNICAL_TEARDOWN pre-release note.
- Validated locally: `cargo xtask release-prep-guard --version 0.3.0-alpha.1` passes; `cargo check --workspace` is clean.

## `ci: harden release-channel classification and cover pre-release publishing`
- Switches the `release-crates.yml` channel classification from `grep -q '-'` to a POSIX `case` glob, so it never depends on how `grep` treats a leading-dash pattern.
- Adds a `ci-workflows.bats` test asserting the workflow marks pre-release tags (e.g. `v0.3.0-alpha.1`) as GitHub pre-releases (`--prerelease --latest=false`) while stable tags stay `--latest`.

## Verification of the alpha release path
Ran the release workflow's own logic against `v0.3.0-alpha.1`:
- channel classification → `WESLEY_PRERELEASE=true` (and `v0.3.0` → `false`);
- the CHANGELOG release-note `awk` extraction returns the full `0.3.0-alpha.1` section;
- `version_from_release_arg` accepts the SemVer pre-release;
- all 9 `release crates` bats assertions pass (including the new pre-release one).

## Next (post-merge, gated)
Tag `v0.3.0-alpha.1` on the merge commit and push it → `release-crates.yml` publishes the crates to crates.io and cuts the pre-release GitHub Release.

Refs #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the v0.3.0-alpha.1 preview release across the CLI and package ecosystem.
  * Documented pre-release installation, publishing channels, and release behavior.
  * Expanded native CLI documentation with `target`, `init-law`, and `normalize-sdl` command families.

* **Documentation**
  * Updated changelog, release guidance, tutorials, technical documentation, and CI workflow references.

* **Bug Fixes**
  * Improved pre-release detection for version tags, including tags with build metadata.

* **Tests**
  * Added coverage validating pre-release and stable release classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->